### PR TITLE
New aggregate functions: first & last #229

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This card is available in [HACS](https://github.com/custom-components/hacs/issue
 | group | boolean | `false` | v0.2.0 | Disable paddings and box-shadow, useful when nesting the card.
 | hours_to_show | integer | `24` | v0.0.2 | Specify how many hours of history the graph should present.
 | points_per_hour | number | `0.5` | v0.2.0 | Specify amount of data points the graph should display for each hour, *(basically the detail/accuracy/smoothing of the graph)*.
-| aggregate_func | string | `avg` | v0.8.0 | Specify aggregate function used to calculate point/bar in the graph, `avg`, `min`, `max`.
+| aggregate_func | string | `avg` | v0.8.0 | Specify aggregate function used to calculate point/bar in the graph, `avg`, `min`, `max`, `first`, `last`.
 | group_by | string | `interval` | v0.8.0 | Specify type of grouping of data, dynamic `interval`, `date` or `hour`.
 | update_interval | number |  | v0.4.0 | Specify a custom update interval of the history data (in seconds), instead of on every state change.
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.

--- a/src/graph.js
+++ b/src/graph.js
@@ -10,6 +10,8 @@ export default class Graph {
       avg: this._average,
       max: this._maximum,
       min: this._minimum,
+      first: this._first,
+      last: this._last,
     };
 
     this._history = undefined;
@@ -70,11 +72,11 @@ export default class Graph {
     xRatio = Number.isFinite(xRatio) ? xRatio : this.width;
 
     const first = history.filter(Boolean)[0];
-    let last = [this._calcPoint(first), this._last(first)];
+    let last = [this._calcPoint(first), this._lastValue(first)];
     const getCoords = (item, i) => {
       const x = xRatio * i + this.margin[X];
       if (item)
-        last = [this._calcPoint(item), this._last(item)];
+        last = [this._calcPoint(item), this._lastValue(item)];
       return coords.push([x, 0, item ? last[0] : last[1]]);
     };
 
@@ -192,7 +194,15 @@ export default class Graph {
     return Math.min(...items.map(item => item.state));
   }
 
+  _first(items) {
+    return parseFloat(items[0].state);
+  }
+
   _last(items) {
+    return parseFloat(items[items.length - 1].state);
+  }
+
+  _lastValue(items) {
     return parseFloat(items[items.length - 1].state) || 0;
   }
 


### PR DESCRIPTION
Adds two new aggregate functions: `first` & `last`.

* first will take the first history entry from within the data points timeframe to render the data point
* last will take the last history entry from within the data points timeframe to render the data point

Closes #229