### PR TITLE
Add small delay before fetching history data of updated entities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,6 +70,7 @@ class MiniGraphCard extends LitElement {
     this.updateQueue = [];
     this.updating = false;
     this.stateChanged = false;
+    this.initial = true;
   }
 
   static get styles() {
@@ -79,21 +80,26 @@ class MiniGraphCard extends LitElement {
   set hass(hass) {
     this._hass = hass;
     let updated = false;
+    const queue = [];
     this.config.entities.forEach((entity, index) => {
       this.config.entities[index].index = index; // Required for filtered views
       const entityState = hass.states[entity.entity];
       if (entityState && this.entity[index] !== entityState) {
         this.entity[index] = entityState;
-        this.updateQueue.push(entityState.entity_id);
+        queue.push(entityState.entity_id);
         updated = true;
       }
     });
     if (updated) {
+      this.stateChanged = true;
       this.entity = [...this.entity];
       if (!this.config.update_interval && !this.updating) {
-        this.updateData();
+        setTimeout(() => {
+          this.updateQueue = queue;
+          this.updateData();
+        }, this.initial ? 0 : 1000);
       } else {
-        this.stateChanged = true;
+        this.updateQueue = queue;
       }
     }
   }
@@ -251,6 +257,10 @@ class MiniGraphCard extends LitElement {
       );
       return true;
     }
+  }
+
+  firstUpdated() {
+    this.initial = false;
   }
 
   updated(changedProperties) {

--- a/src/main.js
+++ b/src/main.js
@@ -95,11 +95,11 @@ class MiniGraphCard extends LitElement {
       this.entity = [...this.entity];
       if (!this.config.update_interval && !this.updating) {
         setTimeout(() => {
-          this.updateQueue = queue;
+          this.updateQueue = [...queue, ...this.updateQueue];
           this.updateData();
         }, this.initial ? 0 : 1000);
       } else {
-        this.updateQueue = queue;
+        this.updateQueue = [...queue, ...this.updateQueue];
       }
     }
   }
@@ -814,8 +814,9 @@ class MiniGraphCard extends LitElement {
     try {
       const promise = this.entity.map((entity, i) => this.updateEntity(entity, i, start, end));
       await Promise.all(promise);
-    } finally {
-      this.updateQueue = [];
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('mini-graph-card: ', err);
     }
 
 
@@ -891,6 +892,8 @@ class MiniGraphCard extends LitElement {
       || !this.updateQueue.includes(entity.entity_id)
       || this.config.entities[index].show_graph === false
     ) return;
+    this.updateQueue = this.updateQueue.filter(entry => entry !== entity.entity_id);
+
     let stateHistory = [];
     let start = initStart;
     let skipInitialState = false;


### PR DESCRIPTION
From my experience and testing there seem to be a small period before history data is available after an entity is updated. This results in us missing the latest history entry and we'll not receive this data until next time the entity updates or the page is refreshed.

I've added a small static one second delay before fetching history after a state change, except on the initial fetch where there's no delay added.

One second seem sufficient from my testing but I guess it could differ depending on setup.

Also improvements to the updateQueue to make sure we don't miss entries or update entries more than once (could happen with rapid entity updates).