### PR TITLE
Utilize new minimal history API option #373

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -852,6 +852,7 @@ class MiniGraphCard extends LitElement {
     url += `?filter_entity_id=${entityId}`;
     if (end) url += `&end_time=${end.toISOString()}`;
     if (skipInitialState) url += '&skip_initial_state';
+    url += '&minimal_response';
     return this._hass.callApi('GET', url);
   }
 


### PR DESCRIPTION
Utilize new Home Assistant `minimal_response` option when making requests to the history API, makes fetching history faster & much lighter. ⚡ 

Closes #373
