### PR TITLE
feat: add scale_factor and extend value_factor (next)

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -5,6 +5,12 @@ lovelace:
       type: module
 
 default_config:
+http: # support devcontainers/codespaces/gitpod
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 127.0.0.1
+  ip_ban_enabled: true
+  login_attempts_threshold: 5
 
 demo:
 
@@ -37,4 +43,8 @@ sensor:
   - platform: random
     name: random_0_1000
     minimum: 0
+    maximum: 1000
+  - platform: random
+    name: random_150_1000
+    minimum: 150
     maximum: 1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,13 @@
       "**/.hg/store/**": true,
       "**/.rpt2_cache/**": true
     }
-  }
+},
+"portsAttributes": {
+	"5000": {
+		"label": "rollup"
+	},
+	"8123": {
+		"label": "HA"
+	}
+}
 }

--- a/.devcontainer/ui-lovelace.yaml
+++ b/.devcontainer/ui-lovelace.yaml
@@ -3,19 +3,15 @@ views:
     cards:
       - type: custom:mini-graph-card
         entities:
-          - sensor.humidity
+          - sensor.outside_humidity
       - type: custom:mini-graph-card
         entities:
-          - sensor.temperature
-      - type: custom:mini-graph-card
-        entities:
-          - sensor.pressure
+          - sensor.outside_temperature
         show:
           extrema: true
       - type: custom:mini-graph-card
         entities:
-          - entity: weather.home
-            attribute: pressure
+          - entity: sensor.outside_temperature
         show:
           extrema: true
       - type: custom:mini-graph-card
@@ -48,17 +44,39 @@ views:
           points: true
         entities:
           - entity: sensor.random_0_1000
-            name: log(0 - 1000) Gradients
+            name: log(150 - 1000) Gradients
             aggregate_func: last
         color_thresholds:
           - value: 0
             color: "#00ff00"
-          - value: 10
+          - value: 200
             color: "#ffff00"
-          - value: 100
+          - value: 350
             color: "#ff9900"
-          - value: 500
+          - value: 600
             color: "#ff0000"
+      - type: custom:mini-graph-card
+        hours_to_show: 1
+        points_per_hour: 120
+        lower_bound: 0
+        upper_bound: 1000
+        # logarithmic: true
+        smoothing: false
+        height: 600
+        show:
+          extrema: true
+        #   points: true
+        entities:
+          - entity: sensor.random_0_1000
+            name: log(150 - 1000) Simple
+            aggregate_func: last
+        color_thresholds:
+          - value: 0
+            color: green
+          - value: 200
+            color: red
+          - value: 1000
+            color: blue
       - type: custom:mini-graph-card
         entities:
           - sensor.non_existant

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | y_axis | string |  | If 'secondary', displays using the secondary y-axis on the right.
 | fixed_value | boolean |  | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |  | Override for a flag indicating whether to make graph line smooth.
