### PR TITLE
Correctly reset the time part of _endTime

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -218,7 +218,7 @@ export default class Graph {
     switch (this._groupBy) {
       case 'date':
         this._endTime.setDate(this._endTime.getDate() + 1);
-        this._endTime.setHours(0, 0);
+        this._endTime.setHours(0, 0, 0, 0);
         break;
       case 'hour':
         this._endTime.setHours(this._endTime.getHours() + 1);


### PR DESCRIPTION
When using group_by date, the endtime was set to tomorrow at 0 hours, 0 minutes, x seconds and y ms where x and y are the values from the current time.
It should be reset to 0 hours, 0 minutes, 0 seconds and 0 ms. Because all sensor state changes that happened between midnight and 0H0MxSyMS will be considered in the previous day instead.
This caused an issue where all previous days where 0 because I reset the sensor's underlying input_number to 0 at midnight and use "last" as an aggregate_func