### PR TITLE
Added clarification as to what "HACS" is

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The card works with entities from within the **sensor** domain and displays the 
 
 ### HACS
 
-This card is available in [HACS](https://github.com/custom-components/hacs/issues) (Home Assistant Community Store).
+This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community Store).  
+HACS is a 3rd party Community Store, NOT the one you can already find under "Supervisor" in Home Assistant! You can find more info about it with the link above.
 
 ### Manual install
 


### PR DESCRIPTION
I did not know what HACS is and at first thought it's the Official Home Assistant Community store. Since the HACS link only pointed to the "Issues" page and didn't describe what HACS is at all I thought it'd only be fair to describe it a little further for people (like me) that just stumbled across this for their first time :)