### PR TITLE
Fixed incorrect value for the first point

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -218,7 +218,7 @@ export default class Graph {
     switch (this._groupBy) {
       case 'date':
         this._endTime.setDate(this._endTime.getDate() + 1);
-        this._endTime.setHours(0, 0);
+        this._endTime.setHours(0, 0, 0, 0);
         break;
       case 'hour':
         this._endTime.setHours(this._endTime.getHours() + 1);


### PR DESCRIPTION
Hello again @kalkih,

I have noticed one issue. You were not resetting seconds and milliseconds when the endTime was set. This was resulting in slightly wrong value buckets. 

This wouldn't be a big deal alone but you have this condition:
`if (coords[0] && coords[0].length) coords[0] = [coords[0][coords[0].length - 1]];`

For me it looks little bit hacky way of solving some specific scenario. :) IMO we should think about changing this as it works for me only because I care about max value which is always at the end of the bucket. If someone would like to take min or avg this won't work.

Example case which was failing for me:
![image](https://user-images.githubusercontent.com/8268674/78943069-f0be6b80-7ab2-11ea-9206-f46817aab7c6.png)

And the result:
![image](https://user-images.githubusercontent.com/8268674/78943104-016ee180-7ab3-11ea-9f47-b81c585841f9.png)

Take care buddy. I'm impressed how committed you are for these mini-* cards (I see update after update hehe). I use both of them! Thanks for your hard work!

Max