### PR TITLE
Fix calculation for color threshold interpolation (fixes #596)

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -60,6 +60,7 @@ const interpolateStops = (stops) => {
 
   return stops.map((stop, stopIndex) => {
     if (stop.value != null) {
+      leftValuedIndex = stopIndex;
       return { ...stop };
     }
 


### PR DESCRIPTION
Fixes a bug in the feature added in #596, where consecutive "valued" stops don't get used in subsequent interpolations.