### PR TITLE
Add support for runtime config updates

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -31,7 +31,7 @@ const DEFAULT_COLORS = [
   '#2980b9',
   '#8e44ad',
 ];
-const UPDATE_PROPS = ['entity', 'line', 'length', 'fill', 'points', 'tooltip', 'abs'];
+const UPDATE_PROPS = ['entity', 'line', 'length', 'fill', 'points', 'tooltip', 'abs', 'config'];
 const DEFAULT_SHOW = {
   name: true,
   icon: true,

--- a/src/main.js
+++ b/src/main.js
@@ -881,7 +881,7 @@ class MiniGraphCard extends LitElement {
     let start = initStart;
     let skipInitialState = false;
 
-    const history = null; // await this.getCache(entity.entity_id, this.config.useCompress);
+    const history = await this.getCache(entity.entity_id, this.config.useCompress);
     if (history && history.hours_to_show === this.config.hours_to_show) {
       stateHistory = history.data;
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import {
   interpolateColor,
   compress, decompress,
   getFirstDefinedItem,
+  compareArray,
 } from './utils';
 
 localForage.config({
@@ -51,6 +52,7 @@ class MiniGraphCard extends LitElement {
     this.id = Math.random()
       .toString(36)
       .substr(2, 9);
+    this.config = {};
     this.bound = [0, 0];
     this.boundSecondary = [0, 0];
     this.min = {};
@@ -194,7 +196,12 @@ class MiniGraphCard extends LitElement {
       }
     }
 
-    if (!this.Graph) {
+    const entitiesChanged = !compareArray(this.config.entities || [], conf.entities);
+
+    this.config = conf;
+
+    if (!this.Graph || entitiesChanged) {
+      if (this._hass) this.hass = this._hass;
       this.Graph = conf.entities.map(
         entity => new Graph(
           500,
@@ -212,8 +219,6 @@ class MiniGraphCard extends LitElement {
         ),
       );
     }
-
-    this.config = conf;
   }
 
   connectedCallback() {
@@ -876,7 +881,7 @@ class MiniGraphCard extends LitElement {
     let start = initStart;
     let skipInitialState = false;
 
-    const history = await this.getCache(entity.entity_id, this.config.useCompress);
+    const history = null; // await this.getCache(entity.entity_id, this.config.useCompress);
     if (history && history.hours_to_show === this.config.hours_to_show) {
       stateHistory = history.data;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,11 @@ const decompress = data => (typeof data === 'string' ? JSON.parse(lzStringDecomp
 
 const getFirstDefinedItem = (...collection) => collection.find(item => typeof item !== 'undefined');
 
+// eslint-disable-next-line max-len
+const compareArray = (a, b) => a.length === b.length && a.every((value, index) => value === b[index]);
+
 export {
   getMin, getAvg, getMax, getTime, getMilli, interpolateColor, compress, decompress,
   getFirstDefinedItem,
+  compareArray,
 };


### PR DESCRIPTION
Allow the config to be changed after the initial creation of the card.
This was mostly working already, except for when entities changed, but it also required another watched prop to be changed before it would re-render the card.

Fixes:  #184 