### PR TITLE
fix: indicator style for the 1st state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.12.1](https://github.com/kalkih/mini-graph-card/compare/v0.12.0...v0.12.1) (2024-03-20)
+
+
+### Bug Fixes
+
+* tooltip interval start could be after end ([#1065](https://github.com/kalkih/mini-graph-card/issues/1065)) ([930ee39](https://github.com/kalkih/mini-graph-card/commit/930ee39f51744bc11f580f4198f579b5213371ca)), closes [#181](https://github.com/kalkih/mini-graph-card/issues/181)
+
 # [0.12.0](https://github.com/kalkih/mini-graph-card/compare/v0.11.0...v0.12.0) (2024-01-27)
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 2. Grab `mini-graph-card-bundle.js`:
 
   ```
-  $ wget https://github.com/kalkih/mini-graph-card/releases/download/v0.12.0/mini-graph-card-bundle.js
+  $ wget https://github.com/kalkih/mini-graph-card/releases/download/v0.12.1/mini-graph-card-bundle.js
   ```
 
 3. Add the resource reference as decribed below.
@@ -37,7 +37,7 @@ If you configure Lovelace via YAML, add a reference to `mini-graph-card-bundle.j
 
   ```yaml
   resources:
-    - url: /local/mini-graph-card-bundle.js?v=0.12.0
+    - url: /local/mini-graph-card-bundle.js?v=0.12.1
       type: module
   ```
 
@@ -60,7 +60,7 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 
   ```yaml
   resources:
-    - url: /local/mini-graph-card-bundle.js?v=0.12.0
+    - url: /local/mini-graph-card-bundle.js?v=0.12.1
       type: module
   ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-graph-card",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-graph-card",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A minimalistic and customizable graph card for Home Assistant Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/style.js
+++ b/src/style.js
@@ -168,6 +168,10 @@ const style = css`
     max-width: 100%;
     min-width: 0;
   }
+  .state > svg {
+    align-self: center;
+    border-radius: 100%;
+  }
   .state--small {
     font-size: .6em;
     margin-bottom: .6rem;


### PR DESCRIPTION
Consider the code:
```
type: custom:mini-graph-card
entities:
  - entity: sensor.xiaomi_cg_1_co2
    show_state: true
    show_indicator: true
  - entity: sensor.xiaomi_cg_2_co2
    show_state: true
    show_indicator: true
  - entity: sensor.mijia_300_1_co2
    show_state: true
    show_indicator: true
name: xxx
```
Currently an indicator for the 1st state is misaligned & square:

![изображение](https://github.com/kalkih/mini-graph-card/assets/71872483/5dac881e-34b7-434c-b9f2-bb515d5202cf)

After the fix:

![изображение](https://github.com/kalkih/mini-graph-card/assets/71872483/7b71af1f-9cd2-489f-bc25-9dd023a75cfc)

