### PR TITLE
Update default path to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ If you configure Lovelace via YAML, add a reference to `mini-graph-card-bundle.j
 
   ```yaml
   resources:
-    - url: /local/mini-graph-card-bundle.js?v=0.10.0
+    - url: /local/community/mini-graph-card/mini-graph-card-bundle.js?v=0.10.0
       type: module
   ```
+
+If you did not install via HACS, update the url above according to the path where you put the downloaded file.
+Note that files put in `config/www/` directory are served on `/local/` URL.
 
 Else, if you prefer the graphical editor, use the menu to add the resource:
 
 1. Make sure, advanced mode is enabled in your user profile (click on your user name to get there)
 2. Navigate to Configuration -> Lovelace Dashboards -> Resources Tab. Hit orange (+) icon
-3. Enter URL `/local/mini-graph-card-bundle.js` and select type "JavaScript Module".
+3. Enter URL `/local/community/mini-graph-card/mini-graph-card-bundle.js` and select type "JavaScript Module".
 4. Restart Home Assistant.
 
 ## Updating


### PR DESCRIPTION
This is where javascript module is installed by default when added via HACS web GUI. As HACS is listed as the first and also - according to the docs - recommended way, it makes sense to be in pair with this default path.