### PR TITLE
feat: dynamic time line

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -559,11 +559,10 @@ class MiniGraphCard extends LitElement {
           if (diffInMinutes > 0 && diffInMinutes < minutesInGraph) {
             const startDate = new Date(startTime);
             const x = graphWidth - graphWidth / minutesInGraph * diffInMinutes;
-            lines.push(svg`<line x1=${x} y1="0" x2=${x} y2=${height - 12} 
-              stroke="grey" 
-              stroke-width=${this.isMidnight(hour, minutes) ? '2' : '1'} 
-              stroke-dasharray=${this.isMidnight(hour, minutes) ? '0' : '10,5'}
-              /><text x=${x} y=${height - 2} font-size="10" fill="grey" text-anchor="middle">
+            lines.push(svg`<line class="line-${time.replace(':', '-')}" x1=${x} y1="0" x2=${x} y2=${height - 12} 
+              stroke="grey" stroke-width="2" />
+              <text class="text-${time.replace(':', '-')}" x=${x} y=${height - 2} 
+              font-size="10" fill="grey" text-anchor="middle">
               ${this.isMidnight(hour, minutes)
     ? `${this.zeroPad(startDate.getDate())}-${this.zeroPad(startDate.getMonth() + 1)}`
     : time}</text>`);

--- a/src/main.js
+++ b/src/main.js
@@ -538,11 +538,64 @@ class MiniGraphCard extends LitElement {
     return svg`<g class='bars' ?anim=${this.config.animate}>${items}</g>`;
   }
 
+  renderTimeLines() {
+    const { height, hours_to_show, show } = this.config;
+
+    if (!show.time_line) return;
+    const graphWidth = 500;
+    const minutesInGraph = hours_to_show * 60;
+
+    const timeRegex = /^\d{1,2}:\d{2}$/;
+    const lines = [];
+    const endTime = new Date();
+    show.time_line.forEach((time) => {
+      if (timeRegex.test(time)) {
+        const [hour, minutes] = time.split(':');
+        let diffInMinutes = 0;
+        let day = 0;
+        while (diffInMinutes < minutesInGraph) {
+          const startTime = this.createStartTime(day, hour, minutes);
+          diffInMinutes = Math.floor((endTime - startTime) / 1000 / 60);
+          if (diffInMinutes > 0 && diffInMinutes < minutesInGraph) {
+            const startDate = new Date(startTime);
+            const x = graphWidth - graphWidth / minutesInGraph * diffInMinutes;
+            lines.push(svg`<line x1=${x} y1="0" x2=${x} y2=${height - 12} 
+              stroke="grey" 
+              stroke-width=${this.isMidnight(hour, minutes) ? '2' : '1'} 
+              stroke-dasharray=${this.isMidnight(hour, minutes) ? '0' : '10,5'}
+              /><text x=${x} y=${height - 2} font-size="10" fill="grey" text-anchor="middle">
+              ${this.isMidnight(hour, minutes)
+    ? `${this.zeroPad(startDate.getDate())}-${this.zeroPad(startDate.getMonth() + 1)}`
+    : time}</text>`);
+          }
+          day += 1;
+        }
+      }
+    });
+
+    return svg`<g>${lines}</g>`;
+  }
+
+  zeroPad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  isMidnight(hour, minutes) {
+    return (hour === '0' || hour === '00') && minutes === '00';
+  }
+
+  createStartTime(day, hour, minute) {
+    const userTime = new Date();
+    userTime.setDate(userTime.getDate() - day);
+    return userTime.setHours(hour, minute);
+  }
+
   renderSvg() {
     const { height } = this.config;
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
         @click=${e => e.stopPropagation()}>
+        ${this.renderTimeLines()}
         <g>
           <defs>
             ${this.renderSvgGradient(this.gradient)}


### PR DESCRIPTION
In my project I want to have some daily times marked for better graph readibility. Or for long term graphs it might be difficult to realize some specific values in time as the graph does not support it.

My sollution adds user specific times as list in configuration that are displayed in graph.
![timeLine1](https://github.com/user-attachments/assets/07c4f58c-0498-4c11-a1c5-a205ea218e62)

These time lines are tightly coupled with their values, so their position is dynamically rendered along with the graph.
The styling is fully customized by user by <card_mod> as per css class.
Time value could be disabled as well.
On midnight time (when user setup 00:00), graph displays a new date value instead of a time.

![timeLineCustom24hours](https://github.com/user-attachments/assets/be7da53e-33b3-403d-be62-c3e977a9cfe3)

Time lines are applied for every day in the graph so long term graphs are supported
![timeLine48hours](https://github.com/user-attachments/assets/1471c9d5-7b18-40ff-a0f5-15f8271bf37d)

The solution requires new config variable 'time_line' with a list of expected times in format HH:MM under the 'show' option as follows:

```
    - type: custom:mini-graph-card
                entities:
                  - entity: sensor.grid_power_negative
                  - entity: sensor.solar_production
                    color: "#ffee3A"
                color_thresholds_transition: hard
                color_thresholds:
                  - value: -10000
                    color: "#488fc2"
                  - value: 0
                    color: "#8353d1"
                hours_to_show: 24
                line_width: 2
                show:
                  state: false
                  name: false
                  icon: false
                  legend: false
                  time_line:
                    - '00:00'
                    - '12:00'
                points_per_hour: 4
                card_mod:
                  style: |
                    ha-card svg .line-12-00 {
                      stroke-dasharray: 10,5;
                      stroke-width: 1px;
                    }
                    ha-card svg .line-00-00 {
                      stroke: red;
                      stroke-width: 2px;
                    }
                    ha-card svg .text-00-00 {
                      fill: red;
                    }

``` 