### PR TITLE
:bug: Catch if localStorage quota is exceeded

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -667,7 +667,13 @@ class MiniGraphCard extends LitElement {
         last_fetched: end,
         data: stateHistory,
       };
-      storage[HISTORY_STORAGE] = JSON.stringify(history);
+      try {
+        storage[HISTORY_STORAGE] = JSON.stringify(history);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('mini-graph-card: Failed to cache, not enough space.');
+        storage.removeItem(HISTORY_STORAGE);
+      }
     }
 
     if (stateHistory.length === 0) return;


### PR DESCRIPTION
Dealing with storage quota exceeded errors, causing graph to not display.

![](https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/original/3X/c/8/c8f85ba0af805bbab1f0eae4b3fbc4850b651ff7.png)
