### PR TITLE
Handle out of bound history entries + fix last known entry

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -60,7 +60,7 @@ export default class Graph {
   _reducer(res, item) {
     const age = this._endTime - new Date(item.last_changed).getTime();
     const interval = (age / ONE_HOUR * this.points) - this.hours * this.points;
-    const key = Math.floor(Math.abs(interval));
+    const key = interval < 0 ? Math.floor(Math.abs(interval)) : 0;
     if (!res[key]) res[key] = [];
     res[key].push(item);
     return res;

--- a/src/graph.js
+++ b/src/graph.js
@@ -48,6 +48,9 @@ export default class Graph {
 
     const coords = this._history.reduce((res, item) => this._reducer(res, item), []);
 
+    // drop potential out of bound entry's except one
+    if (coords[0] && coords[0].length) coords[0] = [coords[0][coords[0].length - 1]];
+
     // extend length to fill missing history
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);
     coords.length = requiredNumOfPoints;


### PR DESCRIPTION
Entries that were out of bound by more than x amount of time would be pushed into the timeline again because of the use of Math.abs() when calculating the position in the timeline.

This change will make sure these entries are handled as out of bound.
This will also make sure we calculate the "last known entry" based on the actual "most recent last known entry" and not by a calculation on the aggregation of all out of bound entries.