### PR TITLE
Adding more colors for automatic multi colored graph

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -21,7 +21,7 @@ const DEFAULT_COLORS = [
   '#7f8c8d',
   '#27ae60',
   '#2980b9',
-  '#8e44ad'
+  '#8e44ad',
 ];
 const UPDATE_PROPS = ['entity', 'line', 'length', 'fill', 'points', 'tooltip', 'abs'];
 const DEFAULT_SHOW = {

--- a/src/const.js
+++ b/src/const.js
@@ -15,6 +15,13 @@ const DEFAULT_COLORS = [
   '#9b59b6',
   '#f1c40f',
   '#2ecc71',
+  '#1abc9c',
+  '#34495e',
+  '#e67e22',
+  '#7f8c8d',
+  '#27ae60',
+  '#2980b9',
+  '#8e44ad'
 ];
 const UPDATE_PROPS = ['entity', 'line', 'length', 'fill', 'points', 'tooltip', 'abs'];
 const DEFAULT_SHOW = {


### PR DESCRIPTION
With this, there would be 13 colors for multi entities graphs.

Preview : 
![image](https://user-images.githubusercontent.com/25659602/64429751-0734bc80-d0b7-11e9-874d-a1de68497dfc.png)

Note that `var(--accent-color)` is not in the preview !
I preserved the original order for firsts colors to avoid any change in small multiple entities existing graphs.

Colors from https://flatuicolors.com/palette/defo

Would close #147 