### PR TITLE
fix wrong default value for value_factor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | min_bound_range_secondary | number |  | v0.x.x | Applied after everything, makes sure there's a minimum range that the secondary Y-axis will have. Useful for not making small changes look large because of scale.
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
-| value_factor | number | 0 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
+| value_factor | number | 1 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
 | logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph
 
 


### PR DESCRIPTION
the default value for the parameter value_factor is documented as 0. But I think it should be 1.