-| value_multipler | number | 1 | Set a multiplier to use on the graph's value
+| scale_factor | number | 1 | Set a scale factor to use on the graph's value
 | value_factor | number | 0 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
 
 ```yaml
@@ -149,7 +149,7 @@ entities:
   - entity: sensor.pressure
     name: Pressure
     show_state: true
-    value_multipler: -2.1
+    scale_factor: -2.1
   - sensor.humidity
 ```
 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ state_map:
 ![изображение](https://user-images.githubusercontent.com/71872483/170584118-ef826b60-dce3-42ec-a005-0f467616cd37.png)
 
 It is possible to show a state without displaying a graph for a sensor.
-Imagine there are 2 temperature sensors & 1 humidity sensor; graphs are displayed for the temperatures only, and the humidity is shown as a state only.
+Imagine there are two CO-2 sensors & one humidity sensor; graphs are displayed for the CO-2 only, and the humidity is shown as a state only.
 ```
 type: custom:mini-graph-card
 entities:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | y_axis | string |  | If 'secondary', displays using the secondary y-axis on the right.
 | fixed_value | boolean |  | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |  | Override for a flag indicating whether to make graph line smooth.
+| value_multipler | number | 1 | Set a multiplier to use on the graph's value
+| value_factor | number | 0 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
 
 ```yaml
 entities:
@@ -147,6 +149,7 @@ entities:
   - entity: sensor.pressure
     name: Pressure
     show_state: true
+    value_multipler: -2.1
   - sensor.humidity
 ```
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ show:
   icon: false
   labels: true
 ```
+This method may be also used to add a calculated value with it's own `aggregate_func` option.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -488,6 +488,37 @@ state_map:
     label: Detected
 ```
 
+#### Showing additional info on the card
+
+![изображение](https://user-images.githubusercontent.com/71872483/170584118-ef826b60-dce3-42ec-a005-0f467616cd37.png)
+
+It is possible to show a state without displaying a graph for a sensor.
+Imagine there are 2 temperature sensors & 1 humidity sensor; graphs are displayed for the temperatures only, and the humidity is shown as a state only.
+```
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.xiaomi_cg_1_humidity
+    show_state: true
+    show_graph: false
+  - entity: sensor.xiaomi_cg_1_co2
+    color: green
+    show_state: false
+    name: CO2-1
+  - entity: sensor.xiaomi_cg_2_co2
+    color: orange
+    show_state: false
+    name: CO2-2
+name: Humidity
+hours_to_show: 4
+points_per_hour: 60
+show:
+  name: true
+  legend: true
+  icon: false
+  labels: true
+  labels_secondary: false
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -516,7 +516,6 @@ show:
   legend: true
   icon: false
   labels: true
-  labels_secondary: false
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | type ***(required)*** | string |  | v0.0.1 | `custom:mini-graph-card`.
 | entities ***(required)*** | list |  | v0.2.0 | One or more sensor entities in a list, see [entities object](#entities-object) for additional entity options.
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
+| icon_image | string |  | NEXT_VERSION | Override icon with an image url
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
 | unit | string |  | v0.0.1 | Set a custom unit of measurement.
 | tap_action | [action object](#action-object-options) |  | v0.7.0 | Action on click/tap.

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -129,6 +129,7 @@ export default (config) => {
     state_map: [],
     cache: true,
     value_factor: 0,
+    value_multipler: 1,
     tap_action: {
       action: 'more-info',
     },

--- a/src/graph.js
+++ b/src/graph.js
@@ -12,11 +12,9 @@ export default class Graph {
     hours = 24,
     points = 1,
     aggregateFuncName = 'avg',
-    valueFactor = 0,
-    valueMultiplier = 1,
     groupBy = 'interval',
     smoothing = true,
-    logarithmic = false
+    logarithmic = false,
   }) {
     const aggregateFuncMap = {
       avg: this._average,
@@ -40,8 +38,6 @@ export default class Graph {
     this.points = points;
     this.hours = hours;
     this.aggregateFuncName = aggregateFuncName;
-    this.valueFactor = valueFactor;
-    this.valueMultiplier = valueMultiplier;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
     this._logarithmic = logarithmic;

--- a/src/graph.js
+++ b/src/graph.js
@@ -5,7 +5,19 @@ import {
 } from './const';
 
 export default class Graph {
-  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
+  constructor({
+    width,
+    height,
+    margin,
+    hours = 24,
+    points = 1,
+    aggregateFuncName = 'avg',
+    valueFactor = 0,
+    valueMultiplier = 1,
+    groupBy = 'interval',
+    smoothing = true,
+    logarithmic = false
+  }) {
     const aggregateFuncMap = {
       avg: this._average,
       median: this._median,
@@ -28,6 +40,8 @@ export default class Graph {
     this.points = points;
     this.hours = hours;
     this.aggregateFuncName = aggregateFuncName;
+    this.valueFactor = valueFactor;
+    this.valueMultiplier = valueMultiplier;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
     this._logarithmic = logarithmic;

--- a/src/graph.js
+++ b/src/graph.js
@@ -12,7 +12,7 @@ export default class Graph {
     hours = 24,
     points = 1,
     aggregateFuncName = 'avg',
-    valueMultipler = 1,
+    scaleFactor = 1,
     groupBy = 'interval',
     smoothing = true,
     logarithmic = false,
@@ -39,7 +39,7 @@ export default class Graph {
     this.points = points;
     this.hours = hours;
     this.aggregateFuncName = aggregateFuncName;
-    this._valueMultipler = valueMultipler;
+    this._scaleFactor = scaleFactor;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
     this._logarithmic = logarithmic;
@@ -111,7 +111,7 @@ export default class Graph {
   }
 
   _scale(value) {
-    return this._valueMultipler * value;
+    return this._scaleFactor * value;
   }
 
   _calcY(coords) {

--- a/src/main.js
+++ b/src/main.js
@@ -106,6 +106,7 @@ class MiniGraphCard extends LitElement {
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
+      const valueFactor = 10 ** this.config.value_factor;
       this.Graph = this.config.entities.map(
         entity => new Graph({
           width: 500,
@@ -121,6 +122,8 @@ class MiniGraphCard extends LitElement {
             !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
           ),
           logarithmic: this.config.logarithmic,
+          valueMultipler: (entity.value_multipler ? entity.value_multipler : 1)
+            * (entity.value_factor ? 10 ** entity.value_factor : valueFactor),
         }),
       );
     }

--- a/src/main.js
+++ b/src/main.js
@@ -227,6 +227,14 @@ class MiniGraphCard extends LitElement {
   }
 
   renderIcon() {
+    if (this.config.icon_image !== 'undefined') {
+      return html`
+        <div class="icon">
+          <img src="${this.config.icon_image}" height="25"/>
+        </div>
+      `;
+    }
+
     const { icon, icon_adaptive_color } = this.config.show;
     return icon ? html`
       <div class="icon" loc=${this.config.align_icon}

--- a/src/main.js
+++ b/src/main.js
@@ -104,25 +104,26 @@ class MiniGraphCard extends LitElement {
     this.config = buildConfig(config, this.config);
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
-
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
       this.Graph = this.config.entities.map(
-        entity => new Graph(
-          500,
-          this.config.height,
-          [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
-          this.config.hours_to_show,
-          this.config.points_per_hour,
-          entity.aggregate_func || this.config.aggregate_func,
-          this.config.group_by,
-          getFirstDefinedItem(
+        entity => new Graph({
+          width: 500,
+          height: this.config.height,
+          margin: [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
+          hours: this.config.hours_to_show,
+          points: this.config.points_per_hour,
+          aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
+          valueFactor: entity.valueFactor || this.config.valueFactor,
+          valueMultiplier: entity.valueMultiplier || this.config.valueMultiplier,
+          groupBy: this.config.group_by,
+          smoothing: getFirstDefinedItem(
             entity.smoothing,
             this.config.smoothing,
             !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
           ),
-          this.config.logarithmic,
-        ),
+          logarithmic: this.config.logarithmic,
+        }),
       );
     }
   }
@@ -701,14 +702,15 @@ class MiniGraphCard extends LitElement {
     }
     const dec = this.config.decimals;
     const value_factor = 10 ** this.config.value_factor;
+    const value_multipler = this.config.value_multipler || 1;
 
     if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state)) {
-      return this.numberFormat(Math.round(state * value_factor * 100) / 100, this._hass.language);
+      return this.numberFormat(Math.round(state * value_factor * value_multiplier * 100) / 100), this._hass.language);
     }
 
     const x = 10 ** dec;
     return this.numberFormat(
-      (Math.round(state * value_factor * x) / x).toFixed(dec),
+      (Math.round(state * value_factor * x * value_multiplier) / x).toFixed(dec),
       this._hass.language, dec,
     );
   }

--- a/src/main.js
+++ b/src/main.js
@@ -950,7 +950,7 @@ class MiniGraphCard extends LitElement {
     url += `?filter_entity_id=${entityId}`;
     if (end) url += `&end_time=${end.toISOString()}`;
     if (skipInitialState) url += '&skip_initial_state';
-    if (!withAttributes) url += '&minimal_response';
+    if (!withAttributes) url += '&minimal_response&no_attributes';
     if (withAttributes) url += '&significant_changes_only=0';
     return this._hass.callApi('GET', url);
   }

--- a/src/style.js
+++ b/src/style.js
@@ -315,6 +315,7 @@ const style = css`
   .graph__labels.--secondary {
     right: 0;
     margin-right: 0px;
+    align-items: flex-end;
   }
   .graph__labels {
     align-items: flex-start;


### PR DESCRIPTION
I've bootstrapped from PR #608 that was stalling. 

I've fixed the remarks and fixed the implementation to also work with negative scale factor.
This allow to have a negative `value_multiplier` (for example, when injecting current in the grid) per entity and also a `value_factor` per entity.

I've also fixed the documentation.

This gives this:
![image](https://user-images.githubusercontent.com/3277165/205089881-89a60648-4c44-49ab-9bb2-11b8fab6ea21.png)

where the blue graph is a negative valued since it's a production not a consumption:
![image](https://user-images.githubusercontent.com/3277165/205090338-451346d7-f38e-4d8f-a61c-45bb8ce9e6c7.png)
