### PR TITLE
Fix #269: add order attribute to entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | attribute | string | | Retrieves an attribute instead of the state
 | name | string |  | Set a custom display name, defaults to entity's friendly_name.
 | color | string |  | Set a custom color, overrides all other color options including thresholds.
+| order | number |  | Change the order in which graphs are rendered.
 | unit | string |  | Set a custom unit of measurement, overrides `unit` set in base config.
 | aggregate_func | string |  | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | show_state | boolean |  | Display the current state.

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -132,6 +132,7 @@ export default (config) => {
     tap_action: {
       action: 'more-info',
     },
+    reverse_graphs: true,
     ...JSON.parse(JSON.stringify(config)),
     show: { ...DEFAULT_SHOW, ...config.show },
   };

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -132,7 +132,6 @@ export default (config) => {
     tap_action: {
       action: 'more-info',
     },
-    reverse_graphs: true,
     ...JSON.parse(JSON.stringify(config)),
     show: { ...DEFAULT_SHOW, ...config.show },
   };

--- a/src/graph.js
+++ b/src/graph.js
@@ -5,7 +5,7 @@ import {
 } from './const';
 
 export default class Graph {
-  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
+  constructor(order, width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
     const aggregateFuncMap = {
       avg: this._average,
       median: this._median,
@@ -17,6 +17,7 @@ export default class Graph {
       delta: this._delta,
     };
 
+    this._order = order;
     this._history = undefined;
     this.coords = [];
     this.width = width - margin[X] * 2;
@@ -33,6 +34,8 @@ export default class Graph {
     this._groupBy = groupBy;
     this._endTime = 0;
   }
+
+  get order() { return this._order || 0; }
 
   get max() { return this._max; }
 

--- a/src/main.js
+++ b/src/main.js
@@ -515,10 +515,10 @@ class MiniGraphCard extends LitElement {
 
     // map element keys to render function
     const fillMap = orderedKeys.map((i, order) => this.renderSvgFill(this.fill[i], i, order));
-    const fillRectMap = orderedKeys.map((i) => this.renderSvgFillRect(this.fill[i], i));
+    const fillRectMap = orderedKeys.map(i => this.renderSvgFillRect(this.fill[i], i));
     const lineMap = orderedKeys.map((i, order) => this.renderSvgLine(this.line[i], i, order));
-    const lineRectMap = orderedKeys.map((i) => this.renderSvgLineRect(this.line[i], i));
-    const barMap = orderedKeys.map((i) => this.renderSvgBars(this.bar[i], i));
+    const lineRectMap = orderedKeys.map(i => this.renderSvgLineRect(this.line[i], i));
+    const barMap = orderedKeys.map(i => this.renderSvgBars(this.bar[i], i));
     const pointsMap = orderedKeys.map((i, order) => this.renderSvgPoints(this.points[i], i, order));
 
     return svg`

--- a/src/main.js
+++ b/src/main.js
@@ -109,11 +109,12 @@ class MiniGraphCard extends LitElement {
       if (this._hass) this.hass = this._hass;
       let order = 0;
       this.Graph = this.config.entities.map(
-        entity => {
+        (entity) => {
           let graphOrder = entity.order;
-          if (!Number.isInteger(graphOrder))
-            graphOrder = order++;
-          else
+          if (!Number.isInteger(graphOrder)) {
+            order += 1;
+            graphOrder = order;
+          } else
             order = graphOrder + 1;
 
           return new Graph(
@@ -132,7 +133,7 @@ class MiniGraphCard extends LitElement {
             ),
             this.config.logarithmic,
           );
-        }
+        },
       );
     }
   }
@@ -513,12 +514,12 @@ class MiniGraphCard extends LitElement {
     orderedKeys.sort((a, b) => this.Graph[b].order - this.Graph[a].order);
 
     // map element keys to render function
-    let fillMap =     orderedKeys.map((i, order) => this.renderSvgFill(this.fill[i], i, order));
-    let fillRectMap = orderedKeys.map((i, order) => this.renderSvgFillRect(this.fill[i], i));
-    let lineMap =     orderedKeys.map((i, order) => this.renderSvgLine(this.line[i], i, order));
-    let lineRectMap = orderedKeys.map((i, order) => this.renderSvgLineRect(this.line[i], i));
-    let barMap =      orderedKeys.map((i, order) => this.renderSvgBars(this.bar[i], i));
-    let pointsMap =   orderedKeys.map((i, order) => this.renderSvgPoints(this.points[i], i, order));
+    const fillMap = orderedKeys.map((i, order) => this.renderSvgFill(this.fill[i], i, order));
+    const fillRectMap = orderedKeys.map((i) => this.renderSvgFillRect(this.fill[i], i));
+    const lineMap = orderedKeys.map((i, order) => this.renderSvgLine(this.line[i], i, order));
+    const lineRectMap = orderedKeys.map((i) => this.renderSvgLineRect(this.line[i], i));
+    const barMap = orderedKeys.map((i) => this.renderSvgBars(this.bar[i], i));
+    const pointsMap = orderedKeys.map((i, order) => this.renderSvgPoints(this.points[i], i, order));
 
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'

--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,11 @@ class MiniGraphCard extends LitElement {
 
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
-      this.Graph = this.config.entities.map(
+      let { entities } = this.config;
+      if (this.config.reverse_graphs)
+        entities = entities.reverse();
+
+      this.Graph = entities.map(
         entity => new Graph(
           500,
           this.config.height,

--- a/src/main.js
+++ b/src/main.js
@@ -766,28 +766,23 @@ class MiniGraphCard extends LitElement {
     if (config.show.graph) {
       let graphPos = 0;
       this.entity.forEach((entity, i) => {
-        if (!entity) return;
-
-        const graphEntity = this.Graph[i];
-
-        if (graphEntity.coords.length === 0) return;
-        
+        if (!entity || this.Graph[i].coords.length === 0) return;
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
-        [graphEntity.min, graphEntity.max] = [bound[0], bound[1]];
+        [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
           const numVisible = this.visibleEntities.length;
-          this.bar[i] = graphEntity.getBars(graphPos, numVisible, config.bar_spacing);
+          this.bar[i] = this.Graph[i].getBars(graphPos, numVisible, config.bar_spacing);
           graphPos += 1;
         } else {
-          const line = graphEntity.getPath();
+          const line = this.Graph[i].getPath();
           if (config.entities[i].show_line !== false) this.line[i] = line;
           if (config.show.fill
-            && config.entities[i].show_fill !== false) this.fill[i] = graphEntity.getFill(line);
+            && config.entities[i].show_fill !== false) this.fill[i] = this.Graph[i].getFill(line);
           if (config.show.points && (config.entities[i].show_points !== false)) {
-            this.points[i] = graphEntity.getPoints();
+            this.points[i] = this.Graph[i].getPoints();
           }
           if (config.color_thresholds.length > 0 && !config.entities[i].color)
-            this.gradient[i] = graphEntity.computeGradient(
+            this.gradient[i] = this.Graph[i].computeGradient(
               config.color_thresholds, this.config.logarithmic,
             );
         }

--- a/src/main.js
+++ b/src/main.js
@@ -113,6 +113,8 @@ class MiniGraphCard extends LitElement {
           let graphOrder = entity.order;
           if (!Number.isInteger(graphOrder))
             graphOrder = order++;
+          else
+            order = graphOrder + 1;
 
           return new Graph(
             graphOrder,
@@ -357,7 +359,7 @@ class MiniGraphCard extends LitElement {
     `;
   }
 
-  renderSvgFill(fill, i) {
+  renderSvgFill(fill, i, renderOrder) {
     if (!fill) return;
     const fade = this.config.show.fill === 'fade';
     const init = this.length[i] || this.config.entities[i].show_line === false;
@@ -375,7 +377,7 @@ class MiniGraphCard extends LitElement {
         <path class='fill'
           type=${this.config.show.fill}
           .id=${i} anim=${this.config.animate} ?init=${init}
-          style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+          style="animation-delay: ${this.config.animate ? `${renderOrder * 0.5}s` : '0s'}"
           fill='white'
           mask=${fade ? `url(#fill-grad-mask-${this.id}-${i})` : ''}
           d=${this.fill[i]}
@@ -383,7 +385,7 @@ class MiniGraphCard extends LitElement {
       </mask>`;
   }
 
-  renderSvgLine(line, i) {
+  renderSvgLine(line, i, renderOrder) {
     if (!line) return;
 
     const path = svg`
@@ -391,7 +393,7 @@ class MiniGraphCard extends LitElement {
         class='line'
         .id=${i}
         anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+        style="animation-delay: ${this.config.animate ? `${renderOrder * 0.5}s` : '0s'}"
         fill='none'
         stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
         stroke=${'white'}
@@ -422,7 +424,7 @@ class MiniGraphCard extends LitElement {
     `;
   }
 
-  renderSvgPoints(points, i) {
+  renderSvgPoints(points, i, renderOrder) {
     if (!points) return;
     const color = this.computeColor(this.entity[i].state, i);
     return svg`
@@ -431,7 +433,7 @@ class MiniGraphCard extends LitElement {
         ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
         ?init=${this.length[i]}
         anim=${this.config.animate && this.config.show.points !== 'hover'}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5 + 0.5}s` : '0s'}"
+        style="animation-delay: ${this.config.animate ? `${renderOrder * 0.5 + 0.5}s` : '0s'}"
         fill=${color}
         stroke=${color}
         stroke-width=${this.config.line_width / 2}>
@@ -511,12 +513,12 @@ class MiniGraphCard extends LitElement {
     orderedKeys.sort((a, b) => this.Graph[b].order - this.Graph[a].order);
 
     // map element keys to render function
-    let fillMap =     orderedKeys.map(i => this.renderSvgFill(this.fill[i], i));
-    let fillRectMap = orderedKeys.map(i => this.renderSvgFillRect(this.fill[i], i));
-    let lineMap =     orderedKeys.map(i => this.renderSvgLine(this.line[i], i));
-    let lineRectMap = orderedKeys.map(i => this.renderSvgLineRect(this.line[i], i));
-    let barMap =      orderedKeys.map(i => this.renderSvgBars(this.bar[i], i));
-    let pointsMap =   orderedKeys.map(i => this.renderSvgPoints(this.points[i], i));
+    let fillMap =     orderedKeys.map((i, order) => this.renderSvgFill(this.fill[i], i, order));
+    let fillRectMap = orderedKeys.map((i, order) => this.renderSvgFillRect(this.fill[i], i));
+    let lineMap =     orderedKeys.map((i, order) => this.renderSvgLine(this.line[i], i, order));
+    let lineRectMap = orderedKeys.map((i, order) => this.renderSvgLineRect(this.line[i], i));
+    let barMap =      orderedKeys.map((i, order) => this.renderSvgBars(this.bar[i], i));
+    let pointsMap =   orderedKeys.map((i, order) => this.renderSvgPoints(this.points[i], i, order));
 
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'


### PR DESCRIPTION
This PR adds an optional attribute to entities, which changes the order, in which graphs are rendered. This fixes #269: if no order is set, the graphs are rendered in reversed order as they are specified in the config. This means the first entity is rendered last (on top of everything else).

Nothing else should be affected by this. Animations should still be played from back to front etc.

Please tell me what you think and test this enhancement with your own setup!