### PR TITLE
Reduce white space when extrema isn't enabled #320

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -534,7 +534,7 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
-    return html`
+    return this.abs.length > 0 ? html`
       <div class="info flex">
         ${this.abs.map(entry => html`
           <div class="info__item">
@@ -548,7 +548,7 @@ class MiniGraphCard extends LitElement {
           </div>
         `)}
       </div>
-    `;
+    ` : html``;
   }
 
   handlePopup(e, entity) {


### PR DESCRIPTION
This will hide the info container if no extrema options are used.
The info container did always take up 16px vertical space even when it was empty.

Closes #320 