### PR TITLE
Set correct graph date after 12am

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -799,7 +799,7 @@ class MiniGraphCard extends LitElement {
 
     const end = this.getEndDate();
     const start = new Date(end);
-    start.setHours(start.getHours() - config.hours_to_show);
+    start.setMilliseconds(start.getMilliseconds() - getMilli(config.hours_to_show));
 
     try {
       const promise = this.entity.map((entity, i) => this.updateEntity(entity, i, start, end));


### PR DESCRIPTION
Fixes some weird issue when calculating graph start date after 12am when `hours_to_show` is set lower than `1`. It's possible that this can occur in other situations as well.

This prevented fetching of new data, since the start date would be the same as end date.