### PR TITLE
update Readme with correct default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This card is available in [HACS](https://github.com/custom-components/hacs/issue
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
-| height | number | `150` | v0.0.1 | Set a custom height of the line graph.
+| height | number | `100` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.


### PR DESCRIPTION
According to buildConfig.js default value for height in Card options is 100 (not 150 as currently stated in Readme).