### PR TITLE
fix: card height in grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
-| height | number | `150` | v0.0.1 | Set a custom height of the graph. Disregarded, if the card has a fixed size already, e.g. in sections/grid view.
+| height | number | `150` | v0.0.1 | Set a custom height of the graph. Disregarded, if the card has a fixed size already, e.g. in sections view or grid/horizontal-stack card.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
-| height | number | `150` | v0.0.1 | Set a custom height of the line graph.
+| height | number | `150` | v0.0.1 | Set a custom height of the graph. Disregarded, if the card has a fixed size already, e.g. in sections/grid view.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.

--- a/src/main.js
+++ b/src/main.js
@@ -429,6 +429,7 @@ class MiniGraphCard extends LitElement {
         stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
         stroke=${'white'}
         stroke-width=${this.config.line_width}
+        vector-effect='non-scaling-stroke'
         d=${this.line[i]}
       />`;
 

--- a/src/main.js
+++ b/src/main.js
@@ -429,7 +429,6 @@ class MiniGraphCard extends LitElement {
         stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
         stroke=${'white'}
         stroke-width=${this.config.line_width}
-        vector-effect='non-scaling-stroke'
         d=${this.line[i]}
       />`;
 
@@ -443,16 +442,24 @@ class MiniGraphCard extends LitElement {
   renderSvgPoint(point, i) {
     const color = this.gradient[i] ? this.computeColor(point[V], i) : 'inherit';
     return svg`
-      <circle
-        class='line--point'
-        ?inactive=${this.tooltip.index !== point[3]}
-        style=${`--mcg-hover: ${color};`}
+    <g
+      class='line--point--group'
+      ?inactive=${this.tooltip.index !== point[3]}
+      @mouseover=${() => this.setTooltip(i, point[3], point[V])}
+      @mouseout=${() => (this.tooltip = {})}
+    >
+      <line
+        class='line--point--border'
+        x1=${point[X]} y1=${point[Y]} x2=${point[X]} y2=${point[Y]}
+        stroke-linecap="round" stroke-width=${this.config.line_width * 2}
         stroke=${color}
-        fill=${color}
-        cx=${point[X]} cy=${point[Y]} r=${this.config.line_width}
-        @mouseover=${() => this.setTooltip(i, point[3], point[V])}
-        @mouseout=${() => (this.tooltip = {})}
       />
+      <line
+        class='line--point--fill'
+        x1=${point[X]} y1=${point[Y]} x2=${point[X]} y2=${point[Y]}
+        stroke-linecap="round" stroke-width=${this.config.line_width}
+      />
+    </g>
     `;
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -329,11 +329,11 @@ class MiniGraphCard extends LitElement {
       <div class="graph">
         ${ready ? html`
             <div class="graph__container">
-              ${this.renderLabels()}
-              ${this.renderLabelsSecondary()}
               <div class="graph__container__svg">
                 ${this.renderSvg()}
               </div>
+              ${this.renderLabels()}
+              ${this.renderLabelsSecondary()}
             </div>
             ${this.renderLegend()}
         ` : html`
@@ -539,6 +539,7 @@ class MiniGraphCard extends LitElement {
     const { height } = this.config;
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
+        preserveAspectRatio='none'
         @click=${e => e.stopPropagation()}>
         <g>
           <defs>

--- a/src/style.js
+++ b/src/style.js
@@ -232,6 +232,7 @@ const style = css`
   }
   .graph {
     flex: auto;
+    min-height: 0;
     align-self: flex-end;
     box-sizing: border-box;
     display: flex;

--- a/src/style.js
+++ b/src/style.js
@@ -4,6 +4,7 @@ const style = css`
   :host {
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
   ha-card {
     flex-direction: column;
@@ -234,6 +235,7 @@ const style = css`
     right: 0;
   }
   .graph {
+    flex: auto;
     align-self: flex-end;
     box-sizing: border-box;
     display: flex;
@@ -245,10 +247,13 @@ const style = css`
     display: flex;
     flex-direction: row;
     position: relative;
+    height: 100%;
   }
   .graph__container__svg {
     cursor: default;
-    flex: 1;
+    position: relative;
+    width: 100%;
+    height: 100%;
   }
   svg {
     overflow: hidden;

--- a/src/style.js
+++ b/src/style.js
@@ -1,17 +1,13 @@
 import { css } from 'lit-element';
 
 const style = css`
-  :host {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
   ha-card {
     flex-direction: column;
     flex: 1;
     padding: 16px 0;
     position: relative;
     overflow: hidden;
+    height: 100%;
   }
   ha-card > div {
     padding: 0px 16px 16px 16px;

--- a/src/style.js
+++ b/src/style.js
@@ -273,6 +273,22 @@ const style = css`
   .line[anim="false"] {
     animation: pop .25s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;
   }
+  .line {
+    vector-effect: non-scaling-stroke;
+  }
+  .line--point--group {
+    cursor: pointer;
+  }
+  .line--point--border {
+    vector-effect: non-scaling-stroke;
+  }
+  .line--point--fill {
+    stroke: var(--primary-background-color, white);
+    vector-effect: non-scaling-stroke;
+  }
+  .line--point--group:hover .line--point--fill {
+    visibility: hidden;
+  }
   .line--points[inactive],
   .line--rect[inactive],
   .fill--rect[inactive] {
@@ -280,16 +296,8 @@ const style = css`
     animation: none !important;
     transition: all .15s !important;
   }
-  .line--points[tooltip] .line--point[inactive] {
+  .line--points[tooltip] .line--point--group[inactive] {
     opacity: 0;
-  }
-  .line--point {
-    cursor: pointer;
-    fill: var(--primary-background-color, white);
-    stroke-width: inherit;
-  }
-  .line--point:hover {
-    fill: var(--mcg-hover, inherit) !important;
   }
   .bars {
     animation: pop .25s cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -304,8 +312,9 @@ const style = css`
     opacity: .5;
     cursor: pointer;
   }
-  ha-card[gradient] .line--point:hover {
-    fill: var(--primary-text-color, white);
+  ha-card[gradient] .line--point--group:hover .line--point--fill {
+    visibility: unset;
+    stroke: var(--primary-text-color, white);
   }
   path,
   .line--points,


### PR DESCRIPTION
This is my take on the sections/grid issue. :-)

This changes the card height to occupy the assigned height in grid/sections view. The Graph will be stretched to fill this space! That means, its aspect ration will change. Change the `height` option to make it look better. See this example:
<img width="348" alt="image" src="https://github.com/user-attachments/assets/b7bff748-916c-4333-844f-c7430a2344d9" />

I consider this better than simply fixing the card height, because the card remains with lots of empty space in this case. If we fill the space, the default look will be nicer. Here's how it looks, if only the card height is fixed:
<img width="175" alt="image" src="https://github.com/user-attachments/assets/06b2ca2d-1324-4a9f-aeb6-bb70017ca2fb" />

Here's how it is done technically:

* :host.height = 100%
  => fixes height of entire card to fill space, if there is a defined space
* graph.flex = auto
  => assigns remaining space in card to the graph itself
* graph_container.height = 100%
  => makes the container fill the entire space
* graph__container__svg:
  .position=relative
  .width=100%
  .height=100%
  => makes the container use the entire space. Not only in flex width.
* The relative positioning changes the z-order of the graph and the labels. So, this is fixed in the main source code.
* The SVG also is freed aspect-ratio-wise, otherwise it could not fill the entire space.