### PR TITLE
Pressing/clicking state entries will trigger the popup for that entity

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -305,6 +305,7 @@ class MiniGraphCard extends LitElement {
       return html`
         <div
           class="state state--small"
+          @click=${e => this.handlePopup(e, this.entity[id])}
           style=${entity.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}>
           ${entity.show_indicator ? this.renderIndicator(state, id) : ''}
           <span class="state__value ellipsis">


### PR DESCRIPTION
This intends to complement issue #31, which does the same when clicking legend entries.