### PR TITLE
fix: more intuitive min_bound_range behavior

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -819,10 +819,16 @@ class MiniGraphCard extends LitElement {
 
       // Doesn't matter if minBoundRange is NaN because this will be false if so
       if (diff > 0) {
-        boundary = [
-          boundary[0] - diff / 2,
-          boundary[1] + diff / 2,
-        ];
+        if (min !== undefined && max === undefined) {
+          boundary[1] += diff;
+        } else if (max !== undefined && min === undefined) {
+          boundary[0] -= diff;
+        } else {
+          boundary = [
+            boundary[0] - diff / 2,
+            boundary[1] + diff / 2,
+          ];
+        }
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -820,7 +820,7 @@ class MiniGraphCard extends LitElement {
       // Doesn't matter if minBoundRange is NaN because this will be false if so
       if (diff > 0) {
         const weights = [
-          min !== undefined && min[0] !== '~' ? 0 : (max === undefined ? 0 : 1),
+          min !== undefined && min[0] !== '~' || max === undefined ? 0 : 1,
           max !== undefined && max[0] !== '~' ? 0 : (min === undefined ? 0 : 1),
         ];
         const sum = weights[0] + weights[1];

--- a/src/main.js
+++ b/src/main.js
@@ -820,8 +820,8 @@ class MiniGraphCard extends LitElement {
       // Doesn't matter if minBoundRange is NaN because this will be false if so
       if (diff > 0) {
         const weights = [
-          min !== undefined && min[0] !== '~' ? 0 : 1,
-          max !== undefined && max[0] !== '~' ? 0 : 1,
+          min !== undefined && min[0] !== '~' ? 0 : (max === undefined && min !== undefined ? 0 : 1),
+          max !== undefined && max[0] !== '~' ? 0 : (min === undefined && min !== undefined ? 0 : 1),
         ];
         const sum = weights[0] + weights[1];
         if (sum > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -820,8 +820,8 @@ class MiniGraphCard extends LitElement {
       // Doesn't matter if minBoundRange is NaN because this will be false if so
       if (diff > 0) {
         const weights = [
-          min !== undefined && min[0] !== '~' ? 0 : (max === undefined && min !== undefined ? 0 : 1),
-          max !== undefined && max[0] !== '~' ? 0 : (min === undefined && min !== undefined ? 0 : 1),
+          min !== undefined && min[0] !== '~' ? 0 : (max === undefined ? 0 : 1),
+          max !== undefined && max[0] !== '~' ? 0 : (min === undefined ? 0 : 1),
         ];
         const sum = weights[0] + weights[1];
         if (sum > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -821,7 +821,7 @@ class MiniGraphCard extends LitElement {
       if (diff > 0) {
         const weights = [
           min !== undefined && min[0] !== '~' || max === undefined ? 0 : 1,
-          max !== undefined && max[0] !== '~' ? 0 : (min === undefined ? 0 : 1),
+          max !== undefined && max[0] !== '~' || min === undefined ? 0 : 1,
         ];
         const sum = weights[0] + weights[1];
         if (sum > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -819,10 +819,16 @@ class MiniGraphCard extends LitElement {
 
       // Doesn't matter if minBoundRange is NaN because this will be false if so
       if (diff > 0) {
-        if (min !== undefined && max === undefined) {
-          boundary[1] += diff;
-        } else if (max !== undefined && min === undefined) {
-          boundary[0] -= diff;
+        const weights = [
+          min !== undefined && min[0] !== '~' ? 0 : 1,
+          max !== undefined && max[0] !== '~' ? 0 : 1,
+        ];
+        const sum = weights[0] + weights[1];
+        if (sum > 0) {
+          boundary = [
+            boundary[0] - diff * weights[0] / sum,
+            boundary[1] + diff * weights[1] / sum,
+          ];
         } else {
           boundary = [
             boundary[0] - diff / 2,


### PR DESCRIPTION
This is a quick and simple change to the behavior of the min_bound_range option, to make it more intuitive to use and more predictable to new users.

Old behavior: it ignores every other bound option and overrides it

New behavior: If lower bound is set, it increases the range "upwards". If upper bound is set, it increases the range "downwards". 
If no bound is set, or if both upper AND lower bounds are set, old behavior is used.

This was mentioned in #1047, not an essential groundbreaking feature but it was a simple enough fix that I gave it a try. Tested on my machine.

This is my second ever PR so go easy on me please :)

Did I use the correct semantic title?