### PR TITLE
Added value_factor support, to scale value shown in state label

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ HACS is a 3rd party Community Store, NOT the one you can already find under "Sup
 | upper_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed upper bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
+| value_factor | number | 0 | vX.X.X | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down. 
 
 #### Entities object
 Entities may be listed directly (as per `sensor.temperature` in the example below), or defined using

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -51,6 +51,7 @@ export default (config) => {
     smoothing: true,
     state_map: [],
     cache: true,
+    value_factor: 0,
     tap_action: {
       action: 'more-info',
     },

--- a/src/main.js
+++ b/src/main.js
@@ -662,11 +662,13 @@ class MiniGraphCard extends LitElement {
       state = Number(inState);
     }
     const dec = this.config.decimals;
+    const value_factor = 10 ** this.config.value_factor;
+
     if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state))
-      return Math.round(state * 100) / 100;
+      return Math.round(state * value_factor * 100) / 100;
 
     const x = 10 ** dec;
-    return (Math.round(state * x) / x).toFixed(dec);
+    return (Math.round(state * value_factor * x) / x).toFixed(dec);
   }
 
   updateOnInterval() {


### PR DESCRIPTION
Hey,
My router reports everything in bytes, which is not very handy for daily use, therefore I added ability to scale value to other unit. If you like it, fell free to merge it.

![obraz](https://user-images.githubusercontent.com/9393341/82839970-5d5dc000-9ed1-11ea-91ba-a41f9557c240.png)
Default settings

![obraz](https://user-images.githubusercontent.com/9393341/82839879-1b347e80-9ed1-11ea-9420-297d5abbae23.png)

Value factor applied
```
value_factor: -9
decimals: 2
unit: GB
```