### PR TITLE
fix: add first datapoint tooltip for line graph

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -118,16 +118,18 @@ export default class Graph {
       coords[1] = [this.width + this.margin[X], 0, coords[0][V]];
     }
     coords = this._calcY(this.coords);
-    let next; let Z;
-    let last = coords[0];
-    const coords2 = coords.map((point, i) => {
-      next = point;
-      Z = this._smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
-      const sum = this._smoothing ? (next[V] + last[V]) / 2 : next[V];
-      last = next;
-      return [Z[X], Z[Y], sum, i];
-    });
-    return coords2;
+    if (this._smoothing) {
+      let last = coords[0];
+      coords.shift();
+      return coords.map((point, i) => {
+        const Z = this._midPoint(last[X], last[Y], point[X], point[Y]);
+        const sum = (last[V] + point[V]) / 2;
+        last = point;
+        return [Z[X], Z[Y], sum, i + 1];
+      });
+    } else {
+      return coords.map((point, i) => [point[X], point[Y], point[V], i]);
+    }
   }
 
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -120,13 +120,12 @@ export default class Graph {
     coords = this._calcY(this.coords);
     let next; let Z;
     let last = coords[0];
-    coords.shift();
     const coords2 = coords.map((point, i) => {
       next = point;
       Z = this._smoothing ? this._midPoint(last[X], last[Y], next[X], next[Y]) : next;
       const sum = this._smoothing ? (next[V] + last[V]) / 2 : next[V];
       last = next;
-      return [Z[X], Z[Y], sum, i + 1];
+      return [Z[X], Z[Y], sum, i];
     });
     return coords2;
   }


### PR DESCRIPTION
Already the first commit 7e15867ed657cbd0a3b64a3a0a5d47c7f69ffb91 introducing tooltips did not render the first data point as tooltip-able. While there certainly was a reason for it, I cannot figure it out. Additionally, there is no such logic for bar tooltips (`getBars`) nor in the actual line graph (`getLine`). So, I propose to include the first point in the tooltips.

Fixes #879, #878 