### PR TITLE
Define timeframes to record data points

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ const getAvg = (arr, val) => arr.reduce((sum, p) => (
 const getMax = (arr, val) => arr.reduce((max, p) => (
   Number(p[val]) > Number(max[val]) ? p : max
 ), arr[0]);
-const getTime = (date, extra, locale = 'en-US') => date.toLocaleString(locale, { hour: 'numeric', minute: 'numeric', ...extra });
+const getTime = (date, extra, locale = 'en-US') => date.toLocaleString(locale, { ...extra });
 const getMilli = hours => hours * 60 ** 2 * 10 ** 3;
 
 const interpolateColor = (a, b, factor) => {


### PR DESCRIPTION
I tried creating a stock market graph with a custom:Mini-graph-cards but mini-graph-card records data points all the time. Stock markets are normally closed between 16h30 and 9h30. It could be very useful and helpful to have a setting to specify when not to record data points for certain graphs. I am sure this request is fairly easy to implement and it would be a very nice addition for any finance geek that want to create graphs to follow his stock.