### PR TITLE
fix: allow zero tooltip

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -293,7 +293,7 @@ class MiniGraphCard extends LitElement {
           style=${entityConfig.state_adaptive_color ? `color: ${this.computeColor(state, id)};` : ''}>
           ${entityConfig.show_indicator ? this.renderIndicator(state, id) : ''}
           <span class="state__value ellipsis">
-            ${this.computeState(isPrimary && tooltipValue || state)}
+            ${this.computeState((isPrimary && tooltipValue !== undefined) ? tooltipValue : state)}
           </span>
           <span class="state__uom ellipsis">
             ${this.computeUom(isPrimary && entity || id)}


### PR DESCRIPTION
fixes #805 as outlined in my comment there

Note: this could as well be fixed with ES2020's nullish coalescing operator `??`. But the source did not compile with it.