### PR TITLE
fix: retain the last out-of-bounds state

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -70,6 +70,8 @@ export default class Graph {
       const key = Math.floor(Math.abs(interval));
       if (!res[key]) res[key] = [];
       res[key].push(item);
+    } else {
+      res[0] = [item];
     }
     return res;
   }


### PR DESCRIPTION
This re-insures the logic to keep the last known state before the start of our grah interval within the history. While this is not really correct, it allows for rendering steady-state-graphs.

This element was mistakenly removed in #881.

The piece of code relies on history being chronographical.

fixes #960