### PR TITLE
Force re-render on changes to the extrema (#248)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ class MiniGraphCard extends LitElement {
     this.entity = [];
     this.line = [];
     this.bar = [];
+    this.abs = [];
     this.fill = [];
     this.points = [];
     this.gradient = [];
@@ -629,7 +630,6 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
-    if (!this.abs.length) return;
     return html`
       <div class="info flex">
         ${this.abs.map(entry => html`

--- a/src/main.js
+++ b/src/main.js
@@ -56,9 +56,6 @@ class MiniGraphCard extends LitElement {
     this.config = {};
     this.bound = [0, 0];
     this.boundSecondary = [0, 0];
-    this.min = {};
-    this.avg = {};
-    this.max = {};
     this.length = [];
     this.entity = [];
     this.line = [];
@@ -632,14 +629,10 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
-    const info = [];
-    if (this.config.show.extrema) info.push(this.min);
-    if (this.config.show.average) info.push(this.avg);
-    if (this.config.show.extrema) info.push(this.max);
-    if (!info.length) return;
+    if (!this.abs.length) return;
     return html`
       <div class="info flex">
-        ${info.map(entry => html`
+        ${this.abs.map(entry => html`
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
@@ -946,18 +939,21 @@ class MiniGraphCard extends LitElement {
     if (stateHistory.length === 0) return;
 
     if (entity.entity_id === this.entity[0].entity_id) {
-      this.min = {
-        type: 'min',
-        ...getMin(stateHistory, 'state'),
-      };
-      this.avg = {
-        type: 'avg',
-        state: getAvg(stateHistory, 'state'),
-      };
-      this.max = {
-        type: 'max',
-        ...getMax(stateHistory, 'state'),
-      };
+      const { extrema, average } = this.config.show;
+      this.abs = [
+        ...(extrema ? [{
+          type: 'min',
+          ...getMin(stateHistory, 'state'),
+        }] : []),
+        ...(average ? [{
+          type: 'avg',
+          state: getAvg(stateHistory, 'state'),
+        }] : []),
+        ...(extrema ? [{
+          type: 'max',
+          ...getMax(stateHistory, 'state'),
+        }] : []),
+      ];
     }
 
     if (this.config.entities[index].fixed_value === true) {

--- a/src/style.js
+++ b/src/style.js
@@ -367,13 +367,13 @@ const style = css`
     flex-flow: column;
     text-align: center;
   }
-  .info__item:first-child {
-    align-items: flex-start;
-    text-align: left;
-  }
   .info__item:last-child {
     align-items: flex-end;
     text-align: right;
+  }
+  .info__item:first-child {
+    align-items: flex-start;
+    text-align: left;
   }
   .info__item__type {
     text-transform: capitalize;


### PR DESCRIPTION
Fixes card not re-rendering when changes to the extrema is made, particularly noticeable when hiding the graph completely resulting in no reactive/watched props updating in a long time.

Fixes #248