### PR TITLE
fix: graph loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ All properties are optional.
 | labels_secondary | `hover` | `true` / `false` / `hover` | Display secondary Y-axis labels.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.
 | icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity color.
+| loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
+
 
 #### Line color object
 See [dynamic line color](#dynamic-line-color) for example usage.

--- a/src/const.js
+++ b/src/const.js
@@ -43,6 +43,7 @@ const DEFAULT_SHOW = {
   legend: true,
   fill: true,
   points: 'hover',
+  loading_indicator: true,
 };
 
 const X = 0;

--- a/src/const.js
+++ b/src/const.js
@@ -43,7 +43,6 @@ const DEFAULT_SHOW = {
   legend: true,
   fill: true,
   points: 'hover',
-  loading_indicator: true,
 };
 
 const X = 0;

--- a/src/main.js
+++ b/src/main.js
@@ -323,15 +323,15 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    const ready =
-      (this.entity[0] &&
-        !this.Graph.some(
-          element,
-          (index) =>
-            element._history === undefined &&
-            this.config.entities[index].show_graph !== false,
-        )) ||
-      this.config.show.loading_indicator !== true;
+    const ready = (this.entity[0] &&
+                    !this.Graph.some(
+                      element,
+                      (index) =>
+                        element._history === undefined &&
+                        this.config.entities[index].show_graph !== false,
+                    )
+                  )
+                  || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -324,8 +324,7 @@ class MiniGraphCard extends LitElement {
 
   renderGraph() {
     const ready = (this.entity[0] && !this.Graph.some(
-      element,
-      index => element._history === undefined && this.config.entities[index].show_graph !== false
+      (element, index) => element._history === undefined && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -325,9 +325,9 @@ class MiniGraphCard extends LitElement {
   renderGraph() {
     const ready = (this.entity[0] && !this.Graph.some(
       element,
-      index => element._history === undefined && this.config.entities[index].show_graph !== false)
-      )
-      || this.config.show.loading_indicator !== true;
+      index => element._history === undefined && this.config.entities[index].show_graph !== false
+    ))
+    || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -323,8 +323,14 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    const ready = this.entity[0] && this.Graph[0]._history !== undefined;
-
+    let historyLoadingIncomplete = 0;
+    this.Graph.forEach((graph, index) => {
+      if (graph._history === undefined
+          && this.config.entities[index].show_graph !== false)
+        historyLoadingIncomplete += 1;
+    });
+    const ready = (this.entity[0] && (historyLoadingIncomplete === 0))
+                    || (this.config.show.loading_indicator !== true);
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -327,7 +327,7 @@ class MiniGraphCard extends LitElement {
       (element, index) => element._history === undefined
       && this.config.entities[index].show_graph !== false,
     ))
-    || this.config.show.loading_indicator !== true;
+    || this.config.show.loading_indicator === false;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -325,7 +325,7 @@ class MiniGraphCard extends LitElement {
   renderGraph() {
     const ready = (this.entity[0] && !this.Graph.some(
       element,
-      (index) => element._history === undefined && this.config.entities[index].show_graph !== false)
+      index => element._history === undefined && this.config.entities[index].show_graph !== false)
       )
       || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -323,14 +323,15 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    let historyLoadingIncomplete = 0;
-    this.Graph.forEach((graph, index) => {
-      if (graph._history === undefined
-          && this.config.entities[index].show_graph !== false)
-        historyLoadingIncomplete += 1;
-    });
-    const ready = (this.entity[0] && (historyLoadingIncomplete === 0))
-                    || (this.config.show.loading_indicator !== true);
+    const ready =
+      (this.entity[0] &&
+        !this.Graph.some(
+          element,
+          (index) =>
+            element._history === undefined &&
+            this.config.entities[index].show_graph !== false,
+        )) ||
+      this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -327,8 +327,8 @@ class MiniGraphCard extends LitElement {
                    && !this.Graph.some(
                       element,
                       (index) =>
-                        element._history === undefined &&
-                        this.config.entities[index].show_graph !== false,
+                      element._history === undefined &&
+                      this.config.entities[index].show_graph !== false,
                     )
                   )
                   || this.config.show.loading_indicator !== true;

--- a/src/main.js
+++ b/src/main.js
@@ -325,11 +325,11 @@ class MiniGraphCard extends LitElement {
   renderGraph() {
     const ready = (this.entity[0]
                    && !this.Graph.some(
-                        element,
-                        (index) =>
-                          element._history === undefined &&
-                          this.config.entities[index].show_graph !== false,
-                      )
+                      element,
+                      (index) =>
+                        element._history === undefined &&
+                        this.config.entities[index].show_graph !== false,
+                    )
                   )
                   || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -324,7 +324,8 @@ class MiniGraphCard extends LitElement {
 
   renderGraph() {
     const ready = (this.entity[0] && !this.Graph.some(
-      (element, index) => element._history === undefined && this.config.entities[index].show_graph !== false,
+      (element, index) => element._history === undefined
+      && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -323,13 +323,11 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    const ready = (this.entity[0]
-                   && !this.Graph.some(
-                      element,
-                      (index) =>
-                      element._history === undefined &&
-                      this.config.entities[index].show_graph !== false,
-                    )
+    const ready = (this.entity[0] && !this.Graph.some(
+                    element,
+                    (index) =>
+                    element._history === undefined &&
+                    this.config.entities[index].show_graph !== false)
                   )
                   || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -323,13 +323,13 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    const ready = (this.entity[0] &&
-                    !this.Graph.some(
-                      element,
-                      (index) =>
-                        element._history === undefined &&
-                        this.config.entities[index].show_graph !== false,
-                    )
+    const ready = (this.entity[0]
+                   && !this.Graph.some(
+                        element,
+                        (index) =>
+                          element._history === undefined &&
+                          this.config.entities[index].show_graph !== false,
+                      )
                   )
                   || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -324,12 +324,10 @@ class MiniGraphCard extends LitElement {
 
   renderGraph() {
     const ready = (this.entity[0] && !this.Graph.some(
-                    element,
-                    (index) =>
-                    element._history === undefined &&
-                    this.config.entities[index].show_graph !== false)
-                  )
-                  || this.config.show.loading_indicator !== true;
+      element,
+      (index) => element._history === undefined && this.config.entities[index].show_graph !== false)
+      )
+      || this.config.show.loading_indicator !== true;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`


### PR DESCRIPTION
1. Added `show::loading_indicator` option (for users who do not like it).
2. Fix for https://github.com/kalkih/mini-graph-card/issues/1195.