### PR TITLE
Group by date missing data

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -52,10 +52,8 @@ export default class Graph {
     const age = this._endTime - new Date(item.last_changed).getTime();
     const interval = (age / ONE_HOUR * this.points) - this.hours * this.points;
     const key = Math.floor(Math.abs(interval));
-    if (interval < 0) {
-      if (!res[key]) res[key] = [];
-      res[key].push(item);
-    }
+    if (!res[key]) res[key] = [];
+    res[key].push(item);
     return res;
   }
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -50,12 +50,12 @@ export default class Graph {
       coords.splice(0, coords.length - requiredNumOfPoints);
     } else {
       // extend length to match the required number of points
-      coords.length = requiredNumOfPoints;
       if (this._groupBy === 'date') {
         while (coords.length < requiredNumOfPoints) {
           coords.unshift(undefined);
         }
       }
+      coords.length = requiredNumOfPoints;
     }
 
     this.coords = this._calcPoints(coords);

--- a/src/graph.js
+++ b/src/graph.js
@@ -11,11 +11,6 @@ export default class Graph {
       max: this._maximum,
       min: this._minimum,
     };
-    const groupByFuncMap = {
-      interval: this._getGroupByIntervalFunc(),
-      hour: this._getGroupByIntervalFunc(),
-      date: this._getGroupByDateFunc(),
-    };
 
     this.coords = [];
     this.width = width - margin[X] * 2;
@@ -26,7 +21,6 @@ export default class Graph {
     this.points = points;
     this.hours = hours;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
-    this._reducer = groupByFuncMap[groupBy] || this._getGroupByIntervalFunc;
     this._smoothing = smoothing;
     this._groupBy = groupBy;
     this._endTime = 0;
@@ -44,42 +38,25 @@ export default class Graph {
     this._updateEndTime();
 
     const coords = history.reduce((res, item) => this._reducer(res, item), []);
+
+    // extend length to fill missing history
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);
-    if (coords.length > requiredNumOfPoints) {
-      // if there is too much data we reduce it
-      coords.splice(0, coords.length - requiredNumOfPoints);
-    } else {
-      // extend length to match the required number of points
-      coords.length = requiredNumOfPoints;
-    }
+    coords.length = requiredNumOfPoints;
 
     this.coords = this._calcPoints(coords);
     this.min = Math.min(...this.coords.map(item => Number(item[V])));
     this.max = Math.max(...this.coords.map(item => Number(item[V])));
   }
 
-  _getGroupByIntervalFunc() {
-    return (res, item) => {
-      const age = this._endTime - new Date(item.last_changed).getTime();
-      const interval = (age / ONE_HOUR * this.points) - this.hours * this.points;
-      const key = Math.floor(Math.abs(interval));
+  _reducer(res, item) {
+    const age = this._endTime - new Date(item.last_changed).getTime();
+    const interval = (age / ONE_HOUR * this.points) - this.hours * this.points;
+    const key = Math.floor(Math.abs(interval));
+    if (interval < 0) {
       if (!res[key]) res[key] = [];
       res[key].push(item);
-      return res;
-    };
-  }
-
-  _getGroupByDateFunc() {
-    return (res, item) => {
-      const age = this._endTime - new Date(item.last_changed).getTime();
-      const interval = (age / (ONE_HOUR * 24) - this.hours / 24);
-      const key = Math.floor(Math.abs(interval));
-      if (interval < 0) {
-        if (!res[key]) res[key] = [];
-        res[key].push(item);
-      }
-      return res;
-    };
+    }
+    return res;
   }
 
   _calcPoints(history) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -51,6 +51,11 @@ export default class Graph {
     } else {
       // extend length to match the required number of points
       coords.length = requiredNumOfPoints;
+      if (this._groupBy === 'date') {
+        while (coords.length < requiredNumOfPoints) {
+          coords.unshift(undefined);
+        }
+      }
     }
 
     this.coords = this._calcPoints(coords);

--- a/src/main.js
+++ b/src/main.js
@@ -577,7 +577,6 @@ class MiniGraphCard extends LitElement {
       points_per_hour,
       hours_to_show,
       format,
-      group_by,
     } = this.config;
     const offset = hours_to_show < 1 && points_per_hour < 1
       ? points_per_hour * hours_to_show
@@ -585,20 +584,7 @@ class MiniGraphCard extends LitElement {
 
     const id = Math.abs(index + 1 - Math.ceil(hours_to_show * points_per_hour));
 
-    const now = new Date();
-
-    switch (group_by) {
-      case 'date':
-        now.setDate(now.getDate() + 1);
-        now.setHours(0, 0);
-        break;
-      case 'hour':
-        now.setHours(now.getHours() + 1);
-        now.setMinutes(0, 0);
-        break;
-      default:
-        break;
-    }
+    const now = this.getEndDate();
 
     const oneMinInHours = 1 / 60;
     now.setMilliseconds(now.getMilliseconds() - getMilli(offset * id + oneMinInHours));
@@ -802,7 +788,7 @@ class MiniGraphCard extends LitElement {
   async updateData({ config } = this) {
     this.updating = true;
 
-    const end = new Date();
+    const end = this.getEndDate();
     const start = new Date();
     start.setHours(end.getHours() - config.hours_to_show);
 
@@ -972,6 +958,23 @@ class MiniGraphCard extends LitElement {
     }
 
     res.state = resultIndex;
+  }
+
+  getEndDate() {
+    const date = new Date();
+    switch (this.config.group_by) {
+      case 'date':
+        date.setDate(date.getDate() + 1);
+        date.setHours(0, 0);
+        break;
+      case 'hour':
+        date.setHours(date.getHours() + 1);
+        date.setMinutes(0, 0);
+        break;
+      default:
+        break;
+    }
+    return date;
   }
 
   getCardSize() {


### PR DESCRIPTION
This will add missing array entries at the beginning instead of at the end when using `group_by: date`, it's  not a great solution though since it doesn't cover all cases. With this fix we basically anticipate; if length is incorrect we are missing data at the beginning.

So I think if we are missing data at the end or for a whole date when using `group_by: date` the graph will still render incorrectly

The `_getGroupByIntervalFunc()` works by inserting data at the correct index in the coords array, so for example if we have:

* hours_to_show: 6
* points_per_hour: 1

and we are missing data for hour 1,3 and 6, the output would be:

`[empty, data, empty, data, data]`

Therefore if the array is ever too small, we know we are missing data at the end (most recent) of the timeframe and we just increase the length of the array to fill the missing data with empty entries.

Length is less than expected (hours * points), expand length:

`[empty, data, empty, data, data, empty]`

Fixes: #183