### PR TITLE
Support user specifying update and render start date/hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "license": "MIT",
   "dependencies": {
     "@kalkih/lz-string": "^1.4.5",
-    "lit-element": "^2.2.1",
-    "localforage": "^1.7.3"
+    "cjs": "0.0.11",
+    "lit-element": "^2.4.0",
+    "localforage": "^1.9.0",
+    "lz-string": "^1.4.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.4",
@@ -33,11 +35,12 @@
     "@babel/plugin-transform-template-literals": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "@rollup/plugin-json": "^4.1.0",
+    "babel-cli": "^6.26.0",
     "babel-plugin-iife-wrap": "^1.1.0",
     "babel-preset-minify": "^0.5.0",
-    "eslint": "^5.3.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.17.2",
+    "eslint": "^5.16.0",
+    "eslint-config-airbnb-base": "^13.2.0",
+    "eslint-plugin-import": "^2.22.1",
     "rollup": "^0.66.6",
     "rollup-plugin-node-resolve": "^3.4.0"
   },

--- a/src/graph.js
+++ b/src/graph.js
@@ -5,7 +5,7 @@ import {
 } from './const';
 
 export default class Graph {
-  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
+  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false, start_days_ago = null, start_on_hour = null, hours_to_show = 24) {
     const aggregateFuncMap = {
       avg: this._average,
       max: this._maximum,
@@ -31,6 +31,9 @@ export default class Graph {
     this._logarithmic = logarithmic;
     this._groupBy = groupBy;
     this._endTime = 0;
+    this.start_days_ago = start_days_ago;
+    this.start_on_hour = start_on_hour;
+    this.hours_to_show = hours_to_show;
   }
 
   get max() { return this._max; }
@@ -250,6 +253,12 @@ export default class Graph {
         break;
       default:
         break;
+    }
+    if (this.start_days_ago && this.start_on_hour && this.start_days_ago !== '' && this.start_on_hour !== '' && this.start_days_ago <= 0) {
+      if (this.start_on_hour < 0 || this.start_on_hour > 23) this.start_on_hour = 0;
+      this._endTime = new Date();
+      this._endTime.setDate(this._endTime.getDate() + this.start_days_ago);
+      this._endTime.setHours(this.start_on_hour + this.hours_to_show, 0, 0, 0);
     }
   }
 }


### PR DESCRIPTION
This is a working set of changes to support the user choosing the range of data to display in the graph. This differs from the current latest release, which only allows the user to specify a start date that is a configurable number of hours from the current date and time. These changes have been tested by me with success starting from Home Assistant version 0.118.1.

The new and modified configuration variables are my examples below along with explanations of how they are currently designed to work.

**start_days_ago: -1**
  - 0 to any negative integer
  - Defaults to 0 if **start_on_hour** is supplied by user, but this variable is not
  - Defaults to 0 if the user enters a positive integer (this probably needs to be reversed so that "start days ago" only permits positive integers because "days ago" implies a past date)
  - In English: "Start yesterday", etc.
  - Needs to be improved so that it can't exceed the earliest date in the database?

**start_on_hour: 14**
  - 0 (for 0:00) to 23 (for 23:00)
  - No minute or second values supported
  - Defaults to 0 if **start_days_ago** is supplied by user, but this variable is not
  - Defaults to 0 if the user enters a value that is not >= 0 and <= 23
  - In English: "Start on hour 14 (2:00 PM) on **start_days_ago** from today"

**hours_to_show: 15**
  - Current production variable
  - Expanded functionality, dual purposes
  - If **start_days_ago** _or_ **start_on_hour** are supplied by the user, this variable is used to show number of hours _from the start date_ unless the end date would be in the future, then the currently designed start date and end date are applied
  - If **start_days_ago** _and_ **start_on_hour** are not supplied by the user, this variable works as _currently designed_ (from the end date)

There may be some inconsistencies in my changes for what happens when the user supplies only one of the two new configuration variables now that I look at my additions. These should be reviewed. I think that the user should be able to successfully use only one of them if they want.

I could use some help with the new footer function, renderFooter(), that displays the timestamps of the current view. This information will be necessary for user confirmation that the graph is displaying what they requested. It may be that other developers have already thought of a better way to display this information (other than appended HTML).

I also am not familiar enough with Home Assistant's framework to know how to support user localization settings. I do believe that I have added adequate time zone support, but it is only tested in my time zone of UTC -4.