### PR TITLE
[WIP] Adding aspect ratio support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@kalkih/lz-string": "^1.4.5",
     "lit-element": "^2.2.1",
-    "lit-html": "^1.2.1",
     "localforage": "^1.7.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@kalkih/lz-string": "^1.4.5",
     "lit-element": "^2.2.1",
+    "lit-html": "^1.2.1",
     "localforage": "^1.7.3"
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,4 @@
 import { LitElement, html, svg } from 'lit-element';
-import { styleMap } from 'lit-html/directives/style-map';
 import localForage from 'localforage/src/localforage';
 import Graph from './graph';
 import style from './style';
@@ -170,17 +169,14 @@ class MiniGraphCard extends LitElement {
   }
 
   render({ config } = this) {
-    const aspectRatio = {};
-    if (config.aspect_ratio) {
-      aspectRatio['--aspect-ratio'] = config.aspect_ratio;
-    } else {
-      aspectRatio.display = 'inline';
-    }
+    const aspectRatio = config.aspect_ratio
+      ? `--aspect-ratio: ${config.aspect_ratio}`
+      : 'display: inline;';
 
     return html`
       <div 
         id="aspect-ratio"
-        style="${styleMap(aspectRatio)}">
+        style="${aspectRatio}">
         <ha-card
           class="flex"
           ?group=${config.group}

--- a/src/main.js
+++ b/src/main.js
@@ -174,9 +174,7 @@ class MiniGraphCard extends LitElement {
       : 'display: inline;';
 
     return html`
-      <div 
-        id="aspect-ratio"
-        style="${aspectRatio}">
+      <div style="${aspectRatio}">
         <ha-card
           class="flex"
           ?group=${config.group}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { LitElement, html, svg } from 'lit-element';
+import { styleMap } from 'lit-html/directives/style-map';
 import localForage from 'localforage/src/localforage';
 import Graph from './graph';
 import style from './style';
@@ -169,21 +170,32 @@ class MiniGraphCard extends LitElement {
   }
 
   render({ config } = this) {
+    const aspectRatio = {};
+    if (config.aspect_ratio) {
+      aspectRatio['--aspect-ratio'] = config.aspect_ratio;
+    } else {
+      aspectRatio.display = 'inline';
+    }
+
     return html`
-      <ha-card
-        class="flex"
-        ?group=${config.group}
-        ?fill=${config.show.graph && config.show.fill}
-        ?points=${config.show.points === 'hover'}
-        ?labels=${config.show.labels === 'hover'}
-        ?labels-secondary=${config.show.labels_secondary === 'hover'}
-        ?gradient=${config.color_thresholds.length > 0}
-        ?hover=${config.tap_action.action !== 'none'}
-        style="font-size: ${config.font_size}px;"
-        @click=${e => this.handlePopup(e, config.tap_action.entity || this.entity[0])}
-      >
-        ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()} ${this.renderInfo()}
-      </ha-card>
+      <div 
+        id="aspect-ratio"
+        style="${styleMap(aspectRatio)}">
+        <ha-card
+          class="flex"
+          ?group=${config.group}
+          ?fill=${config.show.graph && config.show.fill}
+          ?points=${config.show.points === 'hover'}
+          ?labels=${config.show.labels === 'hover'}
+          ?labels-secondary=${config.show.labels_secondary === 'hover'}
+          ?gradient=${config.color_thresholds.length > 0}
+          ?hover=${config.tap_action.action !== 'none'}
+          style="font-size: ${config.font_size}px;"
+          @click=${e => this.handlePopup(e, config.tap_action.entity || this.entity[0])}
+        >
+          ${this.renderHeader()} ${this.renderStates()} ${this.renderGraph()} ${this.renderInfo()}
+        </ha-card>
+      </div>
     `;
   }
 

--- a/src/style.js
+++ b/src/style.js
@@ -8,9 +8,12 @@ const style = css`
   ha-card {
     flex-direction: column;
     flex: 1;
-    padding: 16px 0;
+    padding: 0;
     position: relative;
     overflow: hidden;
+  }
+  ha-card > div:first-child {
+    padding: 16px;
   }
   ha-card > div {
     padding: 0px 16px 16px 16px;
@@ -66,6 +69,28 @@ const style = css`
   }
   ha-card[hover] {
     cursor: pointer;
+  }
+  [style*='--aspect-ratio'] > :first-child {
+    width: 100%;
+  }
+  [style*='--aspect-ratio'] > img {
+    height: auto;
+  }
+  @supports (--custom: property) {
+    [style*='--aspect-ratio'] {
+      position: relative;
+    }
+    [style*='--aspect-ratio']::before {
+      content: '';
+      display: block;
+      padding-bottom: calc(100% / (var(--aspect-ratio)));
+    }
+    [style*='--aspect-ratio'] > :first-child {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+    }
   }
   .flex {
     display: flex;


### PR DESCRIPTION
Opening up a WIP to open discussion about adding support for an aspect_ratio config, which will allow the user to force the card to render in a specified "aspect ratio".  From personal experience and from browsing the community forums, I know this is a desired feature by some because it allows users to achieve a conformed look when using the mini-graph card in a horizontal stack with other cards (especially those that already support aspect ratios, such as custom button-card).

This is a basic implementation that sizes the card according to the aspect_ratio config (in the format of 1/1, 1/2, 2/1, etc).  It works similarly to how the aspect_ratio works in the custom button-card.  Excluding the aspect_ratio config will give back the cards ability to dynamically size itself.  The caveat is that it does not, in it's current state, account for the overflow of elements within the card (e.g, enabling extrema, icon, and state when your card is sufficiently small because it's in a horizontal stack with 3 other cards will cause some information to be hidden).  