### PR TITLE
fix: legend unit percent w/o whitespace

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -349,12 +349,11 @@ class MiniGraphCard extends LitElement {
     const { show_legend_state = false } = this.config.entities[index];
 
     if (show_legend_state) {
-      let uom = this.computeUom(index);
-      if (uom === '%') {
-        legend += ` (${this.computeState(state)}${uom})`;
+      if (this.computeUom(index) === '%') {
+        legend += ` (${this.computeState(state)}${this.computeUom(index)})`;
       }
       else {
-        legend += ` (${this.computeState(state)} ${uom})`;
+        legend += ` (${this.computeState(state)} ${this.computeUom(index)})`;
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -349,7 +349,14 @@ class MiniGraphCard extends LitElement {
     const { show_legend_state = false } = this.config.entities[index];
 
     if (show_legend_state) {
-      legend += ` (${this.computeState(state)} ${this.computeUom(index)})`;
+      let uom = this.computeUom(index);
+      let state = this.computeState(state);
+      if (uom === '%') {
+        legend += ` (${state}${uom})`;
+      }
+      else {
+        legend += ` (${state} ${uom})`;
+      }
     }
 
     return legend;

--- a/src/main.js
+++ b/src/main.js
@@ -350,12 +350,11 @@ class MiniGraphCard extends LitElement {
 
     if (show_legend_state) {
       let uom = this.computeUom(index);
-      let state = this.computeState(state);
       if (uom === '%') {
-        legend += ` (${state}${uom})`;
+        legend += ` (${this.computeState(state)}${uom})`;
       }
       else {
-        legend += ` (${state} ${uom})`;
+        legend += ` (${this.computeState(state)} ${uom})`;
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -351,8 +351,7 @@ class MiniGraphCard extends LitElement {
     if (show_legend_state) {
       if (this.computeUom(index) === '%') {
         legend += ` (${this.computeState(state)}${this.computeUom(index)})`;
-      }
-      else {
+      } else {
         legend += ` (${this.computeState(state)} ${this.computeUom(index)})`;
       }
     }


### PR DESCRIPTION
A small fix:
if UoM = "%", then do not use a whitespace as a delimeter.