### PR TITLE
fix: height in grid

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -4,6 +4,7 @@ const style = css`
   :host {
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
   ha-card {
     flex-direction: column;

--- a/src/style.js
+++ b/src/style.js
@@ -1,17 +1,13 @@
 import { css } from 'lit-element';
 
 const style = css`
-  :host {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
   ha-card {
     flex-direction: column;
     flex: 1;
     padding: 16px 0;
     position: relative;
     overflow: hidden;
+    height: 100%;
   }
   ha-card > div {
     padding: 0px 16px 16px 16px;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/db197a9c-00c3-49e2-abf0-43310dc58417)
```
  - type: grid
    columns: 2
    square: false
    title: not square
    cards:
      - &ref_graph_card
        type: custom:mini-graph-card
        entities:
          - entity: sensor.xiaomi_cg_1_co2
      - &ref_entity_card
        type: entity
        entity: sun.sun
      - *ref_entity_card
      - *ref_graph_card

  - type: grid
    columns: 2
    square: true
    title: square
    cards:
      - *ref_graph_card
      - *ref_entity_card
      - *ref_entity_card
      - *ref_graph_card
```
After:
![image](https://github.com/user-attachments/assets/772f3b9f-b791-442d-9481-ecdb18bbdb9f)


Probably may be useful in case of using a new experimental "sections" views (honestly, do not care about this still beta feature).