### PR TITLE
Add average support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ All options are optional.
 | fill | true | `true` / `false` / `fade` | Display the line graph fill
 | points | hover | `true` / `false` / `hover` | Display graph data points
 | legend | true | `true` / `false` | Display the graph legend (only shown when graph contains multiple entities)
+| average | false | `true` / `false` | Display average information
 | extrema | false | `true` / `false` | Display max/min information
 | labels | hover | `true` / `false` / `hover` | Display Y-axis labels
 | labels_secondary | hover | `true` / `false` / `hover` | Display secondary Y-axis labels

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import {
 } from './const';
 import {
   getMin,
+  getAvg,
   getMax,
   getTime,
   getMilli,
@@ -49,7 +50,9 @@ class MiniGraphCard extends LitElement {
       .substr(2, 9);
     this.bound = [0, 0];
     this.boundSecondary = [0, 0];
-    this.abs = [];
+    this.min = {};
+    this.avg = {};
+    this.max = {};
     this.length = [];
     this.entity = [];
     this.line = [];
@@ -562,17 +565,21 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
-    if (!this.config.show.extrema) return;
+    const info = [];
+    if (this.config.show.extrema) info.push(this.min);
+    if (this.config.show.average) info.push(this.avg);
+    if (this.config.show.extrema) info.push(this.max);
+    if (!info) return;
     return html`
       <div class="info flex">
-        ${this.abs.map(entry => html`
+        ${info.map(entry => html`
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
               ${this.computeState(entry.state)} ${this.computeUom(0)}
             </span>
             <span class="info__item__time">
-              ${getTime(new Date(entry.last_changed), this.config.format, this._hass.language)}
+              ${entry.type !== 'avg' ? getTime(new Date(entry.last_changed), this.config.format, this._hass.language) : ''}
             </span>
           </div>
         `)}
@@ -827,16 +834,18 @@ class MiniGraphCard extends LitElement {
     if (stateHistory.length === 0) return;
 
     if (entity.entity_id === this.entity[0].entity_id) {
-      this.abs = [
-        {
-          type: 'min',
-          ...getMin(stateHistory, 'state'),
-        },
-        {
-          type: 'max',
-          ...getMax(stateHistory, 'state'),
-        },
-      ];
+      this.min = {
+        type: 'min',
+        ...getMin(stateHistory, 'state'),
+      };
+      this.avg = {
+        type: 'avg',
+        state: getAvg(stateHistory, 'state'),
+      };
+      this.max = {
+        type: 'max',
+        ...getMax(stateHistory, 'state'),
+      };
     }
 
     if (this.config.entities[index].fixed_value === true) {

--- a/src/style.js
+++ b/src/style.js
@@ -364,12 +364,15 @@ const style = css`
   .info__item {
     display: flex;
     flex-flow: column;
-    align-items: flex-end;
-    text-align: right;
+    text-align: center;
   }
   .info__item:first-child {
     align-items: flex-start;
     text-align: left;
+  }
+  .info__item:last-child {
+    align-items: flex-end;
+    text-align: right;
   }
   .info__item__type {
     text-transform: capitalize;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,8 +4,8 @@ import { compress as lzStringCompress, decompress as lzStringDecompress } from '
 const getMin = (arr, val) => arr.reduce((min, p) => (
   Number(p[val]) < Number(min[val]) ? p : min
 ), arr[0]);
-const getAvg = (arr, val) => arr.reduce((avg, p) => (
-  avg + Number(p[val])
+const getAvg = (arr, val) => arr.reduce((sum, p) => (
+  sum + Number(p[val])
 ), 0) / arr.length;
 const getMax = (arr, val) => arr.reduce((max, p) => (
   Number(p[val]) > Number(max[val]) ? p : max

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,9 @@ import { compress as lzStringCompress, decompress as lzStringDecompress } from '
 const getMin = (arr, val) => arr.reduce((min, p) => (
   Number(p[val]) < Number(min[val]) ? p : min
 ), arr[0]);
+const getAvg = (arr, val) => arr.reduce((avg, p) => (
+  avg + Number(p[val])
+), 0) / arr.length;
 const getMax = (arr, val) => arr.reduce((max, p) => (
   Number(p[val]) > Number(max[val]) ? p : max
 ), arr[0]);
@@ -31,5 +34,5 @@ const compress = data => lzStringCompress(JSON.stringify(data));
 const decompress = data => (typeof data === 'string' ? JSON.parse(lzStringDecompress(data)) : data);
 
 export {
-  getMin, getMax, getTime, getMilli, interpolateColor, compress, decompress,
+  getMin, getAvg, getMax, getTime, getMilli, interpolateColor, compress, decompress,
 };


### PR DESCRIPTION
Note: not related to #73, this shows the average of the first value only, just like the current extrema support. It may however be helpful to that reporter anyway if they did create an extra sensor.

```
show:
  extrema: true
  average: true
```
<img width="470" alt="Screenshot 2019-08-16 at 15 25 08" src="https://user-images.githubusercontent.com/1885159/63170654-0d94c300-c03a-11e9-8d3d-388ae6afcf1e.png">


```
show:
  average: true
  extrema: false
```
<img width="469" alt="Screenshot 2019-08-16 at 15 24 29" src="https://user-images.githubusercontent.com/1885159/63170627-f950c600-c039-11e9-83d8-9ac5bd426918.png">


```
show:
  extrema: true
  average: false
```
<img width="470" alt="Screenshot 2019-08-16 at 15 23 37" src="https://user-images.githubusercontent.com/1885159/63170580-e0e0ab80-c039-11e9-8228-45f977e7baa8.png">
