### PR TITLE
Add unit_first option

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,5 +1,5 @@
 name: "Semantic PR"
-description: Ensure your PR title matches the Conventional Commits spec (https://www.conventionalcommits.org/).
+# description: Ensure your PR title matches the Conventional Commits spec (https://www.conventionalcommits.org/).
 
 on:
   pull_request_target:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
 | unit | string |  | v0.0.1 | Set a custom unit of measurement.
-| unit_first | boolean |  | v0.11.1 | Put the unit of measurement before the state (e.g. £1.50 or $10.90 if the entity is tracking cost).
+| unit_first | boolean | `false` | v0.11.1 | Put the unit of measurement before the state (e.g. £1.50 or $10.90 if the entity is tracking cost).
 | tap_action | [action object](#action-object-options) |  | v0.7.0 | Action on click/tap.
 | group | boolean | `false` | v0.2.0 | Disable paddings and box-shadow, useful when nesting the card.
 | hours_to_show | integer | `24` | v0.0.2 | Specify how many hours of history the graph should present.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
 | unit | string |  | v0.0.1 | Set a custom unit of measurement.
+| unit_first | boolean |  | v0.11.1 | Put the unit of measurement before the state (e.g. £1.50 or $10.90 if the entity is tracking cost).
 | tap_action | [action object](#action-object-options) |  | v0.7.0 | Action on click/tap.
 | group | boolean | `false` | v0.2.0 | Disable paddings and box-shadow, useful when nesting the card.
 | hours_to_show | integer | `24` | v0.0.2 | Specify how many hours of history the graph should present.

--- a/src/main.js
+++ b/src/main.js
@@ -570,7 +570,7 @@ class MiniGraphCard extends LitElement {
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
-              ${this.computeState(entry.state)} ${this.computeUom(0)}
+              ${this.config.unit_first ? this.computeUom(0) this.computeState(entry.state) : this.computeState(entry.state) this.computeUom(0)}
             </span>
             <span class="info__item__time">
               ${entry.type !== 'avg' ? getTime(new Date(entry.last_changed), this.config.format, this._hass.language) : ''}

--- a/src/main.js
+++ b/src/main.js
@@ -306,8 +306,8 @@ class MiniGraphCard extends LitElement {
           ${entityConfig.show_indicator ? this.renderIndicator(state, id) : ''}
           ${this.unitFirstOrLast(isPrimary, tooltipValue, state, id, entity)}
           ${isPrimary && this.renderStateTime() || ''}
-        </div >
-        `;
+        </div>
+      `;
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -273,6 +273,26 @@ class MiniGraphCard extends LitElement {
     }
   }
 
+  unitFirstOrLast(isPrimary, tooltipValue, state, id, entity) {
+    if (this.config.unit_first) {
+      return html`
+        <span class="state__uom ellipsis">
+          ${this.computeUom(isPrimary && entity || id)}
+        </span>
+        <span class="state__value ellipsis">
+          ${this.computeState(isPrimary && tooltipValue || state)}
+        </span>`;
+    } else {
+      return html`
+        <span class="state__value ellipsis">
+          ${this.computeState(isPrimary && tooltipValue || state)}
+        </span>
+        <span class="state__uom ellipsis">
+          ${this.computeUom(isPrimary && entity || id)}
+        </span>`;
+    }
+  }
+
   renderState(entityConfig, id) {
     const isPrimary = id === 0;
     if (isPrimary || entityConfig.show_state) {
@@ -284,15 +304,10 @@ class MiniGraphCard extends LitElement {
           @click=${e => this.handlePopup(e, this.entity[id])}
           style=${entityConfig.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}>
           ${entityConfig.show_indicator ? this.renderIndicator(state, id) : ''}
-          <span class="state__value ellipsis">
-            ${this.computeState(isPrimary && tooltipValue || state)}
-          </span>
-          <span class="state__uom ellipsis">
-            ${this.computeUom(isPrimary && entity || id)}
-          </span>
+          ${this.unitFirstOrLast(isPrimary, tooltipValue, state, id, entity)}
           ${isPrimary && this.renderStateTime() || ''}
-        </div>
-      `;
+        </div >
+        `;
     }
   }
 
@@ -570,7 +585,7 @@ class MiniGraphCard extends LitElement {
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
-              ${this.config.unit_first ? this.computeUom(0) this.computeState(entry.state) : this.computeState(entry.state) this.computeUom(0)}
+              ${this.computeState(entry.state)} ${this.computeUom(0)}
             </span>
             <span class="info__item__time">
               ${entry.type !== 'avg' ? getTime(new Date(entry.last_changed), this.config.format, this._hass.language) : ''}


### PR DESCRIPTION
I'm trying to use `mini-graph-card` to track energy costs but the unit shows after the monetary value. Thus showing as `2.50 £` which isn't right!

This adds a Boolean option, `unit_first`, which moves the unit to the start.

---

Fully understand that this is ... messy code; I'm not a JS dev by any means 😅 
However, just wanted to contribute my "fork" back upstream 🚀 
