### PR TITLE
Use localStorage for caching history data

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "@babel/preset-env": "^7.3.1",
     "babel-plugin-iife-wrap": "^1.1.0",
     "babel-preset-minify": "^0.5.0",
-    "eslint": "^5.14.0",
+    "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-import": "^2.17.2",
     "rollup": "^0.66.6",
     "rollup-plugin-node-resolve": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Karl Kihlström <mrkihlstrom@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "lit-element": "^2.0.1"
+    "lit-element": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/const.js
+++ b/src/const.js
@@ -1,4 +1,5 @@
 const URL_DOCS = 'https://github.com/kalkih/mini-graph-card/blob/master/README.md';
+const HISTORY_STORAGE = 'mcg-history';
 const FONT_SIZE = 14;
 const FONT_SIZE_HEADER = 14;
 const MAX_BARS = 96;
@@ -8,7 +9,14 @@ const ICONS = {
   temperature: 'hass:thermometer',
   battery: 'hass:battery',
 };
-const DEFAULT_COLORS = ['var(--accent-color)', '#3498db', '#e74c3c', '#9b59b6', '#f1c40f', '#2ecc71'];
+const DEFAULT_COLORS = [
+  'var(--accent-color)',
+  '#3498db',
+  '#e74c3c',
+  '#9b59b6',
+  '#f1c40f',
+  '#2ecc71',
+];
 const UPDATE_PROPS = ['entity', 'line', 'length', 'fill', 'points', 'tooltip', 'abs'];
 const DEFAULT_SHOW = {
   name: true,
@@ -28,6 +36,7 @@ const V = 2;
 
 export {
   URL_DOCS,
+  HISTORY_STORAGE,
   FONT_SIZE,
   FONT_SIZE_HEADER,
   MAX_BARS,
@@ -35,5 +44,7 @@ export {
   DEFAULT_COLORS,
   UPDATE_PROPS,
   DEFAULT_SHOW,
-  X, Y, V,
+  X,
+  Y,
+  V,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -617,9 +617,10 @@ class MiniGraphCard extends LitElement {
     }
   }
 
-  async updateEntity(entity, index, start, end) {
+  async updateEntity(entity, index, initStart, end) {
     if (!entity || !this.updateQueue.includes(entity.entity_id)) return;
     let stateHistory = [];
+    let start = initStart;
     if (this.history[index]) {
       stateHistory = this.history[index].data;
       start = this.history[index].last_fetched;

--- a/src/main.js
+++ b/src/main.js
@@ -223,17 +223,12 @@ class MiniGraphCard extends LitElement {
 
   renderIcon() {
     const { icon, icon_adaptive_color } = this.config.show;
-    return icon
-      ? html`
-          <div
-            class="icon"
-            loc=${this.config.align_icon}
-            style=${icon_adaptive_color ? `color: ${this.color};` : ''}
-          >
-            <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
-          </div>
-        `
-      : '';
+    return icon ? html`
+      <div class="icon" loc=${this.config.align_icon}
+        style=${icon_adaptive_color ? `color: ${this.color};` : ''}>
+        <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
+      </div>
+    ` : '';
   }
 
   renderName() {
@@ -280,8 +275,7 @@ class MiniGraphCard extends LitElement {
       return html`
         <div
           class="state state--small"
-          style=${entity.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}
-        >
+          style=${entity.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}>
           ${entity.show_indicator ? this.renderIndicator(state, id) : ''}
           <span class="state__value ellipsis">
             ${this.computeState(state)}
@@ -305,33 +299,28 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    return this.config.show.graph
-      ? html`
-          <div class="graph">
-            <div class="graph__container">
-              ${this.renderLabels()}
-              <div class="graph__container__svg">
-                ${this.renderSvg()}
-              </div>
-            </div>
-            ${this.renderLegend()}
+    return this.config.show.graph ? html`
+      <div class="graph">
+        <div class="graph__container">
+          ${this.renderLabels()}
+          <div class="graph__container__svg">
+            ${this.renderSvg()}
           </div>
-        `
-      : '';
+        </div>
+        ${this.renderLegend()}
+      </div>` : '';
   }
 
   renderLegend() {
     if (this.config.entities.length <= 1 || !this.config.show.legend) return;
     return html`
       <div class="graph__legend">
-        ${this.entity.map(
-    (entity, i) => html`
-            <div class="graph__legend__item" @click=${e => this.handlePopup(e, entity)}>
-              ${this.renderIndicator(entity.state, i)}
-              <span class="ellipsis">${this.computeName(i)}</span>
-            </div>
-          `,
-  )}
+        ${this.entity.map((entity, i) => html`
+          <div class="graph__legend__item" @click=${e => this.handlePopup(e, entity)}>
+            ${this.renderIndicator(entity.state, i)}
+            <span class="ellipsis">${this.computeName(i)}</span>
+          </div>
+        `)}
       </div>
     `;
   }
@@ -376,11 +365,7 @@ class MiniGraphCard extends LitElement {
         style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
         fill='none'
         stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
-        stroke=${
-  this.gradient[i]
-    ? `url(#grad-${this.id}-${i})`
-    : this.computeColor(this.entity[i].state, i)
-}
+        stroke=${this.gradient[i] ? `url(#grad-${this.id}-${i})` : this.computeColor(this.entity[i].state, i)}
         stroke-width=${this.config.line_width}
         d=${this.line[i]}
       />`;
@@ -397,8 +382,7 @@ class MiniGraphCard extends LitElement {
         fill=${color}
         stroke=${color}
         stroke-width=${this.config.line_width / 2}>
-        ${points.map(
-    (point, num) => svg`
+        ${points.map((point, num) => svg`
           <circle
             class='line--point'
             stroke=${this.gradient[i] ? this.gradient[i][num].color : 'inherit'}
@@ -406,8 +390,8 @@ class MiniGraphCard extends LitElement {
             cx=${point[X]} cy=${point[Y]} r=${this.config.line_width}
             @mouseover=${() => this.setTooltip(i, point[3], point[V])}
             @mouseout=${() => (this.tooltip = {})}
-          />`,
-  )}
+          />
+        `)}
       </g>`;
   }
 
@@ -417,13 +401,9 @@ class MiniGraphCard extends LitElement {
       if (!gradient) return;
       return svg`
         <linearGradient id=${`grad-${this.id}-${i}`}>
-          ${gradient.map(
-    stop => svg`
-            <stop stop-color=${stop.color}
-              offset=${`${stop.offset}%`}
-            />
-          `,
-  )}
+          ${gradient.map(stop => svg`
+            <stop stop-color=${stop.color} offset=${`${stop.offset}%`}/>
+          `)}
         </linearGradient>`;
     });
     return svg`<defs>${items}</defs>`;
@@ -501,19 +481,17 @@ class MiniGraphCard extends LitElement {
     if (!this.config.show.extrema) return;
     return html`
       <div class="info flex">
-        ${this.abs.map(
-    entry => html`
-            <div class="info__item">
-              <span class="info__item__type">${entry.type}</span>
-              <span class="info__item__value">
-                ${this.computeState(entry.state)} ${this.computeUom(0)}
-              </span>
-              <span class="info__item__time">
-                ${getTime(new Date(entry.last_changed), this.config.format, this._hass.language)}
-              </span>
-            </div>
-          `,
-  )}
+        ${this.abs.map(entry => html`
+          <div class="info__item">
+            <span class="info__item__type">${entry.type}</span>
+            <span class="info__item__value">
+              ${this.computeState(entry.state)} ${this.computeUom(0)}
+            </span>
+            <span class="info__item__time">
+              ${getTime(new Date(entry.last_changed), this.config.format, this._hass.language)}
+            </span>
+          </div>
+        `)}
       </div>
     `;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -626,7 +626,7 @@ class MiniGraphCard extends LitElement {
     let start = initStart;
     let skipInitialState = false;
 
-    let history = JSON.parse(storage[HISTORY_STORAGE]);
+    let history = storage[HISTORY_STORAGE] ? JSON.parse(storage[HISTORY_STORAGE]) : undefined;
     if (history && history[entity.entity_id]) {
       stateHistory = history[entity.entity_id].data;
       stateHistory = stateHistory.filter(item => new Date(item.last_updated) > initStart);
@@ -639,18 +639,17 @@ class MiniGraphCard extends LitElement {
       }
     }
 
-    let newStateHistory = await this.fetchRecent(entity.entity_id, start, end, skipInitialState)[0];
-    if (newStateHistory && newStateHistory.length < 1) {
+    let newStateHistory = await this.fetchRecent(entity.entity_id, start, end, skipInitialState);
+    if (newStateHistory[0] && newStateHistory[0].length > 0) {
       newStateHistory = newStateHistory[0].filter(item => !Number.isNaN(parseFloat(item.state)));
       stateHistory = [...stateHistory, ...newStateHistory];
 
-      history = JSON.parse(storage[HISTORY_STORAGE]);
-      if (!history) {
-        history = {};
-      }
+      history = storage[HISTORY_STORAGE] ? JSON.parse(storage[HISTORY_STORAGE]) : {};
       history[entity.entity_id] = { last_fetched: end, data: stateHistory };
       storage[HISTORY_STORAGE] = JSON.stringify(history);
     }
+
+    if (stateHistory.length === 0) return;
 
     if (entity.entity_id === this.entity[0].entity_id) {
       this.abs = [

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
-import { LitElement, html, svg } from 'lit-element';
-import Graph from './graph';
-import style from './style';
+import { LitElement, html, svg } from "lit-element";
+import Graph from "./graph";
+import style from "./style";
 import {
   URL_DOCS,
   FONT_SIZE,
@@ -10,19 +10,18 @@ import {
   DEFAULT_COLORS,
   UPDATE_PROPS,
   DEFAULT_SHOW,
-  X, Y, V,
-} from './const';
-import {
-  getMin,
-  getMax,
-  getTime,
-  getMilli,
-} from './utils';
+  X,
+  Y,
+  V
+} from "./const";
+import { getMin, getMax, getTime, getMilli } from "./utils";
 
 class MiniGraphCard extends LitElement {
   constructor() {
     super();
-    this.id = Math.random().toString(36).substr(2, 9);
+    this.id = Math.random()
+      .toString(36)
+      .substr(2, 9);
     this.bound = [0, 0];
     this.abs = [];
     this.length = [];
@@ -34,6 +33,9 @@ class MiniGraphCard extends LitElement {
     this.gradient = [];
     this.tooltip = {};
     this.updateQueue = [];
+    this.history = [];
+    this.updating = false;
+    this.stateChanged = false;
   }
 
   static get styles() {
@@ -42,18 +44,22 @@ class MiniGraphCard extends LitElement {
 
   set hass(hass) {
     this._hass = hass;
-    let update = false;
+    let updated = false;
     this.config.entities.forEach((entity, index) => {
       const entityState = hass.states[entity.entity];
       if (entityState && this.entity[index] !== entityState) {
         this.entity[index] = entityState;
         this.updateQueue.push(entityState.entity_id);
-        update = true;
+        updated = true;
       }
     });
-    if (update) {
+    if (updated) {
       this.entity = [...this.entity];
-      this.updateData();
+      if (!this.config.update_interval && !this.updating) {
+        this.updateData();
+      } else {
+        this.stateChanged = true;
+      }
     }
   }
 
@@ -71,17 +77,23 @@ class MiniGraphCard extends LitElement {
       abs: [],
       tooltip: {},
       updateQueue: [],
-      color: String,
+      color: String
     };
   }
 
   setConfig(config) {
     if (config.entity)
-      throw new Error(`The "entity" option was removed, please use "entities".\n See ${URL_DOCS}`);
+      throw new Error(
+        `The "entity" option was removed, please use "entities".\n See ${URL_DOCS}`
+      );
     if (!Array.isArray(config.entities))
-      throw new Error(`Please provide the "entities" option as a list.\n See ${URL_DOCS}`);
+      throw new Error(
+        `Please provide the "entities" option as a list.\n See ${URL_DOCS}`
+      );
     if (config.line_color_above || config.line_color_below)
-      throw new Error(`"line_color_above/line_color_below" was removed, please use "color_thresholds".\n See ${URL_DOCS}`);
+      throw new Error(
+        `"line_color_above/line_color_below" was removed, please use "color_thresholds".\n See ${URL_DOCS}`
+      );
 
     const conf = {
       animate: false,
@@ -96,63 +108,77 @@ class MiniGraphCard extends LitElement {
       line_width: 5,
       more_info: true,
       ...config,
-      show: { ...DEFAULT_SHOW, ...config.show },
+      show: { ...DEFAULT_SHOW, ...config.show }
     };
 
     conf.entities.forEach((entity, i) => {
-      if (typeof entity === 'string')
-        conf.entities[i] = { entity };
+      if (typeof entity === "string") conf.entities[i] = { entity };
     });
-    if (typeof config.line_color === 'string')
+    if (typeof config.line_color === "string")
       conf.line_color = [config.line_color, ...DEFAULT_COLORS];
 
     conf.font_size = (config.font_size / 100) * FONT_SIZE || FONT_SIZE;
     conf.color_thresholds.sort((a, b) => b.value - a.value);
-    const additional = conf.hours_to_show > 24 ? { day: 'numeric', weekday: 'short' } : {};
+    const additional =
+      conf.hours_to_show > 24 ? { day: "numeric", weekday: "short" } : {};
     conf.format = { hour12: !conf.hour24, ...additional };
 
-    if (conf.show.graph === 'bar') {
+    if (conf.show.graph === "bar") {
       const entities = conf.entities.length;
-      if ((conf.hours_to_show * conf.points_per_hour) * entities > MAX_BARS) {
+      if (conf.hours_to_show * conf.points_per_hour * entities > MAX_BARS) {
         conf.points_per_hour = MAX_BARS / (conf.hours_to_show * entities);
         // eslint-disable-next-line no-console
-        console.warn('mini-graph-card: Not enough space, adjusting points_per_hour to ', conf.points_per_hour);
+        console.warn(
+          "mini-graph-card: Not enough space, adjusting points_per_hour to ",
+          conf.points_per_hour
+        );
       }
     }
     if (!this.Graph) {
-      this.Graph = conf.entities.map(() => (
-        new Graph(
-          500,
-          conf.height,
-          [conf.show.fill ? 0 : conf.line_width, conf.line_width],
-          conf.hours_to_show,
-          conf.points_per_hour,
-        )
-      ));
+      this.Graph = conf.entities.map(
+        () =>
+          new Graph(
+            500,
+            conf.height,
+            [conf.show.fill ? 0 : conf.line_width, conf.line_width],
+            conf.hours_to_show,
+            conf.points_per_hour
+          )
+      );
     }
 
     this.config = conf;
+  }
+
+  firstUpdated() {
+    if (this.config.update_interval) {
+      this.updateOnInterval();
+      setInterval(
+        () => this.updateOnInterval(),
+        this.config.update_interval * 1000
+      );
+    }
   }
 
   shouldUpdate(changedProps) {
     if (UPDATE_PROPS.some(prop => changedProps.has(prop))) {
       this.color = this.computeColor(
         this.tooltip.value || this.entity[0].state,
-        this.tooltip.entity || 0,
+        this.tooltip.entity || 0
       );
       return true;
     }
   }
 
   updated(changedProperties) {
-    if (this.config.animate && changedProperties.has('line')) {
+    if (this.config.animate && changedProperties.has("line")) {
       if (this.length.length < this.entity.length) {
-        this.shadowRoot.querySelectorAll('svg path.line').forEach((ele) => {
+        this.shadowRoot.querySelectorAll("svg path.line").forEach(ele => {
           this.length[ele.id] = ele.getTotalLength();
         });
         this.length = [...this.length];
       } else {
-        this.length = Array(this.entity.length).fill('none');
+        this.length = Array(this.entity.length).fill("none");
       }
     }
   }
@@ -160,55 +186,68 @@ class MiniGraphCard extends LitElement {
   render({ config } = this) {
     return html`
       <ha-card
-        class='flex'
+        class="flex"
         ?group=${config.group}
         ?fill=${config.show.graph && config.show.fill}
-        ?points=${config.show.points === 'hover'}
-        ?labels=${config.show.labels === 'hover'}
+        ?points=${config.show.points === "hover"}
+        ?labels=${config.show.labels === "hover"}
         ?gradient=${config.color_thresholds.length > 0}
         ?more-info=${config.more_info}
-        style='font-size: ${config.font_size}px;'
-        @click=${e => this.handlePopup(e, this.entity[0])}>
-        ${this.renderHeader()}
-        ${this.renderStates()}
-        ${this.renderGraph()}
+        style="font-size: ${config.font_size}px;"
+        @click=${e => this.handlePopup(e, this.entity[0])}
+      >
+        ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()}
         ${this.renderInfo()}
-      </ha-card>`;
+      </ha-card>
+    `;
   }
 
   renderHeader() {
-    const {
-      show, align_icon, align_header, font_size_header,
-    } = this.config;
-    return show.name || (show.icon && align_icon !== 'state') ? html`
-      <div class='header flex' loc=${align_header} style='font-size: ${font_size_header}px;'>
-        ${this.renderName()}
-        ${align_icon !== 'state' ? this.renderIcon() : ''}
-      </div>` : '';
+    const { show, align_icon, align_header, font_size_header } = this.config;
+    return show.name || (show.icon && align_icon !== "state")
+      ? html`
+          <div
+            class="header flex"
+            loc=${align_header}
+            style="font-size: ${font_size_header}px;"
+          >
+            ${this.renderName()}
+            ${align_icon !== "state" ? this.renderIcon() : ""}
+          </div>
+        `
+      : "";
   }
 
   renderIcon() {
     const { icon, icon_adaptive_color } = this.config.show;
-    return icon ? html`
-      <div class='icon' loc=${this.config.align_icon}
-        style=${icon_adaptive_color ? `color: ${this.color};` : ''}>
-        <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
-      </div>` : '';
+    return icon
+      ? html`
+          <div
+            class="icon"
+            loc=${this.config.align_icon}
+            style=${icon_adaptive_color ? `color: ${this.color};` : ""}
+          >
+            <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
+          </div>
+        `
+      : "";
   }
 
   renderName() {
     if (!this.config.show.name) return;
-    const name = this.tooltip.entity !== undefined
-      ? this.computeName(this.tooltip.entity)
-      : this.config.name || this.computeName(0);
+    const name =
+      this.tooltip.entity !== undefined
+        ? this.computeName(this.tooltip.entity)
+        : this.config.name || this.computeName(0);
     const color = this.config.show.name_adaptive_color
       ? `opacity: 1; color: ${this.color};`
-      : '';
+      : "";
 
     return html`
-      <div class='name flex'>
-        <span class='ellipsis' style=${color}>${name}</span>
-      </div>`;
+      <div class="name flex">
+        <span class="ellipsis" style=${color}>${name}</span>
+      </div>
+    `;
   }
 
   renderStates() {
@@ -216,73 +255,92 @@ class MiniGraphCard extends LitElement {
     const state = value !== undefined ? value : this.entity[0].state;
     const color = this.config.entities[0].state_adaptive_color
       ? `color: ${this.color};`
-      : '';
+      : "";
     if (this.config.show.state)
       return html`
-        <div class='states flex' loc=${this.config.align_state}>
-          <div class='state'>
-            <span class='state__value ellipsis' style=${color}>
+        <div class="states flex" loc=${this.config.align_state}>
+          <div class="state">
+            <span class="state__value ellipsis" style=${color}>
               ${this.computeState(state)}
             </span>
-            <span class='state__uom ellipsis' style=${color}>
+            <span class="state__uom ellipsis" style=${color}>
               ${this.computeUom(entity || 0)}
             </span>
             ${this.renderStateTime()}
           </div>
-          <div class='states--secondary'>${this.config.entities.map((ent, i) => this.renderState(ent, i))}</div>
-          ${this.config.align_icon === 'state' ? this.renderIcon() : ''}
-        </div>`;
+          <div class="states--secondary">
+            ${this.config.entities.map((ent, i) => this.renderState(ent, i))}
+          </div>
+          ${this.config.align_icon === "state" ? this.renderIcon() : ""}
+        </div>
+      `;
   }
 
   renderState(entity, id) {
     if (entity.show_state && id !== 0) {
       const { state } = this.entity[id];
       return html`
-        <div class='state state--small'
-          style=${entity.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}>
-          ${entity.show_indicator ? this.renderIndicator(state, id) : ''}
-          <span class='state__value ellipsis'>
+        <div
+          class="state state--small"
+          style=${entity.state_adaptive_color
+            ? `color: ${this.computeColor(state, id)};`
+            : ""}
+        >
+          ${entity.show_indicator ? this.renderIndicator(state, id) : ""}
+          <span class="state__value ellipsis">
             ${this.computeState(state)}
           </span>
-          <span class='state__uom ellipsis'>
+          <span class="state__uom ellipsis">
             ${this.computeUom(id)}
           </span>
-        </div>`;
+        </div>
+      `;
     }
   }
 
   renderStateTime() {
     if (this.tooltip.value === undefined) return;
     return html`
-      <div class='state__time'>
-        <span>${this.tooltip.time[0]}</span> - <span>${this.tooltip.time[1]}</span>
-      </div>`;
+      <div class="state__time">
+        <span>${this.tooltip.time[0]}</span> -
+        <span>${this.tooltip.time[1]}</span>
+      </div>
+    `;
   }
 
   renderGraph() {
-    return this.config.show.graph ? html`
-      <div class='graph'>
-        <div class='graph__container'>
-          ${this.renderLabels()}
-          <div class='graph__container__svg'>
-            ${this.renderSvg()}
+    return this.config.show.graph
+      ? html`
+          <div class="graph">
+            <div class="graph__container">
+              ${this.renderLabels()}
+              <div class="graph__container__svg">
+                ${this.renderSvg()}
+              </div>
+            </div>
+            ${this.renderLegend()}
           </div>
-        </div>
-        ${this.renderLegend()}
-      </div>` : '';
+        `
+      : "";
   }
 
   renderLegend() {
     if (this.config.entities.length <= 1 || !this.config.show.legend) return;
     return html`
-      <div class='graph__legend'>
-      ${this.entity.map((entity, i) => html`
-        <div class='graph__legend__item' @click=${e => this.handlePopup(e, entity)}>
-          ${this.renderIndicator(entity.state, i)}
-          <span class='ellipsis'>${this.computeName(i)}</span>
-        </div>
-      `)}
-      </div>`;
+      <div class="graph__legend">
+        ${this.entity.map(
+          (entity, i) => html`
+            <div
+              class="graph__legend__item"
+              @click=${e => this.handlePopup(e, entity)}
+            >
+              ${this.renderIndicator(entity.state, i)}
+              <span class="ellipsis">${this.computeName(i)}</span>
+            </div>
+          `
+        )}
+      </div>
+    `;
   }
 
   renderIndicator(state, index) {
@@ -296,10 +354,12 @@ class MiniGraphCard extends LitElement {
   renderSvgFill(fill, i) {
     if (!fill) return;
     const color = this.computeColor(this.entity[i].state, i);
-    const fade = this.config.show.fill === 'fade';
+    const fade = this.config.show.fill === "fade";
     return svg`
       <defs>
-        <linearGradient id=${`fill-grad-${this.id}-${i}`} x1="0%" y1="0%" x2="0%" y2="100%">
+        <linearGradient id=${`fill-grad-${
+          this.id
+        }-${i}`} x1="0%" y1="0%" x2="0%" y2="100%">
           <stop stop-color=${color} offset='0%' stop-opacity='1'/>
           <stop stop-color=${color} offset='100%' stop-opacity='.15'/>
         </linearGradient>
@@ -308,7 +368,7 @@ class MiniGraphCard extends LitElement {
         class='line--fill'
         type=${this.config.show.fill}
         .id=${i} anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : "0s"}"
         fill=${fade ? `url(#fill-grad-${this.id}-${i})` : color}
         stroke=${fade ? `url(#fill-grad-${this.id}-${i})` : color}
         stroke-width=${this.config.line_width}
@@ -322,10 +382,15 @@ class MiniGraphCard extends LitElement {
       <path
         class='line'
         .id=${i} anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : "0s"}"
         fill='none'
-        stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
-        stroke=${this.gradient[i] ? `url(#grad-${this.id}-${i})` : this.computeColor(this.entity[i].state, i)}
+        stroke-dasharray=${this.length[i] || "none"} stroke-dashoffset=${this
+      .length[i] || "none"}
+        stroke=${
+          this.gradient[i]
+            ? `url(#grad-${this.id}-${i})`
+            : this.computeColor(this.entity[i].state, i)
+        }
         stroke-width=${this.config.line_width}
         d=${this.line[i]}
       />`;
@@ -337,20 +402,24 @@ class MiniGraphCard extends LitElement {
     return svg`
       <g class='line--points'
         ?init=${this.length[i]}
-        anim=${this.config.animate && this.config.show.points !== 'hover'}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5 + 0.5}s` : '0s'}"
+        anim=${this.config.animate && this.config.show.points !== "hover"}
+        style="animation-delay: ${
+          this.config.animate ? `${i * 0.5 + 0.5}s` : "0s"
+        }"
         fill=${color}
         stroke=${color}
         stroke-width=${this.config.line_width / 2}>
-        ${points.map((point, num) => svg`
+        ${points.map(
+          (point, num) => svg`
           <circle
             class='line--point'
-            stroke=${this.gradient[i] ? this.gradient[i][num].color : 'inherit'}
-            fill=${this.gradient[i] ? this.gradient[i][num].color : 'inherit'}
+            stroke=${this.gradient[i] ? this.gradient[i][num].color : "inherit"}
+            fill=${this.gradient[i] ? this.gradient[i][num].color : "inherit"}
             cx=${point[X]} cy=${point[Y]} r=${this.config.line_width}
             @mouseover=${() => this.setTooltip(i, point[3], point[V])}
-            @mouseout=${() => this.tooltip = {}}
-          />`)}
+            @mouseout=${() => (this.tooltip = {})}
+          />`
+        )}
       </g>`;
   }
 
@@ -360,11 +429,13 @@ class MiniGraphCard extends LitElement {
       if (!gradient) return;
       return svg`
         <linearGradient id=${`grad-${this.id}-${i}`}>
-          ${gradient.map(stop => svg`
+          ${gradient.map(
+            stop => svg`
             <stop stop-color=${stop.color}
               offset=${`${stop.offset}%`}
             />
-          `)}
+          `
+          )}
         </linearGradient>`;
     });
     return svg`<defs>${items}</defs>`;
@@ -375,16 +446,18 @@ class MiniGraphCard extends LitElement {
     const items = bars.map((bar, i) => {
       const animation = this.config.animate
         ? svg`
-          <animate attributeName='y' from=${this.config.height} to=${bar.y} dur='1s' fill='remove'
+          <animate attributeName='y' from=${this.config.height} to=${
+            bar.y
+          } dur='1s' fill='remove'
             calcMode='spline' keyTimes='0; 1' keySplines='0.215 0.61 0.355 1'>
           </animate>`
-        : '';
+        : "";
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
           height=${bar.height} width=${bar.width} fill=${color}
           @mouseover=${() => this.setTooltip(index, i, bar.value)}
-          @mouseout=${() => this.tooltip = {}}>
+          @mouseout=${() => (this.tooltip = {})}>
           ${animation}
         </rect>`;
     });
@@ -394,7 +467,9 @@ class MiniGraphCard extends LitElement {
   renderSvg() {
     const { height } = this.config;
     return svg`
-      <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
+      <svg width='100%' height=${
+        height !== 0 ? "100%" : 0
+      } viewBox='0 0 500 ${height}'
         @click=${e => e.stopPropagation()}>
         <g>
           ${this.renderSvgGradient(this.gradient)}
@@ -408,63 +483,79 @@ class MiniGraphCard extends LitElement {
 
   setTooltip(entity, index, value) {
     const { points_per_hour, hours_to_show, format } = this.config;
-    const offset = hours_to_show < 1 && points_per_hour < 1
-      ? points_per_hour * hours_to_show
-      : 1 / points_per_hour;
+    const offset =
+      hours_to_show < 1 && points_per_hour < 1
+        ? points_per_hour * hours_to_show
+        : 1 / points_per_hour;
 
-    const id = Math.abs((index + 1) - Math.ceil(hours_to_show * points_per_hour));
+    const id = Math.abs(index + 1 - Math.ceil(hours_to_show * points_per_hour));
 
     const now = new Date();
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id));
-    const end = getTime(now, { hour12: !this.config.hour24 }, this._hass.language);
+    const end = getTime(
+      now,
+      { hour12: !this.config.hour24 },
+      this._hass.language
+    );
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset));
     const start = getTime(now, format, this._hass.language);
 
     this.tooltip = {
-      value, id, entity, time: [start, end],
+      value,
+      id,
+      entity,
+      time: [start, end]
     };
   }
 
   renderLabels() {
     if (!this.config.show.labels) return;
     return html`
-      <div class='graph__labels flex'>
-        <span class='label--max'>${this.computeState(this.bound[1])}</span>
-        <span class='label--min'>${this.computeState(this.bound[0])}</span>
-      </div>`;
+      <div class="graph__labels flex">
+        <span class="label--max">${this.computeState(this.bound[1])}</span>
+        <span class="label--min">${this.computeState(this.bound[0])}</span>
+      </div>
+    `;
   }
 
   renderInfo() {
     if (!this.config.show.extrema) return;
     return html`
-      <div class='info flex'>
-        ${this.abs.map(entry => html`
-          <div class='info__item'>
-            <span class='info__item__type'>${entry.type}</span>
-            <span class='info__item__value'>
-              ${this.computeState(entry.state)}
-              ${this.computeUom(0)}
-            </span>
-            <span class='info__item__time'>
-              ${getTime(new Date(entry.last_changed), this.config.format, this._hass.language)}
-            </span>
-          </div>`)}
-      </div>`;
+      <div class="info flex">
+        ${this.abs.map(
+          entry => html`
+            <div class="info__item">
+              <span class="info__item__type">${entry.type}</span>
+              <span class="info__item__value">
+                ${this.computeState(entry.state)} ${this.computeUom(0)}
+              </span>
+              <span class="info__item__time">
+                ${getTime(
+                  new Date(entry.last_changed),
+                  this.config.format,
+                  this._hass.language
+                )}
+              </span>
+            </div>
+          `
+        )}
+      </div>
+    `;
   }
 
   handlePopup(e, entity) {
     e.stopPropagation();
     if (this.config.more_info)
-      this.fire('hass-more-info', { entityId: entity.entity_id });
+      this.fire("hass-more-info", { entityId: entity.entity_id });
   }
 
   fire(type, inDetail, inOptions) {
     const options = inOptions || {};
-    const detail = (inDetail === null || inDetail === undefined) ? {} : inDetail;
+    const detail = inDetail === null || inDetail === undefined ? {} : inDetail;
     const e = new Event(type, {
       bubbles: options.bubbles === undefined ? true : options.bubbles,
       cancelable: Boolean(options.cancelable),
-      composed: options.composed === undefined ? true : options.composed,
+      composed: options.composed === undefined ? true : options.composed
     });
     e.detail = detail;
     this.dispatchEvent(e);
@@ -476,27 +567,34 @@ class MiniGraphCard extends LitElement {
     const state = Number(inState) || 0;
     const threshold = {
       color: line_color[i] || line_color[0],
-      ...color_thresholds.find(ele => ele.value < state),
+      ...color_thresholds.find(ele => ele.value < state)
     };
     return this.config.entities[i].color || threshold.color;
   }
 
   computeName(index) {
-    return this.config.entities[index].name
-      || this.entity[index].attributes.friendly_name;
+    return (
+      this.config.entities[index].name ||
+      this.entity[index].attributes.friendly_name
+    );
   }
 
   computeIcon(entity) {
-    return this.config.icon
-      || entity.attributes.icon
-      || ICONS[entity.attributes.device_class]
-      || ICONS.temperature;
+    return (
+      this.config.icon ||
+      entity.attributes.icon ||
+      ICONS[entity.attributes.device_class] ||
+      ICONS.temperature
+    );
   }
 
   computeUom(index) {
-    return this.config.entities[index].unit
-      || this.config.unit
-      || this.entity[index].attributes.unit_of_measurement || '';
+    return (
+      this.config.entities[index].unit ||
+      this.config.unit ||
+      this.entity[index].attributes.unit_of_measurement ||
+      ""
+    );
   }
 
   computeState(inState) {
@@ -509,13 +607,31 @@ class MiniGraphCard extends LitElement {
     return (Math.round(state * x) / x).toFixed(dec);
   }
 
+  updateOnInterval() {
+    if (this.stateChanged && !this.updating) {
+      this.stateChanged = false;
+      this.updateData();
+    }
+  }
+
   async updateData({ config } = this) {
+    this.updating = true;
+
     const end = new Date();
     const start = new Date();
-    start.setMilliseconds(end.getMilliseconds() - (getMilli(config.hours_to_show)));
+    start.setMilliseconds(
+      end.getMilliseconds() - getMilli(config.hours_to_show)
+    );
 
-    const promise = this.entity.map((entity, i) => this.updateEntity(entity, i, start, end));
-    await Promise.all(promise);
+    try {
+      const promise = this.entity.map((entity, i) =>
+        this.updateEntity(entity, i, start, end)
+      );
+      await Promise.all(promise);
+    } finally {
+      this.updating = false;
+    }
+
     this.updateQueue = [];
 
     this.bound = [
@@ -524,25 +640,26 @@ class MiniGraphCard extends LitElement {
         : Math.min(...this.Graph.map(ele => ele.min)) || this.bound[0],
       config.upper_bound !== undefined
         ? config.upper_bound
-        : Math.max(...this.Graph.map(ele => ele.max)) || this.bound[1],
+        : Math.max(...this.Graph.map(ele => ele.max)) || this.bound[1]
     ];
 
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
         if (!entity || this.Graph[i].coords.length === 0) return;
         [this.Graph[i].min, this.Graph[i].max] = [this.bound[0], this.bound[1]];
-        if (config.show.graph === 'bar') {
+        if (config.show.graph === "bar") {
           this.bar[i] = this.Graph[i].getBars(i, config.entities.length);
         } else {
           this.line[i] = this.Graph[i].getPath();
           if (config.show.fill)
             this.fill[i] = this.Graph[i].getFill(this.line[i]);
-          if (config.show.points)
-            this.points[i] = this.Graph[i].getPoints();
+          if (config.show.points) this.points[i] = this.Graph[i].getPoints();
           if (config.color_thresholds.length > 0 && !config.entities[i].color)
             this.gradient[i] = this.Graph[i].computeGradient(
               config.color_thresholds,
-              config.entities[i].color || config.line_color[i] || config.line_color[0],
+              config.entities[i].color ||
+                config.line_color[i] ||
+                config.line_color[0]
             );
         }
       });
@@ -552,30 +669,45 @@ class MiniGraphCard extends LitElement {
 
   async updateEntity(entity, index, start, end) {
     if (!entity || !this.updateQueue.includes(entity.entity_id)) return;
-    let stateHistory = await this.fetchRecent(entity.entity_id, start, end);
-    if (!stateHistory[0]) return;
-    stateHistory = stateHistory[0].filter(item => !Number.isNaN(parseFloat(item.state)));
-    if (stateHistory.length < 1) return;
+    let stateHistory = [];
+    if (this.history[index]) {
+      stateHistory = this.history[index].data;
+      start = this.history[index].last_fetched;
+    }
+    let newStateHistory = await this.fetchRecent(entity.entity_id, start, end);
+
+    if (!newStateHistory[0]) return;
+    newStateHistory = newStateHistory[0].filter(
+      item => !Number.isNaN(parseFloat(item.state))
+    );
+    if (newStateHistory.length < 1) return;
+
+    stateHistory = [...stateHistory, ...newStateHistory];
+
+    this.history[index] = { last_fetched: new Date(), data: stateHistory };
 
     if (entity.entity_id === this.entity[0].entity_id) {
-      this.abs = [{
-        type: 'min',
-        ...getMin(stateHistory, 'state'),
-      }, {
-        type: 'max',
-        ...getMax(stateHistory, 'state'),
-      }];
+      this.abs = [
+        {
+          type: "min",
+          ...getMin(stateHistory, "state")
+        },
+        {
+          type: "max",
+          ...getMax(stateHistory, "state")
+        }
+      ];
     }
 
     this.Graph[index].update(stateHistory);
   }
 
   async fetchRecent(entityId, start, end) {
-    let url = 'history/period';
+    let url = "history/period";
     if (start) url += `/${start.toISOString()}`;
     url += `?filter_entity_id=${entityId}`;
     if (end) url += `&end_time=${end.toISOString()}`;
-    return this._hass.callApi('GET', url);
+    return this._hass.callApi("GET", url);
   }
 
   getCardSize() {
@@ -583,4 +715,4 @@ class MiniGraphCard extends LitElement {
   }
 }
 
-customElements.define('mini-graph-card', MiniGraphCard);
+customElements.define("mini-graph-card", MiniGraphCard);

--- a/src/main.js
+++ b/src/main.js
@@ -627,7 +627,11 @@ class MiniGraphCard extends LitElement {
     let skipInitialState = false;
 
     let history = storage[HISTORY_STORAGE] ? JSON.parse(storage[HISTORY_STORAGE]) : undefined;
-    if (history && history[entity.entity_id]) {
+    if (
+      history
+      && history[entity.entity_id]
+      && history[entity.entity_id].hours_to_show === this.config.hours_to_show
+    ) {
       stateHistory = history[entity.entity_id].data;
       stateHistory = stateHistory.filter(item => new Date(item.last_updated) > initStart);
       if (stateHistory.length > 0) {
@@ -645,7 +649,11 @@ class MiniGraphCard extends LitElement {
       stateHistory = [...stateHistory, ...newStateHistory];
 
       history = storage[HISTORY_STORAGE] ? JSON.parse(storage[HISTORY_STORAGE]) : {};
-      history[entity.entity_id] = { last_fetched: end, data: stateHistory };
+      history[entity.entity_id] = {
+        hours_to_show: this.config.hours_to_show,
+        last_fetched: end,
+        data: stateHistory,
+      };
       storage[HISTORY_STORAGE] = JSON.stringify(history);
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -622,13 +622,14 @@ class MiniGraphCard extends LitElement {
     let stateHistory = [];
     let start = initStart;
 
-    let history;
-    if (localStorage.getItem(HISTORY_STORAGE)) {
-      history = JSON.parse(localStorage.getItem(HISTORY_STORAGE));
+    let history = JSON.parse(localStorage.getItem(HISTORY_STORAGE));
+    if (history) {
       if (history[entity.entity_id]) {
         stateHistory = history[entity.entity_id].data;
         start = new Date(history[entity.entity_id].last_fetched);
       }
+    } else {
+      history = {};
     }
 
     let newStateHistory = await this.fetchRecent(entity.entity_id, start, end);
@@ -639,9 +640,8 @@ class MiniGraphCard extends LitElement {
 
     stateHistory = [...stateHistory, ...newStateHistory];
 
-    if (localStorage.getItem(HISTORY_STORAGE)) {
-      history = JSON.parse(localStorage.getItem(HISTORY_STORAGE));
-    } else {
+    history = JSON.parse(localStorage.getItem(HISTORY_STORAGE));
+    if (!history) {
       history = {};
     }
     history[entity.entity_id] = { last_fetched: end, data: stateHistory };

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
-import { LitElement, html, svg } from "lit-element";
-import Graph from "./graph";
-import style from "./style";
+import { LitElement, html, svg } from 'lit-element';
+import Graph from './graph';
+import style from './style';
 import {
   URL_DOCS,
   FONT_SIZE,
@@ -12,9 +12,11 @@ import {
   DEFAULT_SHOW,
   X,
   Y,
-  V
-} from "./const";
-import { getMin, getMax, getTime, getMilli } from "./utils";
+  V,
+} from './const';
+import {
+  getMin, getMax, getTime, getMilli,
+} from './utils';
 
 class MiniGraphCard extends LitElement {
   constructor() {
@@ -77,22 +79,18 @@ class MiniGraphCard extends LitElement {
       abs: [],
       tooltip: {},
       updateQueue: [],
-      color: String
+      color: String,
     };
   }
 
   setConfig(config) {
     if (config.entity)
-      throw new Error(
-        `The "entity" option was removed, please use "entities".\n See ${URL_DOCS}`
-      );
+      throw new Error(`The "entity" option was removed, please use "entities".\n See ${URL_DOCS}`);
     if (!Array.isArray(config.entities))
-      throw new Error(
-        `Please provide the "entities" option as a list.\n See ${URL_DOCS}`
-      );
+      throw new Error(`Please provide the "entities" option as a list.\n See ${URL_DOCS}`);
     if (config.line_color_above || config.line_color_below)
       throw new Error(
-        `"line_color_above/line_color_below" was removed, please use "color_thresholds".\n See ${URL_DOCS}`
+        `"line_color_above/line_color_below" was removed, please use "color_thresholds".\n See ${URL_DOCS}`,
       );
 
     const conf = {
@@ -108,42 +106,40 @@ class MiniGraphCard extends LitElement {
       line_width: 5,
       more_info: true,
       ...config,
-      show: { ...DEFAULT_SHOW, ...config.show }
+      show: { ...DEFAULT_SHOW, ...config.show },
     };
 
     conf.entities.forEach((entity, i) => {
-      if (typeof entity === "string") conf.entities[i] = { entity };
+      if (typeof entity === 'string') conf.entities[i] = { entity };
     });
-    if (typeof config.line_color === "string")
+    if (typeof config.line_color === 'string')
       conf.line_color = [config.line_color, ...DEFAULT_COLORS];
 
     conf.font_size = (config.font_size / 100) * FONT_SIZE || FONT_SIZE;
     conf.color_thresholds.sort((a, b) => b.value - a.value);
-    const additional =
-      conf.hours_to_show > 24 ? { day: "numeric", weekday: "short" } : {};
+    const additional = conf.hours_to_show > 24 ? { day: 'numeric', weekday: 'short' } : {};
     conf.format = { hour12: !conf.hour24, ...additional };
 
-    if (conf.show.graph === "bar") {
+    if (conf.show.graph === 'bar') {
       const entities = conf.entities.length;
       if (conf.hours_to_show * conf.points_per_hour * entities > MAX_BARS) {
         conf.points_per_hour = MAX_BARS / (conf.hours_to_show * entities);
         // eslint-disable-next-line no-console
         console.warn(
-          "mini-graph-card: Not enough space, adjusting points_per_hour to ",
-          conf.points_per_hour
+          'mini-graph-card: Not enough space, adjusting points_per_hour to ',
+          conf.points_per_hour,
         );
       }
     }
     if (!this.Graph) {
       this.Graph = conf.entities.map(
-        () =>
-          new Graph(
-            500,
-            conf.height,
-            [conf.show.fill ? 0 : conf.line_width, conf.line_width],
-            conf.hours_to_show,
-            conf.points_per_hour
-          )
+        () => new Graph(
+          500,
+          conf.height,
+          [conf.show.fill ? 0 : conf.line_width, conf.line_width],
+          conf.hours_to_show,
+          conf.points_per_hour,
+        ),
       );
     }
 
@@ -153,10 +149,7 @@ class MiniGraphCard extends LitElement {
   firstUpdated() {
     if (this.config.update_interval) {
       this.updateOnInterval();
-      setInterval(
-        () => this.updateOnInterval(),
-        this.config.update_interval * 1000
-      );
+      setInterval(() => this.updateOnInterval(), this.config.update_interval * 1000);
     }
   }
 
@@ -164,21 +157,21 @@ class MiniGraphCard extends LitElement {
     if (UPDATE_PROPS.some(prop => changedProps.has(prop))) {
       this.color = this.computeColor(
         this.tooltip.value || this.entity[0].state,
-        this.tooltip.entity || 0
+        this.tooltip.entity || 0,
       );
       return true;
     }
   }
 
   updated(changedProperties) {
-    if (this.config.animate && changedProperties.has("line")) {
+    if (this.config.animate && changedProperties.has('line')) {
       if (this.length.length < this.entity.length) {
-        this.shadowRoot.querySelectorAll("svg path.line").forEach(ele => {
+        this.shadowRoot.querySelectorAll('svg path.line').forEach((ele) => {
           this.length[ele.id] = ele.getTotalLength();
         });
         this.length = [...this.length];
       } else {
-        this.length = Array(this.entity.length).fill("none");
+        this.length = Array(this.entity.length).fill('none');
       }
     }
   }
@@ -189,33 +182,29 @@ class MiniGraphCard extends LitElement {
         class="flex"
         ?group=${config.group}
         ?fill=${config.show.graph && config.show.fill}
-        ?points=${config.show.points === "hover"}
-        ?labels=${config.show.labels === "hover"}
+        ?points=${config.show.points === 'hover'}
+        ?labels=${config.show.labels === 'hover'}
         ?gradient=${config.color_thresholds.length > 0}
         ?more-info=${config.more_info}
         style="font-size: ${config.font_size}px;"
         @click=${e => this.handlePopup(e, this.entity[0])}
       >
-        ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()}
-        ${this.renderInfo()}
+        ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()} ${this.renderInfo()}
       </ha-card>
     `;
   }
 
   renderHeader() {
-    const { show, align_icon, align_header, font_size_header } = this.config;
-    return show.name || (show.icon && align_icon !== "state")
+    const {
+      show, align_icon, align_header, font_size_header,
+    } = this.config;
+    return show.name || (show.icon && align_icon !== 'state')
       ? html`
-          <div
-            class="header flex"
-            loc=${align_header}
-            style="font-size: ${font_size_header}px;"
-          >
-            ${this.renderName()}
-            ${align_icon !== "state" ? this.renderIcon() : ""}
+          <div class="header flex" loc=${align_header} style="font-size: ${font_size_header}px;">
+            ${this.renderName()} ${align_icon !== 'state' ? this.renderIcon() : ''}
           </div>
         `
-      : "";
+      : '';
   }
 
   renderIcon() {
@@ -225,23 +214,20 @@ class MiniGraphCard extends LitElement {
           <div
             class="icon"
             loc=${this.config.align_icon}
-            style=${icon_adaptive_color ? `color: ${this.color};` : ""}
+            style=${icon_adaptive_color ? `color: ${this.color};` : ''}
           >
             <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
           </div>
         `
-      : "";
+      : '';
   }
 
   renderName() {
     if (!this.config.show.name) return;
-    const name =
-      this.tooltip.entity !== undefined
-        ? this.computeName(this.tooltip.entity)
-        : this.config.name || this.computeName(0);
-    const color = this.config.show.name_adaptive_color
-      ? `opacity: 1; color: ${this.color};`
-      : "";
+    const name = this.tooltip.entity !== undefined
+      ? this.computeName(this.tooltip.entity)
+      : this.config.name || this.computeName(0);
+    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.color};` : '';
 
     return html`
       <div class="name flex">
@@ -253,9 +239,7 @@ class MiniGraphCard extends LitElement {
   renderStates() {
     const { entity, value } = this.tooltip;
     const state = value !== undefined ? value : this.entity[0].state;
-    const color = this.config.entities[0].state_adaptive_color
-      ? `color: ${this.color};`
-      : "";
+    const color = this.config.entities[0].state_adaptive_color ? `color: ${this.color};` : '';
     if (this.config.show.state)
       return html`
         <div class="states flex" loc=${this.config.align_state}>
@@ -271,7 +255,7 @@ class MiniGraphCard extends LitElement {
           <div class="states--secondary">
             ${this.config.entities.map((ent, i) => this.renderState(ent, i))}
           </div>
-          ${this.config.align_icon === "state" ? this.renderIcon() : ""}
+          ${this.config.align_icon === 'state' ? this.renderIcon() : ''}
         </div>
       `;
   }
@@ -282,11 +266,9 @@ class MiniGraphCard extends LitElement {
       return html`
         <div
           class="state state--small"
-          style=${entity.state_adaptive_color
-            ? `color: ${this.computeColor(state, id)};`
-            : ""}
+          style=${entity.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}
         >
-          ${entity.show_indicator ? this.renderIndicator(state, id) : ""}
+          ${entity.show_indicator ? this.renderIndicator(state, id) : ''}
           <span class="state__value ellipsis">
             ${this.computeState(state)}
           </span>
@@ -321,7 +303,7 @@ class MiniGraphCard extends LitElement {
             ${this.renderLegend()}
           </div>
         `
-      : "";
+      : '';
   }
 
   renderLegend() {
@@ -329,16 +311,13 @@ class MiniGraphCard extends LitElement {
     return html`
       <div class="graph__legend">
         ${this.entity.map(
-          (entity, i) => html`
-            <div
-              class="graph__legend__item"
-              @click=${e => this.handlePopup(e, entity)}
-            >
+    (entity, i) => html`
+            <div class="graph__legend__item" @click=${e => this.handlePopup(e, entity)}>
               ${this.renderIndicator(entity.state, i)}
               <span class="ellipsis">${this.computeName(i)}</span>
             </div>
-          `
-        )}
+          `,
+  )}
       </div>
     `;
   }
@@ -354,12 +333,10 @@ class MiniGraphCard extends LitElement {
   renderSvgFill(fill, i) {
     if (!fill) return;
     const color = this.computeColor(this.entity[i].state, i);
-    const fade = this.config.show.fill === "fade";
+    const fade = this.config.show.fill === 'fade';
     return svg`
       <defs>
-        <linearGradient id=${`fill-grad-${
-          this.id
-        }-${i}`} x1="0%" y1="0%" x2="0%" y2="100%">
+        <linearGradient id=${`fill-grad-${this.id}-${i}`} x1="0%" y1="0%" x2="0%" y2="100%">
           <stop stop-color=${color} offset='0%' stop-opacity='1'/>
           <stop stop-color=${color} offset='100%' stop-opacity='.15'/>
         </linearGradient>
@@ -368,7 +345,7 @@ class MiniGraphCard extends LitElement {
         class='line--fill'
         type=${this.config.show.fill}
         .id=${i} anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : "0s"}"
+        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
         fill=${fade ? `url(#fill-grad-${this.id}-${i})` : color}
         stroke=${fade ? `url(#fill-grad-${this.id}-${i})` : color}
         stroke-width=${this.config.line_width}
@@ -382,15 +359,14 @@ class MiniGraphCard extends LitElement {
       <path
         class='line'
         .id=${i} anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : "0s"}"
+        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
         fill='none'
-        stroke-dasharray=${this.length[i] || "none"} stroke-dashoffset=${this
-      .length[i] || "none"}
+        stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
         stroke=${
-          this.gradient[i]
-            ? `url(#grad-${this.id}-${i})`
-            : this.computeColor(this.entity[i].state, i)
-        }
+  this.gradient[i]
+    ? `url(#grad-${this.id}-${i})`
+    : this.computeColor(this.entity[i].state, i)
+}
         stroke-width=${this.config.line_width}
         d=${this.line[i]}
       />`;
@@ -402,24 +378,22 @@ class MiniGraphCard extends LitElement {
     return svg`
       <g class='line--points'
         ?init=${this.length[i]}
-        anim=${this.config.animate && this.config.show.points !== "hover"}
-        style="animation-delay: ${
-          this.config.animate ? `${i * 0.5 + 0.5}s` : "0s"
-        }"
+        anim=${this.config.animate && this.config.show.points !== 'hover'}
+        style="animation-delay: ${this.config.animate ? `${i * 0.5 + 0.5}s` : '0s'}"
         fill=${color}
         stroke=${color}
         stroke-width=${this.config.line_width / 2}>
         ${points.map(
-          (point, num) => svg`
+    (point, num) => svg`
           <circle
             class='line--point'
-            stroke=${this.gradient[i] ? this.gradient[i][num].color : "inherit"}
-            fill=${this.gradient[i] ? this.gradient[i][num].color : "inherit"}
+            stroke=${this.gradient[i] ? this.gradient[i][num].color : 'inherit'}
+            fill=${this.gradient[i] ? this.gradient[i][num].color : 'inherit'}
             cx=${point[X]} cy=${point[Y]} r=${this.config.line_width}
             @mouseover=${() => this.setTooltip(i, point[3], point[V])}
             @mouseout=${() => (this.tooltip = {})}
-          />`
-        )}
+          />`,
+  )}
       </g>`;
   }
 
@@ -430,12 +404,12 @@ class MiniGraphCard extends LitElement {
       return svg`
         <linearGradient id=${`grad-${this.id}-${i}`}>
           ${gradient.map(
-            stop => svg`
+    stop => svg`
             <stop stop-color=${stop.color}
               offset=${`${stop.offset}%`}
             />
-          `
-          )}
+          `,
+  )}
         </linearGradient>`;
     });
     return svg`<defs>${items}</defs>`;
@@ -446,12 +420,10 @@ class MiniGraphCard extends LitElement {
     const items = bars.map((bar, i) => {
       const animation = this.config.animate
         ? svg`
-          <animate attributeName='y' from=${this.config.height} to=${
-            bar.y
-          } dur='1s' fill='remove'
+          <animate attributeName='y' from=${this.config.height} to=${bar.y} dur='1s' fill='remove'
             calcMode='spline' keyTimes='0; 1' keySplines='0.215 0.61 0.355 1'>
           </animate>`
-        : "";
+        : '';
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
@@ -467,9 +439,7 @@ class MiniGraphCard extends LitElement {
   renderSvg() {
     const { height } = this.config;
     return svg`
-      <svg width='100%' height=${
-        height !== 0 ? "100%" : 0
-      } viewBox='0 0 500 ${height}'
+      <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
         @click=${e => e.stopPropagation()}>
         <g>
           ${this.renderSvgGradient(this.gradient)}
@@ -483,20 +453,15 @@ class MiniGraphCard extends LitElement {
 
   setTooltip(entity, index, value) {
     const { points_per_hour, hours_to_show, format } = this.config;
-    const offset =
-      hours_to_show < 1 && points_per_hour < 1
-        ? points_per_hour * hours_to_show
-        : 1 / points_per_hour;
+    const offset = hours_to_show < 1 && points_per_hour < 1
+      ? points_per_hour * hours_to_show
+      : 1 / points_per_hour;
 
     const id = Math.abs(index + 1 - Math.ceil(hours_to_show * points_per_hour));
 
     const now = new Date();
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id));
-    const end = getTime(
-      now,
-      { hour12: !this.config.hour24 },
-      this._hass.language
-    );
+    const end = getTime(now, { hour12: !this.config.hour24 }, this._hass.language);
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset));
     const start = getTime(now, format, this._hass.language);
 
@@ -504,7 +469,7 @@ class MiniGraphCard extends LitElement {
       value,
       id,
       entity,
-      time: [start, end]
+      time: [start, end],
     };
   }
 
@@ -523,30 +488,25 @@ class MiniGraphCard extends LitElement {
     return html`
       <div class="info flex">
         ${this.abs.map(
-          entry => html`
+    entry => html`
             <div class="info__item">
               <span class="info__item__type">${entry.type}</span>
               <span class="info__item__value">
                 ${this.computeState(entry.state)} ${this.computeUom(0)}
               </span>
               <span class="info__item__time">
-                ${getTime(
-                  new Date(entry.last_changed),
-                  this.config.format,
-                  this._hass.language
-                )}
+                ${getTime(new Date(entry.last_changed), this.config.format, this._hass.language)}
               </span>
             </div>
-          `
-        )}
+          `,
+  )}
       </div>
     `;
   }
 
   handlePopup(e, entity) {
     e.stopPropagation();
-    if (this.config.more_info)
-      this.fire("hass-more-info", { entityId: entity.entity_id });
+    if (this.config.more_info) this.fire('hass-more-info', { entityId: entity.entity_id });
   }
 
   fire(type, inDetail, inOptions) {
@@ -555,7 +515,7 @@ class MiniGraphCard extends LitElement {
     const e = new Event(type, {
       bubbles: options.bubbles === undefined ? true : options.bubbles,
       cancelable: Boolean(options.cancelable),
-      composed: options.composed === undefined ? true : options.composed
+      composed: options.composed === undefined ? true : options.composed,
     });
     e.detail = detail;
     this.dispatchEvent(e);
@@ -567,33 +527,30 @@ class MiniGraphCard extends LitElement {
     const state = Number(inState) || 0;
     const threshold = {
       color: line_color[i] || line_color[0],
-      ...color_thresholds.find(ele => ele.value < state)
+      ...color_thresholds.find(ele => ele.value < state),
     };
     return this.config.entities[i].color || threshold.color;
   }
 
   computeName(index) {
-    return (
-      this.config.entities[index].name ||
-      this.entity[index].attributes.friendly_name
-    );
+    return this.config.entities[index].name || this.entity[index].attributes.friendly_name;
   }
 
   computeIcon(entity) {
     return (
-      this.config.icon ||
-      entity.attributes.icon ||
-      ICONS[entity.attributes.device_class] ||
-      ICONS.temperature
+      this.config.icon
+      || entity.attributes.icon
+      || ICONS[entity.attributes.device_class]
+      || ICONS.temperature
     );
   }
 
   computeUom(index) {
     return (
-      this.config.entities[index].unit ||
-      this.config.unit ||
-      this.entity[index].attributes.unit_of_measurement ||
-      ""
+      this.config.entities[index].unit
+      || this.config.unit
+      || this.entity[index].attributes.unit_of_measurement
+      || ''
     );
   }
 
@@ -619,14 +576,10 @@ class MiniGraphCard extends LitElement {
 
     const end = new Date();
     const start = new Date();
-    start.setMilliseconds(
-      end.getMilliseconds() - getMilli(config.hours_to_show)
-    );
+    start.setMilliseconds(end.getMilliseconds() - getMilli(config.hours_to_show));
 
     try {
-      const promise = this.entity.map((entity, i) =>
-        this.updateEntity(entity, i, start, end)
-      );
+      const promise = this.entity.map((entity, i) => this.updateEntity(entity, i, start, end));
       await Promise.all(promise);
     } finally {
       this.updating = false;
@@ -640,26 +593,23 @@ class MiniGraphCard extends LitElement {
         : Math.min(...this.Graph.map(ele => ele.min)) || this.bound[0],
       config.upper_bound !== undefined
         ? config.upper_bound
-        : Math.max(...this.Graph.map(ele => ele.max)) || this.bound[1]
+        : Math.max(...this.Graph.map(ele => ele.max)) || this.bound[1],
     ];
 
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
         if (!entity || this.Graph[i].coords.length === 0) return;
         [this.Graph[i].min, this.Graph[i].max] = [this.bound[0], this.bound[1]];
-        if (config.show.graph === "bar") {
+        if (config.show.graph === 'bar') {
           this.bar[i] = this.Graph[i].getBars(i, config.entities.length);
         } else {
           this.line[i] = this.Graph[i].getPath();
-          if (config.show.fill)
-            this.fill[i] = this.Graph[i].getFill(this.line[i]);
+          if (config.show.fill) this.fill[i] = this.Graph[i].getFill(this.line[i]);
           if (config.show.points) this.points[i] = this.Graph[i].getPoints();
           if (config.color_thresholds.length > 0 && !config.entities[i].color)
             this.gradient[i] = this.Graph[i].computeGradient(
               config.color_thresholds,
-              config.entities[i].color ||
-                config.line_color[i] ||
-                config.line_color[0]
+              config.entities[i].color || config.line_color[i] || config.line_color[0],
             );
         }
       });
@@ -677,9 +627,7 @@ class MiniGraphCard extends LitElement {
     let newStateHistory = await this.fetchRecent(entity.entity_id, start, end);
 
     if (!newStateHistory[0]) return;
-    newStateHistory = newStateHistory[0].filter(
-      item => !Number.isNaN(parseFloat(item.state))
-    );
+    newStateHistory = newStateHistory[0].filter(item => !Number.isNaN(parseFloat(item.state)));
     if (newStateHistory.length < 1) return;
 
     stateHistory = [...stateHistory, ...newStateHistory];
@@ -689,13 +637,13 @@ class MiniGraphCard extends LitElement {
     if (entity.entity_id === this.entity[0].entity_id) {
       this.abs = [
         {
-          type: "min",
-          ...getMin(stateHistory, "state")
+          type: 'min',
+          ...getMin(stateHistory, 'state'),
         },
         {
-          type: "max",
-          ...getMax(stateHistory, "state")
-        }
+          type: 'max',
+          ...getMax(stateHistory, 'state'),
+        },
       ];
     }
 
@@ -703,11 +651,11 @@ class MiniGraphCard extends LitElement {
   }
 
   async fetchRecent(entityId, start, end) {
-    let url = "history/period";
+    let url = 'history/period';
     if (start) url += `/${start.toISOString()}`;
     url += `?filter_entity_id=${entityId}`;
     if (end) url += `&end_time=${end.toISOString()}`;
-    return this._hass.callApi("GET", url);
+    return this._hass.callApi('GET', url);
   }
 
   getCardSize() {
@@ -715,4 +663,4 @@ class MiniGraphCard extends LitElement {
   }
 }
 
-customElements.define("mini-graph-card", MiniGraphCard);
+customElements.define('mini-graph-card', MiniGraphCard);

--- a/src/main.js
+++ b/src/main.js
@@ -148,11 +148,22 @@ class MiniGraphCard extends LitElement {
     this.config = conf;
   }
 
-  firstUpdated() {
+  connectedCallback() {
+    super.connectedCallback();
     if (this.config.update_interval) {
       this.updateOnInterval();
-      setInterval(() => this.updateOnInterval(), this.config.update_interval * 1000);
+      this.interval = setInterval(
+        () => this.updateOnInterval(),
+        this.config.update_interval * 1000,
+      );
     }
+  }
+
+  disconnectedCallback() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+    super.disconnectedCallback();
   }
 
   shouldUpdate(changedProps) {


### PR DESCRIPTION
Just dropping it here for now. Works ⚡️ fast for me, ~~especially because I render with the cached data before the first fetch is done (as that can take some time)...~~

Things we should think about:
- ~~I store the history based on the `entity_id` if a user would use an entity in more than one graph with different `hours_to_show` settings, it would mess up the data...~~ I now store the `hours_to_show` setting, that means that 2 graphs with the same entity and different `hours_to_show` will not use the cache.
- ~~Increasing the `hours_to_show` setting will not show instant, as it will not fetch new data before the last time. It will not purge however so eventually you will get the right data.~~ I now store the `hours_to_show` setting, after changing it, it will fetch everything.