### PR TITLE
adding since (release version) to value_factor card option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 | upper_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed upper bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
-| value_factor | number | 0 | vX.X.X | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down. 
+| value_factor | number | 0 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
 
 #### Entities object
 Entities may be listed directly (as per `sensor.temperature` in the example below), or defined using


### PR DESCRIPTION
it looks like when releasing the `value_factor` feature in 0.9.4 (pull request https://github.com/kalkih/mini-graph-card/pull/362), the README file was not updated to include the `since` release version. here is a tiny change to correct that oversight.


here are the release notes for v0.9.4:

 => https://github.com/kalkih/mini-graph-card/releases/tag/v0.9.4