### PR TITLE
Support for non numeric states (+ disable smoothing setting) - #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This card is available in [HACS](https://github.com/custom-components/hacs/issue
 | upper_bound | number |  | v0.2.3 | Set a fixed upper bound for the graph Y-axis.
 | lower_bound_secondary | number |  | v0.5.0 | Set a fixed lower bound for the graph secondary Y-axis.
 | upper_bound_secondary | number |  | v0.5.0 | Set a fixed upper bound for the graph secondary Y-axis.
+| smoothing | boolean | `true` | v0.7.1 | Whether to make graph line smooth.
+| state_map | [state map object](#state-map-object) |  | v0.7.1 | List of entity states to convert (order matters as position becomes a value on the graph).
 
 #### Entities object
 Entities may be listed directly (as per `sensor.temperature` in the following example), or defined using
@@ -116,6 +118,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | state_adaptive_color | boolean |  | Make the color of the state adapt to the entity color.
 | y_axis | string |  | If 'secondary', displays using the secondary y-axis on the right.
 | fixed_value | boolean |  | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
+| smoothing | boolean |  | Override for a flag indicating whether to make graph line smooth.
 
 ```yaml
 entities:
@@ -161,6 +164,12 @@ See [dynamic line color](#dynamic-line-color) for example usage.
 | service_data | object |  | Any service data | Service data to include with the service call (e.g. `entity_id: media_player.office`).
 | navigation_path | string |  | Any path | Path to navigate to (e.g. `/lovelace/0/`) when `action` is defined as `navigate`.
 | url | string |  | Any URL | URL to open when `action` is defined as `url`.
+
+#### State map object
+| Name | Type | Default | Description |
+|------|:----:|:-------:|-------------|
+| value ***(required)*** | string |  | Value to convert.
+| label | string | same as value | String to show as label (if the value is not precise).
 
 ### Example usage
 
@@ -347,6 +356,37 @@ from last week.
 ```
 
 ![mini_temperature_aggregate_daily](https://user-images.githubusercontent.com/8268674/66688610-44c0d280-ec7f-11e9-86c2-a728da239dab.png)
+
+#### Non-numeric sensor states
+You can render non-numeric states by providing state_map config. For example this way you can show data comming from binary sensors.
+
+```yaml
+- type: custom:mini-graph-card
+  entities:
+    - entity: binary_sensor.living_room_motion
+      name: Living room
+    - entity: binary_sensor.corridor_motion
+      name: Corridor
+    - entity: binary_sensor.master_bed_motion
+      name: Master bed.
+      color: green
+    - entity: binary_sensor.bedroom_motion
+      name: Bedroom
+  name: Motion last hour
+  hours_to_show: 1
+  points_per_hour: 60
+  update_interval: 30
+  aggregate_func: max
+  line_width: 2
+  smoothing: false
+  state_map:
+    - value: "off"
+      label: Clear
+    - value: "on"
+      label: Detected
+```
+
+![mini_binary_sensor](https://user-images.githubusercontent.com/8268674/66825779-e1ff5d80-ef42-11e9-89eb-673d2ada8d34.png)
 
 ## Development
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 ### ADDED
 - Grouping by date (#78) - (@maxwroc)
 - Point calculation / aggregation functions (#78) - (@maxwroc)
+- Smoothing setting - (@maxwroc)
+- Rendering non-numeric sensor states e.g. binary sensors (#63) - (@maxwroc)
 
 ## v0.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - Rendering non-numeric sensor states e.g. binary sensors (#63) - (@maxwroc)
 
 ### FIXED
-- Rendering initial cached state - (@maxwroc)
+- Rendering initial cached state (#117) - (@maxwroc)
 
 ## v0.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 - Smoothing setting - (@maxwroc)
 - Rendering non-numeric sensor states e.g. binary sensors (#63) - (@maxwroc)
 
+### FIXED
+- Rendering initial cached state - (@maxwroc)
+
 ## v0.7.0
 
 ### BREAKING CHANGE

--- a/src/const.js
+++ b/src/const.js
@@ -10,6 +10,11 @@ const ICONS = {
   pressure: 'hass:gauge',
   power: 'hass:flash',
   signal_strength: 'hass:wifi',
+  motion: 'hass:walk',
+  door: 'hass:door-closed',
+  window: 'hass:window-closed',
+  presence: 'hass:account',
+  light: 'hass:lightbulb',
 };
 const DEFAULT_COLORS = [
   'var(--accent-color)',

--- a/src/graph.js
+++ b/src/graph.js
@@ -16,7 +16,8 @@ export default class Graph {
     this._max = 0;
     this._min = 0;
     this.points = points;
-    this.hours = hours;
+    this.hours = hours
+    console.log(aggregateFuncName);
     this._calculatePoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._groupBy = groupBy;
   }
@@ -33,7 +34,7 @@ export default class Graph {
     const groupByFunc = this._groupBy === 'date' ? this._getGroupByDateFunc() : this._getGroupByIntervalFunc();
     const coords = history.reduce((res, item) => groupByFunc(res, item), []);
 
-
+    console.log(coords);
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);
     if (coords.length > requiredNumOfPoints) {
       // if there is too much data we reduce it
@@ -114,11 +115,13 @@ export default class Graph {
       last = next;
       return [Z[X], Z[Y], sum, i + 1];
     });
+    console.log(coords2);
     return coords2;
   }
 
   getPath() {
     const coords = this._calcY(this.coords);
+    console.log(coords);
     let next; let Z;
     let path = '';
     let last = coords[0];

--- a/src/graph.js
+++ b/src/graph.js
@@ -8,8 +8,6 @@ export default class Graph {
       max: this._maximum,
       min: this._minimum,
     };
-    
-    console.log("last_changed", smoothing);
 
     this.coords = [];
     this.width = width - margin[X] * 2;
@@ -18,7 +16,7 @@ export default class Graph {
     this._max = 0;
     this._min = 0;
     this.points = points;
-    this.hours = hours
+    this.hours = hours;
     this._calculatePoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._groupBy = groupBy;
     this._smoothing = smoothing;

--- a/src/graph.js
+++ b/src/graph.js
@@ -110,7 +110,7 @@ export default class Graph {
     const coords2 = coords.map((point, i) => {
       next = point;
       Z = this._smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
-      const sum = (next[V] + last[V]) / 2;
+      const sum = this._smoothing ? (next[V] + last[V]) / 2 : next[V];
       last = next;
       return [Z[X], Z[Y], sum, i + 1];
     });

--- a/src/graph.js
+++ b/src/graph.js
@@ -109,7 +109,7 @@ export default class Graph {
     coords.shift();
     const coords2 = coords.map((point, i) => {
       next = point;
-      Z = this.smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
+      Z = this._smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
       const sum = (next[V] + last[V]) / 2;
       last = next;
       return [Z[X], Z[Y], sum, i + 1];
@@ -126,7 +126,7 @@ export default class Graph {
 
     coords.forEach((point) => {
       next = point;
-      Z = this.smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
+      Z = this._smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
       path += ` ${Z[X]},${Z[Y]}`;
       path += ` Q ${next[X]},${next[Y]}`;
       last = next;

--- a/src/main.js
+++ b/src/main.js
@@ -743,6 +743,9 @@ class MiniGraphCard extends LitElement {
 
       if (stateMap) {
         return stateMap.label;
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(`mini-graph-card: value [${inState}] not found in state_map`);
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -737,9 +737,10 @@ class MiniGraphCard extends LitElement {
 
   computeState(inState) {
     if (this.config.state_map.length > 0) {
-      const stateMap = Number.isInteger(inState) ?
-                        this.config.state_map[inState] :
-                        this.config.state_map.find(state => state.value === inState);
+      const stateMap = Number.isInteger(inState)
+        ? this.config.state_map[inState]
+        : this.config.state_map.find(state => state.value === inState);
+
       if (stateMap) {
         return stateMap.label;
       }
@@ -842,17 +843,16 @@ class MiniGraphCard extends LitElement {
     if (history && history.hours_to_show === this.config.hours_to_show) {
       stateHistory = history.data;
 
-      let currDataStartIndex = stateHistory.findIndex(item => new Date(item.last_changed) > initStart);
-      if (currDataStartIndex !== -1) {
-
-        if (currDataStartIndex > 0) {
+      let currDataIndex = stateHistory.findIndex(item => new Date(item.last_changed) > initStart);
+      if (currDataIndex !== -1) {
+        if (currDataIndex > 0) {
           // include previous item
-          currDataStartIndex--;
+          currDataIndex -= 1;
           // but change it's last changed time
-          stateHistory[currDataStartIndex].last_changed = initStart;
+          stateHistory[currDataIndex].last_changed = initStart;
         }
 
-        stateHistory = stateHistory.slice(currDataStartIndex, stateHistory.length);
+        stateHistory = stateHistory.slice(currDataIndex, stateHistory.length);
         // skip initial state when fetching recent/not-cached data
         skipInitialState = true;
       }
@@ -925,16 +925,13 @@ class MiniGraphCard extends LitElement {
   }
 
 
-  _convertState(item) {
-    const resultIndex = this.config.state_map.findIndex(stateData => stateData.value === item.state);
+  _convertState(res) {
+    const resultIndex = this.config.state_map.findIndex(s => s.value === res.state);
     if (resultIndex === -1) {
-      console.warn(`mini-graph-card: entity state cannot be converted: ${item.state}`);
       return;
     }
 
-    item.state = resultIndex;
-
-    return;
+    res.state = resultIndex;
   }
 
   getCardSize() {

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import {
   getMilli,
   interpolateColor,
   compress, decompress,
+  getFirstDefinedItem,
 } from './utils';
 
 localForage.config({
@@ -196,7 +197,11 @@ class MiniGraphCard extends LitElement {
           conf.points_per_hour,
           entity.aggregate_func || conf.aggregate_func,
           conf.group_by,
-          entity.smoothing || conf.smoothing,
+          getFirstDefinedItem(
+            entity.smoothing,
+            config.smoothing,
+            !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
+          ),
         ),
       );
     }

--- a/src/main.js
+++ b/src/main.js
@@ -855,6 +855,9 @@ class MiniGraphCard extends LitElement {
         stateHistory = stateHistory.slice(currDataIndex, stateHistory.length);
         // skip initial state when fetching recent/not-cached data
         skipInitialState = true;
+      } else {
+        // there were no states which could be used in current graph so clearing
+        stateHistory = [];
       }
 
       const lastFetched = new Date(history.last_fetched);

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,6 +33,9 @@ const compress = data => lzStringCompress(JSON.stringify(data));
 
 const decompress = data => (typeof data === 'string' ? JSON.parse(lzStringDecompress(data)) : data);
 
+const getFirstDefinedItem = (...collection) => collection.find(item => typeof item !== 'undefined');
+
 export {
   getMin, getAvg, getMax, getTime, getMilli, interpolateColor, compress, decompress,
+  getFirstDefinedItem,
 };


### PR DESCRIPTION
### Feature
With this change we will be able to show e.g. binary sensor states on the graph. This will fill a big gap as the default way of rendering of such sensor data is not readable (talking here about timeline horizontal bars rendered by history-graph card (or in more-info dialog)).

Feature requested in #63 

### Bug fix
In addition I have fixed here the initial state which comes from cache. The problem was that we were filtering out older states than current time but we were not adding previous state on the beginning of the time. This way when sensor was pushing data rarely we were rendering graph in the wrong way.
For example: 
* time now: 2019-10-15 **14:30:00**
* graph beginning time: 2019-10-15 **13:30:00**
* data in cache: 
  ```js
  [ 
    {last_changed: '2019-10-15 12:10:00', state: 25 },
    {last_changed: '2019-10-15 13:50:00', state: 30 },
    {last_changed: '2019-10-15 14:25:00', state: 28 }
  ]
  ```
* filtered result: 
  ```js
  [ 
    {last_changed: '2019-10-15 13:50:00', state: 30 },
    {last_changed: '2019-10-15 14:25:00', state: 28 }
  ]
  ```
So now we will show straight line from the beginning of the graph (13:30) with value 30 till 13:50:00 which is not correct. The line should start on value 25 and it should change at 13:50 to 30.