### PR TITLE
Allow a minimum range for Y-axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The card works with entities from within the **sensor** & **binary_sensor** doma
 
 ### HACS (recommended)
 
-This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community Store).  
+This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community Store).
 <small>*HACS is a third party community store and is not included in Home Assistant out of the box.*</small>
 
 ### Manual install
@@ -96,8 +96,10 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 | align_state | string | `left` | v0.2.0 | Set the alignment of the current state, `left`, `right` or `center`.
 | lower_bound | number *or* string |  | v0.2.3 | Set a fixed lower bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | upper_bound | number *or* string |  | v0.2.3 | Set a fixed upper bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
+| min_bound_range | number |  | v0.x.x | Applied after everything, makes sure there's a minimum range that the Y-axis will have. Useful for not making small changes look large because of scale.
 | lower_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed lower bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | upper_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed upper bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
+| min_bound_range_secondary | number |  | v0.x.x | Applied after everything, makes sure there's a minimum range that the secondary Y-axis will have. Useful for not making small changes look large because of scale.
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
 | value_factor | number | 0 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.

--- a/src/main.js
+++ b/src/main.js
@@ -730,6 +730,10 @@ class MiniGraphCard extends LitElement {
   }
 
   getBoundary(type, configVal, series, defaultVal) {
+    if (!(type in Math)) {
+      throw 'The type "' + type + '" is not present on the Math object';
+    }
+
     if (configVal === undefined) {
       // dynamic boundary depending on values
       return Math[type](...series.map(ele => ele[type])) || defaultVal;
@@ -747,10 +751,39 @@ class MiniGraphCard extends LitElement {
       this.getBoundary('min', config.lower_bound, this.primaryYaxisSeries, this.bound[0]),
       this.getBoundary('max', config.upper_bound, this.primaryYaxisSeries, this.bound[1]),
     ];
+
+    if (config.min_bound_range) {
+      const minBoundRange = parseFloat(config.min_bound_range);
+      const currentRange = Math.abs(this.bound[0] - this.bound[1]);
+      const diff = minBoundRange - currentRange;
+
+      // Doesn't matter if minBoundRange is NaN because this will be false if so
+      if (diff > 0) {
+        this.bound = [
+          this.bound[0] - diff/2,
+          this.bound[1] + diff/2,
+        ];
+      }
+    }
+
     this.boundSecondary = [
       this.getBoundary('min', config.lower_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[0]),
       this.getBoundary('max', config.upper_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[1]),
     ];
+
+    if (config.min_bound_range_secondary) {
+      const minBoundRange = parseFloat(config.min_bound_range_secondary);
+      const currentRange = Math.abs(this.boundSecondary[0] - this.boundSecondary[1]);
+      const diff = minBoundRange - currentRange;
+
+      // Doesn't matter if minBoundRange is NaN because this will be false if so
+      if (diff > 0) {
+        this.boundSecondary = [
+          this.boundSecondary[0] - diff/2,
+          this.boundSecondary[1] + diff/2,
+        ];
+      }
+    }
   }
 
   async getCache(key, compressed) {

--- a/src/main.js
+++ b/src/main.js
@@ -729,7 +729,7 @@ class MiniGraphCard extends LitElement {
     this.setNextUpdate();
   }
 
-  getBoudary(type, configVal, series, defaultVal) {
+  getBoundary(type, configVal, series, defaultVal) {
     if (configVal === undefined) {
       // dynamic boundary depending on values
       return Math[type](...series.map(ele => ele[type])) || defaultVal;
@@ -744,12 +744,12 @@ class MiniGraphCard extends LitElement {
 
   updateBounds({ config } = this) {
     this.bound = [
-      this.getBoudary('min', config.lower_bound, this.primaryYaxisSeries, this.bound[0]),
-      this.getBoudary('max', config.upper_bound, this.primaryYaxisSeries, this.bound[1]),
+      this.getBoundary('min', config.lower_bound, this.primaryYaxisSeries, this.bound[0]),
+      this.getBoundary('max', config.upper_bound, this.primaryYaxisSeries, this.bound[1]),
     ];
     this.boundSecondary = [
-      this.getBoudary('min', config.lower_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[0]),
-      this.getBoudary('max', config.upper_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[1]),
+      this.getBoundary('min', config.lower_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[0]),
+      this.getBoundary('max', config.upper_bound_secondary, this.secondaryYaxisSeries, this.boundSecondary[1]),
     ];
   }
 


### PR DESCRIPTION
This allows the setting of a minimum range for either Y-axis. This is for situations where there may be a small variance in the time frame displayed yielding a graph that looks like there's dramatic change.

As currently setup if below the bound it centers the graph, I could see it being better to add the entirety of the difference to the top so that it's bound to the bottom.

Thanks for the great card!