### PR TITLE
0.106.x compatible

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -54,7 +54,7 @@ export default (config) => {
     tap_action: {
       action: 'more-info',
     },
-    ...config,
+    ...JSON.parse(JSON.stringify(config)),
     show: { ...DEFAULT_SHOW, ...config.show },
   };
 


### PR DESCRIPTION
Deep copy config locally to make card compatible with changes coming in HA 0.106.x.
https://developers.home-assistant.io/blog/2020/02/18/106-custom-card-changes.html

Fixes #274