### PR TITLE
add: state sum to show sum of available points

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -277,7 +277,7 @@ class MiniGraphCard extends LitElement {
   getEntityState(id) {
     const entityConfig = this.config.entities[id];
     if (this.config.show.state === 'sum') {
-      return this.points[id].reduce((sum, point) => sum + point[V], 0)
+      return this.points[id].reduce((sum, point) => sum + point[V], 0);
     } else if (this.config.show.state === 'last') {
       return this.points[id][this.points[id].length - 1][V];
     } else if (entityConfig.attribute) {

--- a/src/main.js
+++ b/src/main.js
@@ -276,7 +276,9 @@ class MiniGraphCard extends LitElement {
 
   getEntityState(id) {
     const entityConfig = this.config.entities[id];
-    if (this.config.show.state === 'last') {
+    if (this.config.show.state === 'sum') {
+      return this.points[id].reduce((sum, point) => sum + point[V], 0)
+    } else if (this.config.show.state === 'last') {
       return this.points[id][this.points[id].length - 1][V];
     } else if (entityConfig.attribute) {
       return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);


### PR DESCRIPTION
I wanted a way to show the default state of the graph as a sum of the available points rather than the current/last point.

This adds a new `sum` value for `state` which sums the available points. This does rely on the fix within #1075 for it to work as it expects `points` to always be defined.