### PR TITLE
feat: add value_multiplier and extend value_factor

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -52,6 +52,7 @@ export default (config) => {
     state_map: [],
     cache: true,
     value_factor: 0,
+    value_multipler: 1,
     tap_action: {
       action: 'more-info',
     },

--- a/src/graph.js
+++ b/src/graph.js
@@ -5,7 +5,19 @@ import {
 } from './const';
 
 export default class Graph {
-  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
+  constructor({
+    width,
+    height,
+    margin,
+    hours = 24,
+    points = 1,
+    aggregateFuncName = 'avg',
+    valueFactor = 0,
+    valueMultiplier = 1,
+    groupBy = 'interval',
+    smoothing = true,
+    logarithmic = false
+  }) {
     const aggregateFuncMap = {
       avg: this._average,
       max: this._maximum,
@@ -26,6 +38,8 @@ export default class Graph {
     this.points = points;
     this.hours = hours;
     this.aggregateFuncName = aggregateFuncName;
+    this.valueFactor = valueFactor;
+    this.valueMultiplier = valueMultiplier;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
     this._logarithmic = logarithmic;

--- a/src/main.js
+++ b/src/main.js
@@ -100,25 +100,26 @@ class MiniGraphCard extends LitElement {
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
 
     this.config = buildConfig(config, this.config);
-
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
       this.Graph = this.config.entities.map(
-        entity => new Graph(
-          500,
-          this.config.height,
-          [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
-          this.config.hours_to_show,
-          this.config.points_per_hour,
-          entity.aggregate_func || this.config.aggregate_func,
-          this.config.group_by,
-          getFirstDefinedItem(
+        entity => new Graph({
+          width: 500,
+          height: this.config.height,
+          margin: [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
+          hours: this.config.hours_to_show,
+          points: this.config.points_per_hour,
+          aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
+          valueFactor: entity.valueFactor || this.config.valueFactor,
+          valueMultiplier: entity.valueMultiplier || this.config.valueMultiplier,
+          groupBy: this.config.group_by,
+          smoothing: getFirstDefinedItem(
             entity.smoothing,
             this.config.smoothing,
             !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
           ),
-          this.config.logarithmic,
-        ),
+          logarithmic: this.config.logarithmic,
+        }),
       );
     }
   }
@@ -666,12 +667,14 @@ class MiniGraphCard extends LitElement {
     }
     const dec = this.config.decimals;
     const value_factor = 10 ** this.config.value_factor;
+    const value_multipler = this.config.value_multipler || 1;
 
-    if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state))
-      return Math.round(state * value_factor * 100) / 100;
+    if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state)) {
+      return (Math.round(state * value_factor * 100) / 100) * value_multipler;
+    }
 
     const x = 10 ** dec;
-    return (Math.round(state * value_factor * x) / x).toFixed(dec);
+    return (Math.round(state * value_factor * x) / x).toFixed(dec) * value_multipler;
   }
 
   updateOnInterval() {


### PR DESCRIPTION
This adds value_multiplier which similarly to the value_factor only it multiplies the value directly. By default it's set to `1`.

I've also added the `value_factor` to the entity itself to allow different factors for each entity. Personally I like this as it allows cards to show more than a single type of data. For example I want to show data usage and power usage on one, the issue is one is in bytes(I want MB) and one is watts(I want KW). I need one to be divided by `1024` and the other `1000`.

I haven't tested this yet so please let me know if there's anything I need to fix.

Closes https://github.com/kalkih/mini-graph-card/issues/607 and https://github.com/kalkih/mini-graph-card/issues/591