### PR TITLE
fix: put hex-color in quotation marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ entities:
   - entity: sensor.outside_temp
     aggregate_func: max
     name: Max
-    color: #e74c3c
+    color: "#e74c3c"
   - entity: sensor.outside_temp
     aggregate_func: min
     name: Min


### PR DESCRIPTION
It would otherwise be a comment and a bit misleading.