### PR TITLE
Avoid rendering of additional bars

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -98,7 +98,6 @@ export default class Graph {
     for (let i = 0; i < history.length; i += 1)
       getCoords(history[i], i);
 
-    if (coords.length === 1) coords[1] = [this.width + this.margin[X], 0, coords[0][V]];
     return coords;
   }
 
@@ -112,7 +111,11 @@ export default class Graph {
   }
 
   getPoints() {
-    const coords = this._calcY(this.coords);
+    let { coords } = this;
+    if (coords.length === 1) {
+      coords[1] = [this.width + this.margin[X], 0, coords[0][V]];
+    }
+    coords = this._calcY(this.coords);
     let next; let Z;
     let last = coords[0];
     coords.shift();
@@ -127,7 +130,11 @@ export default class Graph {
   }
 
   getPath() {
-    const coords = this._calcY(this.coords);
+    let { coords } = this;
+    if (coords.length === 1) {
+      coords[1] = [this.width + this.margin[X], 0, coords[0][V]];
+    }
+    coords = this._calcY(this.coords);
     let next; let Z;
     let path = '';
     let last = coords[0];


### PR DESCRIPTION
Avoid rendering additional bars when a graph only contains one bar / entity.

This was caused by the need of adding an additional entry to line charts containing only one data point.