### PR TITLE
Add median aggregate function

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -26,3 +26,11 @@ sensor:
         unit_of_measurement: "%"
         value_template: "{{ state_attr('weather.home', 'humidity') }}"
         device_class: humidity
+  - platform: random
+    name: random0_100
+    minimum: 0
+    maximum: 100
+  - platform: random
+    name: random_big
+    minimum: 12309812
+    maximum: 22309812

--- a/.devcontainer/ui-lovelace.yaml
+++ b/.devcontainer/ui-lovelace.yaml
@@ -12,4 +12,21 @@ views:
           - sensor.pressure
         show:
           extrema: true
-        # decimals: 10
+      - type: custom:mini-graph-card
+        hours_to_show: 1
+        points_per_hour: 60
+        entities:
+          - entity: sensor.random0_100
+            name: Random 0 - 100
+      - type: custom:mini-graph-card
+        hours_to_show: 1
+        points_per_hour: 20
+        lower_bound: 0
+        upper_bound: 100
+        # agregate_fun: median
+        entities:
+          - entity: sensor.random0_100
+            name: Random MEDIAN
+            aggregate_func: median
+          - entity: sensor.random0_100
+            name: Random AVG

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | name | string |  | Set a custom display name, defaults to entity's friendly_name.
 | color | string |  | Set a custom color, overrides all other color options including thresholds.
 | unit | string |  | Set a custom unit of measurement, overrides `unit` set in base config.
-| aggregate_func | string |  | Override for aggregate function used to calculate point on the graph, `avg`, `min`, `max`, `first`, `last`, `sum`.
+| aggregate_func | string |  | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | show_state | boolean |  | Display the current state.
 | show_indicator | boolean |  | Display a color indicator next to the state, (only when more than two states are visible).
 | show_graph | boolean |  | Set to false to completely hide the entity in the graph.
@@ -194,6 +194,7 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | Name | Since | Description |
 |------|:-------:|-------------|
 | `avg` | v0.8.0 | Average
+| `median` | NEXT_VERSION | Median
 | `min` | v0.8.0 | Minimum - lowest value
 | `max` | v0.8.0 | Maximum - largest value
 | `first` | v0.9.0 |

--- a/src/graph.js
+++ b/src/graph.js
@@ -8,6 +8,7 @@ export default class Graph {
   constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
     const aggregateFuncMap = {
       avg: this._average,
+      median: this._median,
       max: this._maximum,
       min: this._minimum,
       first: this._first,
@@ -199,6 +200,14 @@ export default class Graph {
 
   _average(items) {
     return items.reduce((sum, entry) => (sum + parseFloat(entry.state)), 0) / items.length;
+  }
+
+  _median(items) {
+    items.sort((a, b) => a - b);
+    const mid = Math.floor((items.length - 1) / 2);
+    if (items.length % 2 === 1)
+      return items[mid];
+    return (items[mid] + items[mid + 1]) / 2;
   }
 
   _maximum(items) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -203,11 +203,11 @@ export default class Graph {
   }
 
   _median(items) {
-    items.sort((a, b) => a - b);
-    const mid = Math.floor((items.length - 1) / 2);
-    if (items.length % 2 === 1)
-      return items[mid];
-    return (items[mid] + items[mid + 1]) / 2;
+    const itemsDup = [...items].sort((a, b) => parseFloat(a) - parseFloat(b));
+    const mid = Math.floor((itemsDup.length - 1) / 2);
+    if (itemsDup.length % 2 === 1)
+      return parseFloat(itemsDup[mid].state);
+    return (parseFloat(itemsDup[mid].state) + parseFloat(itemsDup[mid + 1].state)) / 2;
   }
 
   _maximum(items) {


### PR DESCRIPTION
Median is often a more useful alternative to average.

A noteworthy side effect here is that as currently implemented, running `_median` over given items sorts them in place. If that's a problem, need to change so that we make a shallow copy of the array and operate on that.

Caveat: this patch is untested, but filing the PR here so it won't be forgotten and to avoid duplicate work in case someone else's thinking about this. And who knows, it might actually work :)