### PR TITLE
Keep graphs in sync #194 #200

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -12,6 +12,7 @@ export default class Graph {
       min: this._minimum,
     };
 
+    this._history = undefined;
     this.coords = [];
     this.width = width - margin[X] * 2;
     this.height = height - margin[Y] * 4;
@@ -34,10 +35,16 @@ export default class Graph {
 
   set min(min) { this._min = min; }
 
-  update(history) {
+  set history(data) { this._history = data; }
+
+  update(history = undefined) {
+    if (history) {
+      this._history = history;
+    }
+    if (!this._history) return;
     this._updateEndTime();
 
-    const coords = history.reduce((res, item) => this._reducer(res, item), []);
+    const coords = this._history.reduce((res, item) => this._reducer(res, item), []);
 
     // extend length to fill missing history
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);

--- a/src/main.js
+++ b/src/main.js
@@ -808,23 +808,13 @@ class MiniGraphCard extends LitElement {
 
     this.updateQueue = [];
 
-    this.bound = [
-      config.lower_bound !== undefined
-        ? config.lower_bound
-        : Math.min(...this.primaryYaxisSeries.map(ele => ele.min)) || this.bound[0],
-      config.upper_bound !== undefined
-        ? config.upper_bound
-        : Math.max(...this.primaryYaxisSeries.map(ele => ele.max)) || this.bound[1],
-    ];
+    if (config.show.graph) {
+      this.entity.forEach((entity, i) => {
+        if (entity) this.Graph[i].update();
+      });
+    }
 
-    this.boundSecondary = [
-      config.lower_bound_secondary !== undefined
-        ? config.lower_bound_secondary
-        : Math.min(...this.secondaryYaxisSeries.map(ele => ele.min)) || this.boundSecondary[0],
-      config.upper_bound_secondary !== undefined
-        ? config.upper_bound_secondary
-        : Math.max(...this.secondaryYaxisSeries.map(ele => ele.max)) || this.boundSecondary[1],
-    ];
+    this.updateBounds();
 
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
@@ -847,6 +837,26 @@ class MiniGraphCard extends LitElement {
       });
       this.line = [...this.line];
     }
+  }
+
+  updateBounds({ config } = this) {
+    this.bound = [
+      config.lower_bound !== undefined
+        ? config.lower_bound
+        : Math.min(...this.primaryYaxisSeries.map(ele => ele.min)) || this.bound[0],
+      config.upper_bound !== undefined
+        ? config.upper_bound
+        : Math.max(...this.primaryYaxisSeries.map(ele => ele.max)) || this.bound[1],
+    ];
+
+    this.boundSecondary = [
+      config.lower_bound_secondary !== undefined
+        ? config.lower_bound_secondary
+        : Math.min(...this.secondaryYaxisSeries.map(ele => ele.min)) || this.boundSecondary[0],
+      config.upper_bound_secondary !== undefined
+        ? config.upper_bound_secondary
+        : Math.max(...this.secondaryYaxisSeries.map(ele => ele.max)) || this.boundSecondary[1],
+    ];
   }
 
   async getCache(key, compressed) {
@@ -946,9 +956,9 @@ class MiniGraphCard extends LitElement {
 
     if (this.config.entities[index].fixed_value === true) {
       const last = stateHistory[stateHistory.length - 1];
-      this.Graph[index].update([last, last]);
+      this.Graph[index].history = [last, last];
     } else {
-      this.Graph[index].update(stateHistory);
+      this.Graph[index].history = stateHistory;
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import {
   UPDATE_PROPS,
   DEFAULT_SHOW,
   X, Y, V,
+  ONE_HOUR,
 } from './const';
 import {
   getMin,
@@ -803,10 +804,9 @@ class MiniGraphCard extends LitElement {
       const promise = this.entity.map((entity, i) => this.updateEntity(entity, i, start, end));
       await Promise.all(promise);
     } finally {
-      this.updating = false;
+      this.updateQueue = [];
     }
 
-    this.updateQueue = [];
 
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
@@ -837,6 +837,8 @@ class MiniGraphCard extends LitElement {
       });
       this.line = [...this.line];
     }
+    this.updating = false;
+    this.setNextUpdate();
   }
 
   updateBounds({ config } = this) {
@@ -996,6 +998,16 @@ class MiniGraphCard extends LitElement {
         break;
     }
     return date;
+  }
+
+  setNextUpdate() {
+    if (!this.config.update_interval) {
+      const interval = 1 / this.config.points_per_hour;
+      clearInterval(this.interval);
+      this.interval = setInterval(() => {
+        if (!this.updating) this.updateData();
+      }, interval * ONE_HOUR);
+    }
   }
 
   getCardSize() {


### PR DESCRIPTION
This should hopefully resolve graphs getting out of sync as reported in #194 & #200. 

Should probably also add an interval at which the graphs are force refreshed, even if there's no new history data from HA.

Fixes: #194 #200