### PR TITLE
Option to override default more-info entity #201

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See [dynamic line color](#dynamic-line-color) for example usage.
 | Name | Type | Default | Options | Description |
 |------|:----:|:-------:|:-----------:|-------------|
 | action | string | `more-info` | `more-info` / `navigate` / `call-service`  / `url` / `none` | Action to perform.
+| entity | string |  | Any entity id | Override default entity of `more-info`, when  `action` is defined as `more-info`.
 | service | string |  | Any service | Service to call (e.g. `media_player.toggle`) when `action` is defined as `call-service`.
 | service_data | object |  | Any service data | Service data to include with the service call (e.g. `entity_id: media_player.office`).
 | navigation_path | string |  | Any path | Path to navigate to (e.g. `/lovelace/0/`) when `action` is defined as `navigate`.

--- a/src/main.js
+++ b/src/main.js
@@ -275,7 +275,7 @@ class MiniGraphCard extends LitElement {
         ?gradient=${config.color_thresholds.length > 0}
         ?hover=${config.tap_action.action !== 'none'}
         style="font-size: ${config.font_size}px;"
-        @click=${e => this.handlePopup(e, this.entity[0])}
+        @click=${e => this.handlePopup(e, config.tap_action.entity || this.entity[0])}
       >
         ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()} ${this.renderInfo()}
       </ha-card>
@@ -653,7 +653,7 @@ class MiniGraphCard extends LitElement {
 
   handlePopup(e, entity) {
     e.stopPropagation();
-    handleClick(this, this._hass, this.config, this.config.tap_action, entity.entity_id);
+    handleClick(this, this._hass, this.config, this.config.tap_action, entity.entity_id || entity);
   }
 
   computeThresholds(stops, type) {


### PR DESCRIPTION
Adds an option to the `tap_action` object to override the default entity of the more-info popup

```yaml
tap_action:
  action: more-info
  entity: sensor.example
```

Closes #201