### PR TITLE
Add option to graph only the current state of an entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Providing options are optional, entities can be listed directly, see example bel
 | show_legend | boolean | optional | Set to false to turn hide from the legend.
 | state_adaptive_color | boolean | optional | Make the color of the state adapt to the entity color.
 | y_axis | string | optional | If 'secondary', displays using the secondary y-axis on the right.
+| fixed_value | boolean | optional | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 
 Note:
 - If the line and points and fill are all set to false, nothing will be visible in the graph. However, the

--- a/src/main.js
+++ b/src/main.js
@@ -827,7 +827,12 @@ class MiniGraphCard extends LitElement {
       ];
     }
 
-    this.Graph[index].update(stateHistory);
+    if (this.config.entities[index].fixed_value === true) {
+      const last = stateHistory[stateHistory.length - 1];
+      this.Graph[index].update([last, last]);
+    } else {
+      this.Graph[index].update(stateHistory);
+    }
   }
 
   async fetchRecent(entityId, start, end, skipInitialState) {


### PR DESCRIPTION
This feature adds an option to graph the entity's current state as a
fixed value in the graph rather than graphing the entity's state
history. This feature is useful for displaying fixed values, like
averages, that another entity's state history is compared against.

For example, one might want to plot the current temperature against the
average daily temperature. In this use case, the average daily
temperature is updated once a day, and its state history is not
interesting to compare against. Rather, only its current value is
interesting. The `fixed_value` option allows for the current average
daily temperature to be graphed as a horizontal line.