### PR TITLE
Improve label readability on small cards

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -323,7 +323,7 @@ const style = css`
     font-weight: 400;
     justify-content: space-between;
     margin-right: 10px;
-    padding: .6em;
+    padding: 0 .6em;
     position: absolute;
     pointer-events: none;
     top: 0; bottom: 0;
@@ -333,8 +333,9 @@ const style = css`
     cursor: pointer;
     background: var(--primary-background-color, white);
     border-radius: 1em;
-    padding: .2em .6em;
+    padding: .4em .6em;
     box-shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.24);
+    line-height: normal;
   }
   .graph__legend {
     display: flex;


### PR DESCRIPTION
There is often the problem on small cards that the bottom label is hidden.

This PR does not completely solve the problem, as the bottom label can never be completely seen if the graph height is too small.  However, it improves the readability significantly. 

- The top and bottom label padding will be set to 0, as this padding does not have any benefit.
- The line height of the labels is set to normal ( template independent) which makes the bubbles smaller (at same font size).

![image](https://user-images.githubusercontent.com/25910703/112693372-cf4fbe80-8e80-11eb-840f-211d62f9fb62.png)

