### PR TITLE
fix: legend indicators respect entity attribute configuration

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -345,7 +345,7 @@ class MiniGraphCard extends LitElement {
             @click=${e => this.handlePopup(e, this.entity[entity.index])}
             @mouseenter=${() => this.setTooltip(entity.index, -1, this.getEntityState(entity.index), 'Current')}
             @mouseleave=${() => (this.tooltip = {})}>
-            ${this.renderIndicator(this.entity[entity.index].state, entity.index)}
+            ${this.renderIndicator(this.getEntityState(entity.index), entity.index)}
             <span class="ellipsis">${this.computeName(entity.index)}</span>
           </div>
         `)}


### PR DESCRIPTION
When using attributes for entity states, the line picks up the new state location and respects the color thresholds, however the legend indicators do not.

### Current behaivour
```yaml
entities:
  - entity: sensor.sensor_1
    attribute: attribute_1
    name: ' '
  - entity: sensor.sensor_2
    attribute: attribute_1
    name: ' '
# ...
```
<img width="448" alt="image" src="https://github.com/user-attachments/assets/44e2a163-66f3-488a-abc9-1b6a25c00db5">

### New behaviour
This updates the `renderIndicator()` function to use the existing `getEntityState()` which checks if an attribute has been configured, otherwise it falls back to the entity state.

<img width="449" alt="image" src="https://github.com/user-attachments/assets/4f40a2a6-5a85-4164-92e0-6b231e77b484">
