### PR TITLE
feat: add "tooltip--label" class for a static label

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -313,7 +313,7 @@ class MiniGraphCard extends LitElement {
     return html`
       <div class="state__time">
         ${this.tooltip.label ? html`
-          <span>${this.tooltip.label}</span>
+          <span class="tooltip--label">${this.tooltip.label}</span>
         ` : html`
           <span>${this.tooltip.time[0]}</span> -
           <span>${this.tooltip.time[1]}</span>


### PR DESCRIPTION
Currently a "Current" text is shown when some entity is selected in legend:
![image](https://github.com/user-attachments/assets/1b1da9cf-4c3e-4e01-93fe-c7e87c2e67b7)

It is hard-coded in English.
[Also, there is a proposal to allow hiding this label.](https://github.com/kalkih/mini-graph-card/issues/1201)

What we can do now:
1. Add a class for this label.
2. If needed - a user may hide it by card-mod.

In future we need to add:
-- either a config option for this text,
-- (better imho) or localized text for "Current".
Assume one day we will add a UI for the card. Then we will need to localize labels in this UI, so this localized text for "Current" could be a part of this localization.

And even in this case this added class could be useful for card-modders.
Example:
I want to show "start time - end time" labels of red color & hide the "current" label:
(untested code below)
```
card_mod:
  ...
  .state__time span:not(.tooltip--label) { color: red; }
  .state__time span.tooltip--label { display: none; }
```