### PR TITLE
Group by date and aggregate functions #78 #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | name | string |  | Set a custom display name, defaults to entity's friendly_name.
 | color | string |  | Set a custom color, overrides all other color options including thresholds.
 | unit | string |  | Set a custom unit of measurement, overrides `unit` set in base config.
+| aggregate_func | string |  | Override for aggregate function used to calculate point on the graph, `avg`, `min`, `max`.
 | show_state | boolean |  | Display the current state.
 | show_indicator | boolean |  | Display a color indicator next to the state, (only when more than two states are visible).
 | show_line | boolean |  | Set to false to hide the line (see note below table).
@@ -315,12 +316,33 @@ You can group values by date, this way you can visualize for example daily energ
     - entity: sensor.energy_daily
   name: Energy consumption
   hours_to_show: 168
-  height: 150
   aggregate_func: max
   group_by: date
-  hour24: true
   show:
     graph: bar
+```
+
+#### Data aggregation functions
+You can decide how values are agreggated for points on graph. Example how to display min, max, avg temerature per day
+from last week.
+
+```yaml
+- type: custom:mini-graph-card
+  entities:
+    - entity: sensor.outside_temp
+      aggregate_func: max
+      name: Max
+      color: #e74c3c
+    - entity: sensor.outside_temp
+      aggregate_func: min
+      name: Min
+    - entity: sensor.outside_temp
+      aggregate_func: avg
+      name: Avg
+      color: green
+  name: Temp outside daily (last week)
+  hours_to_show: 168
+  group_by: date
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This card is available in [HACS](https://github.com/custom-components/hacs/issue
 | group | boolean | `false` | v0.2.0 | Disable paddings and box-shadow, useful when nesting the card.
 | hours_to_show | integer | `24` | v0.0.2 | Specify how many hours of history the graph should present.
 | points_per_hour | number | `0.5` | v0.2.0 | Specify amount of data points the graph should display for each hour, *(basically the detail/accuracy/smoothing of the graph)*.
+| aggregate_func | string | `avg` | v0.7.1 | Specify aggregate function used to calculate point on the graph, `avg`, `min`, `max`.
+| group_by | string | `interval` | v0.7.1 | Specify type of grouping for a point, dynamic `interval`, `date`.
 | update_interval | number |  | v0.4.0 | Specify a custom update interval of the history data (in seconds), instead of on every state change.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
@@ -206,7 +208,7 @@ See [dynamic line color](#dynamic-line-color) for example usage.
 ![Bar chart card](https://user-images.githubusercontent.com/457678/52970286-985e7300-33b3-11e9-89bc-1278c4e2ecf2.png)
 
 #### Show data from the past week
-Use the `hours_to_show` option to specify how many hours of history the graph should represent.  
+Use the `hours_to_show` option to specify how many hours of history the graph should represent.
 Use the `points_per_hour` option to specify the accuracy/detail of the graph.
 
 ```yaml
@@ -298,11 +300,28 @@ shows turning off the line, points and legend.
       show_points: false
       show_legend: false
       y_axis: secondary
-    show:
-      labels: true
-      labels_secondary: true
+  show:
+    labels: true
+    labels_secondary: true
 ```
 ![Alternate y-axis](https://user-images.githubusercontent.com/373079/60764115-63cf2780-a0c6-11e9-8b9a-97fc47161180.png)
+
+#### Grouping by date
+You can group values by date, this way you can visualize for example daily energy consumption.
+
+```yaml
+- type: type: custom:mini-graph-card
+  entities:
+    - entity: sensor.energy_daily
+  name: Energy consumption
+  hours_to_show: 168
+  height: 150
+  aggregate_func: max
+  group_by: date
+  hour24: true
+  show:
+    graph: bar
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ You can group values by date, this way you can visualize for example daily energ
   show:
     graph: bar
 ```
+![mini_energy_daily](https://user-images.githubusercontent.com/8268674/66688605-3ffc1e80-ec7f-11e9-872e-935870a542f3.png)
 
 #### Data aggregation functions
 You can decide how values are agreggated for points on graph. Example how to display min, max, avg temerature per day
@@ -344,6 +345,8 @@ from last week.
   hours_to_show: 168
   group_by: date
 ```
+
+![mini_temperature_aggregate_daily](https://user-images.githubusercontent.com/8268674/66688610-44c0d280-ec7f-11e9-86c2-a728da239dab.png)
 
 ## Development
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## v0.7.1
+
+### ADDED
+- Grouping by date (#78) - (@maxwroc)
+- Point calculation / aggregation functions (#78) - (@maxwroc)
+
 ## v0.7.0
 
 ### BREAKING CHANGE

--- a/src/graph.js
+++ b/src/graph.js
@@ -35,15 +35,13 @@ export default class Graph {
 
 
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);
-    console.log(coords.length, requiredNumOfPoints);
     if (coords.length > requiredNumOfPoints) {
-      console.log("shift");
       // if there is too much data we reduce it
       coords.splice(0, coords.length - requiredNumOfPoints);
     }
     else {
-      // make sure graph goes to the end
-      coords.length = Math.ceil(this.hours * this.points);
+      // extend length to match the required number of points
+      coords.length = requiredNumOfPoints;
     }
 
     this.coords = this._calcPoints(coords);

--- a/src/graph.js
+++ b/src/graph.js
@@ -4,9 +4,9 @@ import { interpolateColor } from './utils';
 export default class Graph {
   constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval') {
     const aggregateFuncMap = {
-      'avg' : this._average,
-      'max' : this._maximum,
-      'min' : this._minimum
+      avg: this._average,
+      max: this._maximum,
+      min: this._minimum,
     };
 
     this.coords = [];
@@ -30,7 +30,7 @@ export default class Graph {
   set min(min) { this._min = min; }
 
   update(history) {
-    const groupByFunc = this._groupBy == 'date' ? this._getGroupByDateFunc() : this._getGroupByIntervalFunc();
+    const groupByFunc = this._groupBy === 'date' ? this._getGroupByDateFunc() : this._getGroupByIntervalFunc();
     const coords = history.reduce((res, item) => groupByFunc(res, item), []);
 
 
@@ -38,8 +38,7 @@ export default class Graph {
     if (coords.length > requiredNumOfPoints) {
       // if there is too much data we reduce it
       coords.splice(0, coords.length - requiredNumOfPoints);
-    }
-    else {
+    } else {
       // extend length to match the required number of points
       coords.length = requiredNumOfPoints;
     }
@@ -51,26 +50,26 @@ export default class Graph {
 
   _getGroupByIntervalFunc() {
     const now = new Date().getTime();
-    return (result, item) => {
+    return (res, item) => {
       const age = now - new Date(item.last_changed).getTime();
       const interval = (age / (1000 * 3600) * this.points) - this.hours * this.points;
       const key = Math.floor(Math.abs(interval));
-      if (!result[key]) result[key] = [];
-      result[key].push(item);
-      return result;
-    }
+      if (!res[key]) res[key] = [];
+      res[key].push(item);
+      return res;
+    };
   }
 
   _getGroupByDateFunc() {
     const dateToKeyMap = {};
-    return (result, item) => {
-      let date = new Date(item.last_changed).toDateString();
-      if (dateToKeyMap[date] == undefined) dateToKeyMap[date] = result.length;
-      let key = dateToKeyMap[date];
-      if (!result[key]) result[key] = [];
-      result[key].push(item);
-      return result;
-    }
+    return (res, item) => {
+      const date = new Date(item.last_changed).toDateString();
+      if (dateToKeyMap[date] === undefined) dateToKeyMap[date] = res.length;
+      const key = dateToKeyMap[date];
+      if (!res[key]) res[key] = [];
+      res[key].push(item);
+      return res;
+    };
   }
 
   _calcPoints(history) {
@@ -182,19 +181,19 @@ export default class Graph {
     return [Zx, Zy];
   }
 
-  _average(item) {
-    return item.reduce((sum, entry) => (sum + parseFloat(entry.state)), 0) / item.length;
+  _average(items) {
+    return items.reduce((sum, entry) => (sum + parseFloat(entry.state)), 0) / items.length;
   }
 
-  _maximum(item) {
-    return Math.max(...item.map(item => item.state));
+  _maximum(items) {
+    return Math.max(...items.map(item => item.state));
   }
 
-  _minimum(item) {
-    return Math.min(...item.map(item => item.state));
+  _minimum(items) {
+    return Math.min(...items.map(item => item.state));
   }
 
-  _last(item) {
-    return parseFloat(item[item.length - 1].state) || 0;
+  _last(items) {
+    return parseFloat(items[items.length - 1].state) || 0;
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -131,6 +131,8 @@ class MiniGraphCard extends LitElement {
       height: 100,
       hours_to_show: 24,
       points_per_hour: 0.5,
+      point_calc: 'avg',
+      group_by: 'interval',
       line_color: [...DEFAULT_COLORS],
       color_thresholds: [],
       color_thresholds_transition: 'smooth',
@@ -176,6 +178,8 @@ class MiniGraphCard extends LitElement {
           [conf.show.fill ? 0 : conf.line_width, conf.line_width],
           conf.hours_to_show,
           conf.points_per_hour,
+          conf.aggregate_func,
+          conf.group_by,
         ),
       );
     }
@@ -530,7 +534,7 @@ class MiniGraphCard extends LitElement {
   }
 
   setTooltip(entity, index, value, label = null) {
-    const { points_per_hour, hours_to_show, format } = this.config;
+    const { points_per_hour, hours_to_show, format, group_by } = this.config;
     const offset = hours_to_show < 1 && points_per_hour < 1
       ? points_per_hour * hours_to_show
       : 1 / points_per_hour;
@@ -538,6 +542,12 @@ class MiniGraphCard extends LitElement {
     const id = Math.abs(index + 1 - Math.ceil(hours_to_show * points_per_hour));
 
     const now = new Date();
+
+    if (group_by == 'date') {
+      now.setDate(now.getDate() + 1);
+      now.setHours(0, 0);
+    }
+
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id));
     const end = getTime(now, { hour12: !this.config.hour24 }, this._hass.language);
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset));

--- a/src/main.js
+++ b/src/main.js
@@ -549,13 +549,15 @@ class MiniGraphCard extends LitElement {
     const now = new Date();
 
     if (group_by == 'date') {
+      // move end time to the next day at midnight
       now.setDate(now.getDate() + 1);
       now.setHours(0, 0);
     }
 
-    now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id));
+    const oneMinInHours = 1 / 60;
+    now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id + oneMinInHours));
     const end = getTime(now, { hour12: !this.config.hour24 }, this._hass.language);
-    now.setMilliseconds(now.getMilliseconds() - getMilli(offset));
+    now.setMilliseconds(now.getMilliseconds() - getMilli(offset - oneMinInHours));
     const start = getTime(now, format, this._hass.language);
 
     this.tooltip = {

--- a/src/main.js
+++ b/src/main.js
@@ -175,15 +175,16 @@ class MiniGraphCard extends LitElement {
         );
       }
     }
+    
     if (!this.Graph) {
       this.Graph = conf.entities.map(
-        () => new Graph(
+        entity => new Graph(
           500,
           conf.height,
           [conf.show.fill ? 0 : conf.line_width, conf.line_width],
           conf.hours_to_show,
           conf.points_per_hour,
-          conf.aggregate_func,
+          entity.aggregate_func || conf.aggregate_func,
           conf.group_by,
         ),
       );

--- a/src/main.js
+++ b/src/main.js
@@ -159,7 +159,7 @@ class MiniGraphCard extends LitElement {
     const additional = conf.hours_to_show > 24 ? { day: 'numeric', weekday: 'short' } : {};
     conf.format = { hour12: !conf.hour24, ...additional };
 
-    if (conf.group_by == 'date') {
+    if (conf.group_by === 'date') {
       // override points per hour to mach 1 point per day (24h)
       conf.points_per_hour = 1 / 24;
     }
@@ -175,7 +175,7 @@ class MiniGraphCard extends LitElement {
         );
       }
     }
-    
+
     if (!this.Graph) {
       this.Graph = conf.entities.map(
         entity => new Graph(
@@ -540,7 +540,12 @@ class MiniGraphCard extends LitElement {
   }
 
   setTooltip(entity, index, value, label = null) {
-    const { points_per_hour, hours_to_show, format, group_by } = this.config;
+    const {
+      points_per_hour,
+      hours_to_show,
+      format,
+      group_by,
+    } = this.config;
     const offset = hours_to_show < 1 && points_per_hour < 1
       ? points_per_hour * hours_to_show
       : 1 / points_per_hour;
@@ -549,7 +554,7 @@ class MiniGraphCard extends LitElement {
 
     const now = new Date();
 
-    if (group_by == 'date') {
+    if (group_by === 'date') {
       // move end time to the next day at midnight
       now.setDate(now.getDate() + 1);
       now.setHours(0, 0);

--- a/src/main.js
+++ b/src/main.js
@@ -131,7 +131,7 @@ class MiniGraphCard extends LitElement {
       height: 100,
       hours_to_show: 24,
       points_per_hour: 0.5,
-      point_calc: 'avg',
+      aggregate_func: 'avg',
       group_by: 'interval',
       line_color: [...DEFAULT_COLORS],
       color_thresholds: [],
@@ -158,6 +158,11 @@ class MiniGraphCard extends LitElement {
     );
     const additional = conf.hours_to_show > 24 ? { day: 'numeric', weekday: 'short' } : {};
     conf.format = { hour12: !conf.hour24, ...additional };
+
+    if (conf.group_by == 'date') {
+      // override points per hour to mach 1 point per day (24h)
+      conf.points_per_hour = 1 / 24;
+    }
 
     if (conf.show.graph === 'bar') {
       const entities = conf.entities.length;


### PR DESCRIPTION
Daily results and support for various aggregation methods.

Main goal of this change was to give ability to show utility meter results. It other words show grouped results by day and the maximum value achieved - which means show results from 00:00 till 23:59 as a single point.

I've added additional aggregation methods (other than maximum) and now we can for example show min, max, avg temperature stats on the same graph.