### PR TITLE
Fix bar width when hiding some entities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -742,7 +742,7 @@ class MiniGraphCard extends LitElement {
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
-          this.bar[i] = this.Graph[i].getBars(i, config.entities.length);
+          this.bar[i] = this.Graph[i].getBars(i, this.visibleEntities.length);
         } else {
           const line = this.Graph[i].getPath();
           if (config.entities[i].show_line !== false) this.line[i] = line;


### PR DESCRIPTION
In bar graph mode, when hiding the graph for some entities via `show_graph: false` the width of the remaining graph bars was not adjusted properly.