### PR TITLE
Pass the `no_attributes` flag when they are not needed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -950,7 +950,7 @@ class MiniGraphCard extends LitElement {
     url += `?filter_entity_id=${entityId}`;
     if (end) url += `&end_time=${end.toISOString()}`;
     if (skipInitialState) url += '&skip_initial_state';
-    if (!withAttributes) url += '&minimal_response';
+    if (!withAttributes) url += '&minimal_response&no_attributes';
     if (withAttributes) url += '&significant_changes_only=0';
     return this._hass.callApi('GET', url);
   }


### PR DESCRIPTION
This is backwards compatible, it will make a difference on 2022.4dev and later

- Reduces backend I/O by up to 90%

- See related PR https://github.com/home-assistant/frontend/pull/12082

- See related PR https://github.com/home-assistant/developers.home-assistant/pull/1242

- See related PR https://github.com/home-assistant/core/pull/68352

- See related PR https://github.com/home-assistant/core/pull/68224