### PR TITLE
fix: Make sure that the graph is showed on initial load when 'update_interval' is configured

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,7 +125,9 @@ class MiniGraphCard extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     if (this.config.update_interval) {
-      this.updateOnInterval();
+      window.requestAnimationFrame(() => {
+        this.updateOnInterval();
+      });
       this.interval = setInterval(
         () => this.updateOnInterval(),
         this.config.update_interval * 1000,


### PR DESCRIPTION
When using the `update_interval` setting, the graph will not show on initial load, only after the first interval has passed. So when setting it to `30`, it takes 30 seconds before someone will see the graph. (It will also load instantly when a user will switch lovelace views after the initial loading)

After some investigation, I was able to figure out that it is caused because `this.updateOnInterval();` is called too early on initial load. 

This PR will fix it by adding a tiny delay to the first `this.updateOnInterval();`. It could also be done by a timeout, but that seemed a little too random to me. There might be a better solution to solve this bug, but this was the best I could come up with.

This bug is quite annoying when working with a lot of datapoints in a graph that does not need to be updated every second (e.g. utility meter data). So I really hope you will consider merging/fixing this.