### PR TITLE
fix(graph): gradient color fallback

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -166,6 +166,8 @@ export default class Graph {
       } else if (stop.value < this._min && arr[index - 1]) {
         const factor = (arr[index - 1].value - this._min) / (arr[index - 1].value - stop.value);
         color = interpolateColor(arr[index - 1].color, stop.color, factor);
+      } else {
+        color = stop.color;
       }
       let offset;
       if (scale <= 0) {


### PR DESCRIPTION
Added a fallback to use the `stop.color` when threshold values are outside the visible range. This prevents undefined colors from causing unexpected graph rendering behavior, such as turning blue near the edges.