### PR TITLE
fix: drop out-of-bound coords in reducer

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -54,11 +54,6 @@ export default class Graph {
 
     const histGroups = this._history.reduce((res, item) => this._reducer(res, item), []);
 
-    // drop potential out of bound entry's except one
-    if (histGroups[0] && histGroups[0].length) {
-      histGroups[0] = [histGroups[0][histGroups[0].length - 1]];
-    }
-
     // extend length to fill missing history
     const requiredNumOfPoints = Math.ceil(this.hours * this.points);
     histGroups.length = requiredNumOfPoints;
@@ -71,9 +66,11 @@ export default class Graph {
   _reducer(res, item) {
     const age = this._endTime - new Date(item.last_changed).getTime();
     const interval = (age / ONE_HOUR * this.points) - this.hours * this.points;
-    const key = interval < 0 ? Math.floor(Math.abs(interval)) : 0;
-    if (!res[key]) res[key] = [];
-    res[key].push(item);
+    if (interval < 0) {
+      const key = Math.floor(Math.abs(interval));
+      if (!res[key]) res[key] = [];
+      res[key].push(item);
+    }
     return res;
   }
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -75,22 +75,21 @@ export default class Graph {
   }
 
   _calcPoints(history) {
-    const coords = [];
     let xRatio = this.width / (this.hours * this.points - 1);
     xRatio = Number.isFinite(xRatio) ? xRatio : this.width;
 
-    const first = history.filter(Boolean)[0];
-    let last = [this._calcPoint(first), this._lastValue(first)];
-    const getCoords = (item, i) => {
-      const x = xRatio * i + this.margin[X];
-      if (item)
-        last = [this._calcPoint(item), this._lastValue(item)];
-      return coords.push([x, 0, item ? last[0] : last[1]]);
-    };
-
-    for (let i = 0; i < history.length; i += 1)
-      getCoords(history[i], i);
-
+    const coords = [];
+    let last = history.filter(Boolean)[0];
+    let x;
+    for (let i = 0; i < history.length; i += 1) {
+      x = xRatio * i + this.margin[X];
+      if (history[i]) {
+        last = history[i];
+        coords.push([x, 0, this._calcPoint(last)]);
+      } else {
+        coords.push([x, 0, this._lastValue(last)]);
+      }
+    }
     return coords;
   }
 


### PR DESCRIPTION
The fix from #251 introduced a logic that
1. allocated all "too-old" coords to the first group coords[0]
2. deleted all but one entries from that first group.

This caused aggregators to stop calculating proper results for that first group.

The proposed new logic drops out-of-bounds entries already in the reducer. This allows the first group to have multiple entries. Aggregate functions should now work again.

fixed #869 