### PR TITLE
fix: name and icon color respect attribute choice

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -151,7 +151,7 @@ class MiniGraphCard extends LitElement {
     if (UPDATE_PROPS.some(prop => changedProps.has(prop))) {
       this.color = this.computeColor(
         this.tooltip.value !== undefined
-          ? this.tooltip.value : this.entity[0] && this.entity[0].state,
+          ? this.tooltip.value : this.getEntityState(0),
         this.tooltip.entity || 0,
       );
       return true;


### PR DESCRIPTION
fixes #1129 

This is the more minimally invasive method I hadn't thought of before. It will also stick to not calculating the color twice, which is more efficient, I guess. See https://github.com/kalkih/mini-graph-card/issues/1116#issuecomment-2313216516.