### PR TITLE
fix: name and icon color can use attributes

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,6 @@
 extends: airbnb-base
+env:
+  es2020: true
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,4 @@
 extends: airbnb-base
-env:
-  es2020: true
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/src/main.js
+++ b/src/main.js
@@ -233,7 +233,7 @@ class MiniGraphCard extends LitElement {
     const { icon, icon_adaptive_color } = this.config.show;
     return icon ? html`
       <div class="icon" loc=${this.config.align_icon}
-        style=${icon_adaptive_color ? `color: ${this.computeColor(this.tooltip.value ?? this.getEntityState(0), this.tooltip.entity ?? 0)};` : ''}>
+        style=${icon_adaptive_color ? `color: ${this.computeColor(this.tooltip.value !== undefined ? this.tooltip.value : this.getEntityState(0), this.tooltip.entity || 0)};` : ''}>
         <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
       </div>
     ` : '';
@@ -244,7 +244,7 @@ class MiniGraphCard extends LitElement {
     const name = this.tooltip.entity !== undefined
       ? this.computeName(this.tooltip.entity)
       : this.config.name || this.computeName(0);
-    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.computeColor(this.tooltip.value ?? this.getEntityState(0), this.tooltip.entity ?? 0)}};` : '';
+    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.computeColor(this.tooltip.value !== undefined ? this.tooltip.value : this.getEntityState(0), this.tooltip.entity || 0)}};` : '';
 
     return html`
       <div class="name flex">

--- a/src/main.js
+++ b/src/main.js
@@ -149,11 +149,6 @@ class MiniGraphCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (UPDATE_PROPS.some(prop => changedProps.has(prop))) {
-      this.color = this.computeColor(
-        this.tooltip.value !== undefined
-          ? this.tooltip.value : this.entity[0] && this.entity[0].state,
-        this.tooltip.entity || 0,
-      );
       return true;
     }
   }
@@ -238,7 +233,7 @@ class MiniGraphCard extends LitElement {
     const { icon, icon_adaptive_color } = this.config.show;
     return icon ? html`
       <div class="icon" loc=${this.config.align_icon}
-        style=${icon_adaptive_color ? `color: ${this.color};` : ''}>
+        style=${icon_adaptive_color ? `color: ${this.computeColor(this.tooltip.value ?? this.getEntityState(0), this.tooltip.entity ?? 0)};` : ''}>
         <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
       </div>
     ` : '';
@@ -249,7 +244,7 @@ class MiniGraphCard extends LitElement {
     const name = this.tooltip.entity !== undefined
       ? this.computeName(this.tooltip.entity)
       : this.config.name || this.computeName(0);
-    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.color};` : '';
+    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.computeColor(this.tooltip.value ?? this.getEntityState(0), this.tooltip.entity ?? 0)}};` : '';
 
     return html`
       <div class="name flex">

--- a/src/main.js
+++ b/src/main.js
@@ -244,7 +244,7 @@ class MiniGraphCard extends LitElement {
     const name = this.tooltip.entity !== undefined
       ? this.computeName(this.tooltip.entity)
       : this.config.name || this.computeName(0);
-    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.computeColor(this.tooltip.value !== undefined ? this.tooltip.value : this.getEntityState(0), this.tooltip.entity || 0)}};` : '';
+    const color = this.config.show.name_adaptive_color ? `opacity: 1; color: ${this.computeColor(this.tooltip.value !== undefined ? this.tooltip.value : this.getEntityState(0), this.tooltip.entity || 0)};` : '';
 
     return html`
       <div class="name flex">


### PR DESCRIPTION
fixes #1129 

This also refactors to use `computeColor` everytime, instead of using `this.color`. I am not 100% sure, it is the best way. But I was puzzled by the way `this.color` was set in `shouldUpdate()`, which we do not ever do anywhere else... Maybe @jlsjonas can advise on what would be better. Or just more commonly used.