### PR TITLE
feat: Add more options to customize a number format, use default accuracy & format settings

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,6 @@
 extends: airbnb-base
+parserOptions:
+  ecmaVersion: latest
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -10,6 +10,7 @@ rules:
   class-methods-use-this: 0
   no-nested-ternary: 0
   camelcase: 0
+  import/prefer-default-export: 0
 globals:
   window: true
   Event: true

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,6 @@
 extends: airbnb-base
 parserOptions:
-  ecmaVersion: latest
+  ecmaVersion: 2019
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,6 @@
 extends: airbnb-base
 parserOptions:
-  ecmaVersion: 2019
+  ecmaVersion: 2020
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,4 @@
 extends: airbnb-base
-parserOptions:
-  ecmaVersion: 2020
 rules:
   no-else-return: 0
   no-underscore-dangle: 0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 2. Grab `mini-graph-card-bundle.js`:
 
   ```console
-  $ wget https://github.com/kalkih/mini-graph-card/releases/download/v0.12.1/mini-graph-card-bundle.js
+  $ wget https://github.com/kalkih/mini-graph-card/releases/download/v0.12.1/mini-graph-card-bundle.js
   ```
 
 3. Add the resource reference as decribed below.
@@ -98,7 +98,8 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).
 | color_thresholds_transition | string | `smooth` | v0.4.3 | Color threshold transition, `smooth` or `hard`.
-| decimals | integer |  | v0.0.9 | Specify the exact number of decimals to show for states.
+| decimals | integer |  | v0.0.9 | Specify the exact number of decimals to show for number values, see [Number format](#number-format).
+| decimals_secondary | integer |  | v0.13.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
 | hour24 | boolean | `false` | v0.2.1 | Set to `true` to display times in 24-hour format.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
 | font_size_header | number | `14` | v0.3.1 | Adjust the font size of the header, size in pixels.
@@ -129,6 +130,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config.
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
+| decimals | integer |    | Override the exact number of decimals to show for number values, see [Number format](#number-format).
 | show_state | boolean |         | Display the current state.
 | show_legend_state | boolean |  false  | Display the current state as part of the legend.
 | show_indicator | boolean |         | Display a color indicator next to the state, (only when more than two states are visible).
@@ -138,7 +140,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | show_points | boolean |         | Set to false to hide the points.
 | show_legend | boolean |         | Set to false to turn hide from the legend.
 | state_adaptive_color | boolean |         | Make the color of the state adapt to the entity color.
-| y_axis | string |         | If 'secondary', displays using the secondary y-axis on the right.
+| y_axis | string |         | If 'secondary', displays using the secondary Y-axis on the right.
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
 
@@ -254,6 +256,26 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `sum` | v0.9.2 |
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
+
+### Number format
+
+Options `decimals` defined "card-wide" and/or for some entity are used to set an exact number of decimals according to the following rules:
+1. For states:
+- if none `decimals` option is defined - a default presentation is used;
+- if "card-wide" `decimals` is defined - this value is used;
+- if `decimals` for some entity is defined - this value is used for this entity.
+2. For extrema & average values:
+- if none `decimals` option is defined - a default presentation is used;
+- if "card-wide" `decimals` is defined - this value is used;
+- if `decimals` is defined for the 1st entity - this value is used.
+3. For primary Y-axis labels:
+- if "card-wide" `decimals` option is not defined - a default presentation is used;
+- otherwise - this value is used.
+4. For secondary Y-axis labels:
+- if "card-wide" `decimals` & `decimals_secondary` option are not defined - a default presentation is used;
+- if "card-wide" `decimals` option is defined - this value is used;
+- if "card-wide" `decimals_secondary` option is defined - this value is used.
+  
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.
@@ -393,11 +415,11 @@ color_thresholds:
     color: "#c0392b"
 ```
 
-#### Alternate y-axis
-Have one or more series plot on a separate y-axis, which appears on the right side of the graph. This example also
+#### Alternate Y-axis
+Have one or more series plot on a separate Y-axis, which appears on the right side of the graph. This example also
 shows turning off the line, points and legend.
 
-![Alternate y-axis](https://user-images.githubusercontent.com/373079/60764115-63cf2780-a0c6-11e9-8b9a-97fc47161180.png)
+![Alternate Y-axis](https://user-images.githubusercontent.com/373079/60764115-63cf2780-a0c6-11e9-8b9a-97fc47161180.png)
 
 ```yaml
 type: custom:mini-graph-card
@@ -495,6 +517,7 @@ state_map:
   - value: "on"
     label: Detected
 ```
+
 
 #### Showing additional info on the card
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 - if none `decimals` option is defined - a default presentation (see a note below) is used;
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` for some entity is defined - this value is used for this entity.
-2. For extrema & average values:
+2. For extrema & average values (supported for the 1st entity only):
 - if none `decimals` option is defined - a default presentation is used;
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` is defined for the 1st entity - this value is used.

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 A "default presentation" refers to a default look in HA:
 1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).
 2. For an attribute value (also for extrema & average): default HA settings are used (for template sensors - a user-defined accuracy set in jinja templates is used).
-3. For Y-axis labels: TO BE DETAILED
+3. For Y-axis labels: "maximum 2 decimals" accuracy is used.
 And for all values, HA number format settings (like `xxxx.xx` or `x xxx.x` or `x,xxx.x`) are used.
 
 ### Theme variables

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).
 | color_thresholds_transition | string | `smooth` | v0.4.3 | Color threshold transition, `smooth` or `hard`.
 | decimals | integer |  | v0.0.9 | Specify the exact number of decimals to show for number values, see [Number format](#number-format).
-| decimals_secondary | integer |  | v0.13.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
+| decimals_secondary_labels | integer |  | v0.13.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
 | hour24 | boolean | `false` | v0.2.1 | Set to `true` to display times in 24-hour format.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
 | font_size_header | number | `14` | v0.3.1 | Adjust the font size of the header, size in pixels.
@@ -275,9 +275,9 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 - if "card-wide" `decimals` option is not defined - a default presentation is used;
 - otherwise - this value is used.
 4. For secondary Y-axis labels:
-- if "card-wide" `decimals` & `decimals_secondary` options are not defined - a default presentation is used;
+- if "card-wide" `decimals` & `decimals_secondary_labels` options are not defined - a default presentation is used;
 - if "card-wide" `decimals` option is defined - this value is used;
-- if "card-wide" `decimals_secondary` option is defined - this value is used.
+- if "card-wide" `decimals_secondary_labels` option is defined - this value is used.
   
 A "default presentation" refers to a default look in HA:
 1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 
 Options `decimals` defined "card-wide" and/or for some entity are used to set an exact number of decimals according to the following rules:
 1. For states:
-- if none `decimals` option is defined - a default presentation is used;
+- if none `decimals` option is defined - a default presentation (see a note below) is used;
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` for some entity is defined - this value is used for this entity.
 2. For extrema & average values:
@@ -272,10 +272,15 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 - if "card-wide" `decimals` option is not defined - a default presentation is used;
 - otherwise - this value is used.
 4. For secondary Y-axis labels:
-- if "card-wide" `decimals` & `decimals_secondary` option are not defined - a default presentation is used;
+- if "card-wide" `decimals` & `decimals_secondary` options are not defined - a default presentation is used;
 - if "card-wide" `decimals` option is defined - this value is used;
 - if "card-wide" `decimals_secondary` option is defined - this value is used.
   
+A "default presentation" refers to a default look in HA:
+1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).
+2. For an attribute value (also for extrema & average): default HA settings are used (for template sensors - a user-defined accuracy set in jinja templates is used).
+3. For Y-axis labels: TO BE DETAILED
+
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 ### Number format
 
 Options `decimals` defined "card-wide" and/or for some entity are used to set an exact number of decimals according to the following rules:
-1. For states:
+1. For state & attribute values:
 - if none `decimals` option is defined - a default presentation (see a note below) is used;
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` for some entity is defined - this value is used for this entity.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ A "default presentation" refers to a default look in HA:
 1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).
 2. For an attribute value (also for extrema & average): default HA settings are used (for template sensors - a user-defined accuracy set in jinja templates is used).
 3. For Y-axis labels: TO BE DETAILED
-
+And for all values, HA number format settings (like `xxxx.xx` or `x xxx.x` or `x,xxx.x`) are used.
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).
 | color_thresholds_transition | string | `smooth` | v0.4.3 | Color threshold transition, `smooth` or `hard`.
 | decimals | integer |  | v0.0.9 | Specify the exact number of decimals to show for number values, see [Number format](#number-format).
-| decimals_secondary_labels | integer |  | v0.13.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
+| decimals_primary_labels | integer |  | v0.14.0 | Specify the exact number of decimals to show for primary Y-axis labels, see [Number format](#number-format).
+| decimals_secondary_labels | integer |  | v0.14.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
 | hour24 | boolean | `false` | v0.2.1 | Set to `true` to display times in 24-hour format.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
 | font_size_header | number | `14` | v0.3.1 | Adjust the font size of the header, size in pixels.
@@ -272,8 +273,9 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` is defined for the 1st entity - this value is used.
 3. For primary Y-axis labels:
-- if "card-wide" `decimals` option is not defined - a default presentation is used;
-- otherwise - this value is used.
+- if "card-wide" `decimals` & `decimals_primary_labels` options are not defined - a default presentation is used;
+- if "card-wide" `decimals` option is defined - this value is used;
+- if "card-wide" `decimals_primary_labels` option is defined - this value is used.
 4. For secondary Y-axis labels:
 - if "card-wide" `decimals` & `decimals_secondary_labels` options are not defined - a default presentation is used;
 - if "card-wide" `decimals` option is defined - this value is used;

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,4 +1,4 @@
-// fragment of format_number.ts from HA frontend converted to JS
+// This file is mainly a fragment of format_number.ts from HA frontend converted to JS
 
 // this var was converted from TS enum
 /* must be uncommented before merging with https://github.com/kalkih/mini-graph-card/pull/1347

--- a/src/locale.js
+++ b/src/locale.js
@@ -110,22 +110,6 @@ const getDefaultFormatOptions = (
 };
 
 /**
- * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
- *
- * @param num The number to format
- * @param localeOptions The user-selected language and formatting, from `hass.locale`
- * @param options Intl.NumberFormatOptions to use
- */
-const formatNumber = (
-  num, // string | number
-  localeOptions, // FrontendLocaleData (optional)
-  options, // Intl.NumberFormatOptions (optional)
-) =>
-  formatNumberToParts(num, localeOptions, options)
-    .map((part) => part.value)
-    .join('');
-
-/**
  * Returns an array of objects containing the formatted number in parts
  * Similar to Intl.NumberFormat.prototype.formatToParts()
  *
@@ -141,9 +125,8 @@ const formatNumberToParts = (
     : undefined;
 
   // Polyfill for Number.isNaN, which is more reliable than the global isNaN()
-  Number.isNaN =
-    Number.isNaN ||
-    function isNaN(input) {
+  Number.isNaN = Number.isNaN
+    || function isNaN(input) {
       return typeof input === 'number' && isNaN(input);
     };
 
@@ -176,6 +159,21 @@ const formatNumberToParts = (
 
   return [{ type: 'literal', value: num }];
 };
+
+/**
+ * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
+ *
+ * @param num The number to format
+ * @param localeOptions The user-selected language and formatting, from `hass.locale`
+ * @param options Intl.NumberFormatOptions to use
+ */
+const formatNumber = (
+  num, // string | number
+  localeOptions, // FrontendLocaleData (optional)
+  options, // Intl.NumberFormatOptions (optional)
+) => formatNumberToParts(num, localeOptions, options)
+  .map((part) => part.value)
+  .join('');
 
 export {
   formatNumber,

--- a/src/locale.js
+++ b/src/locale.js
@@ -21,27 +21,27 @@ const NumberFormat = Object.freeze({
 
 /* these types are used in FrontendLocaleData
 export enum TimeZone {
-  local = "local",
-  server = "server",
+  local = 'local',
+  server = 'server',
 }
 
 export enum DateFormat {
-  language = "language",
-  system = "system",
-  DMY = "DMY",
-  MDY = "MDY",
-  YMD = "YMD",
+  language = 'language',
+  system = 'system',
+  DMY = 'DMY',
+  MDY = 'MDY',
+  YMD = 'YMD',
 }
 
 export enum FirstWeekday {
-  language = "language",
-  monday = "monday",
-  tuesday = "tuesday",
-  wednesday = "wednesday",
-  thursday = "thursday",
-  friday = "friday",
-  saturday = "saturday",
-  sunday = "sunday",
+  language = 'language',
+  monday = 'monday',
+  tuesday = 'tuesday',
+  wednesday = 'wednesday',
+  thursday = 'thursday',
+  friday = 'friday',
+  saturday = 'saturday',
+  sunday = 'sunday',
 }
 */
 
@@ -61,13 +61,13 @@ const numberFormatToLocale = (
 ) /* : string | string[] | undefined */ => {
   switch (localeOptions.number_format) {
     case NumberFormat.comma_decimal:
-      return ["en-US", "en"]; // Use United States with fallback to English formatting 1,234,567.89
+      return ['en-US', 'en']; // Use United States with fallback to English formatting 1,234,567.89
     case NumberFormat.decimal_comma:
-      return ["de", "es", "it"]; // Use German with fallback to Spanish then Italian formatting 1.234.567,89
+      return ['de', 'es', 'it']; // Use German with fallback to Spanish then Italian formatting 1.234.567,89
     case NumberFormat.space_comma:
-      return ["fr", "sv", "cs"]; // Use French with fallback to Swedish and Czech formatting 1 234 567,89
+      return ['fr', 'sv', 'cs']; // Use French with fallback to Swedish and Czech formatting 1 234 567,89
     case NumberFormat.quote_decimal:
-      return ["de-CH"]; // Use German (Switzerland) formatting 1'234'567.89
+      return ['de-CH']; // Use German (Switzerland) formatting 1'234'567.89
     case NumberFormat.system:
       return undefined;
     default:
@@ -89,7 +89,7 @@ const formatNumber = (
 ) =>
   formatNumberToParts(num, localeOptions, options)
     .map((part) => part.value)
-    .join("");
+    .join('');
 
 /**
  * Returns an array of objects containing the formatted number in parts
@@ -110,7 +110,7 @@ const formatNumberToParts = (
   Number.isNaN =
     Number.isNaN ||
     function isNaN(input) {
-      return typeof input === "number" && isNaN(input);
+      return typeof input === 'number' && isNaN(input);
     };
 
   if (
@@ -126,13 +126,13 @@ const formatNumberToParts = (
 
   if (
     !Number.isNaN(Number(num)) &&
-    num !== "" &&
+    num !== '' &&
     localeOptions &&
     localeOptions.number_format === NumberFormat.none
   ) {
     // If NumberFormat is none, use en-US format without grouping.
     return new Intl.NumberFormat(
-      "en-US",
+      'en-US',
       getDefaultFormatOptions(num, {
         ...options,
         useGrouping: false,
@@ -140,7 +140,7 @@ const formatNumberToParts = (
     ).formatToParts(Number(num));
   }
 
-  return [{ type: "literal", value: num }];
+  return [{ type: 'literal', value: num }];
 };
 
 /**
@@ -157,7 +157,7 @@ const getDefaultFormatOptions = (
     ...options,
   };
 
-  if (typeof num !== "string") {
+  if (typeof num !== 'string') {
     return defaultOptions;
   }
 
@@ -167,7 +167,7 @@ const getDefaultFormatOptions = (
     (options.minimumFractionDigits === undefined &&
       options.maximumFractionDigits === undefined)
   ) {
-    const digits = num.indexOf(".") > -1 ? num.split(".")[1].length : 0;
+    const digits = num.indexOf('.') > -1 ? num.split('.')[1].length : 0;
     defaultOptions.minimumFractionDigits = digits;
     defaultOptions.maximumFractionDigits = digits;
   }

--- a/src/locale.js
+++ b/src/locale.js
@@ -57,7 +57,7 @@ export interface FrontendLocaleData {
 */
 
 const numberFormatToLocale = (
-  localeOptions // FrontendLocaleData
+  localeOptions, // FrontendLocaleData
 ) /* : string | string[] | undefined */ => {
   switch (localeOptions.number_format) {
     case NumberFormat.comma_decimal:
@@ -85,7 +85,7 @@ const numberFormatToLocale = (
 const formatNumber = (
   num, // string | number
   localeOptions, // FrontendLocaleData (optional)
-  options // Intl.NumberFormatOptions (optional)
+  options, // Intl.NumberFormatOptions (optional)
 ) =>
   formatNumberToParts(num, localeOptions, options)
     .map((part) => part.value)
@@ -100,7 +100,7 @@ const formatNumber = (
 const formatNumberToParts = (
   num, // string | number
   localeOptions, // FrontendLocaleData (optional)
-  options // Intl.NumberFormatOptions (optional)
+  options, // Intl.NumberFormatOptions (optional)
 ) => {
   const locale = localeOptions
     ? numberFormatToLocale(localeOptions)
@@ -150,7 +150,7 @@ const formatNumberToParts = (
  */
 const getDefaultFormatOptions = (
   num, // string | number
-  options // Intl.NumberFormatOptions
+  options, // Intl.NumberFormatOptions
 ) => {
   const defaultOptions = { // Intl.NumberFormatOptions
     maximumFractionDigits: 2,

--- a/src/locale.js
+++ b/src/locale.js
@@ -78,6 +78,38 @@ const numberFormatToLocale = (
 };
 
 /**
+ * Generates default options for Intl.NumberFormat
+ * @param num The number to be formatted
+ * @param options The Intl.NumberFormatOptions that should be included in the returned options
+ */
+const getDefaultFormatOptions = (
+  num, // string | number
+  options, // Intl.NumberFormatOptions
+) => {
+  const defaultOptions = { // Intl.NumberFormatOptions
+    maximumFractionDigits: 2,
+    ...options,
+  };
+
+  if (typeof num !== 'string') {
+    return defaultOptions;
+  }
+
+  // Keep decimal trailing zeros if they are present in a string numeric value
+  if (
+    !options
+    || (options.minimumFractionDigits === undefined
+        && options.maximumFractionDigits === undefined)
+  ) {
+    const digits = num.indexOf('.') > -1 ? num.split('.')[1].length : 0;
+    defaultOptions.minimumFractionDigits = digits;
+    defaultOptions.maximumFractionDigits = digits;
+  }
+
+  return defaultOptions;
+};
+
+/**
  * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
  *
  * @param num The number to format
@@ -116,21 +148,21 @@ const formatNumberToParts = (
     };
 
   if (
-    localeOptions &&
-    localeOptions.number_format !== NumberFormat.none &&
-    !Number.isNaN(Number(num))
+    localeOptions
+    && localeOptions.number_format !== NumberFormat.none
+    && !Number.isNaN(Number(num))
   ) {
     return new Intl.NumberFormat(
       locale,
-      getDefaultFormatOptions(num, options)
+      getDefaultFormatOptions(num, options),
     ).formatToParts(Number(num));
   }
 
   if (
-    !Number.isNaN(Number(num)) &&
-    num !== '' &&
-    localeOptions &&
-    localeOptions.number_format === NumberFormat.none
+    !Number.isNaN(Number(num))
+    && num !== ''
+    && localeOptions
+    && localeOptions.number_format === NumberFormat.none
   ) {
     // If NumberFormat is none, use en-US format without grouping.
     return new Intl.NumberFormat(
@@ -138,43 +170,11 @@ const formatNumberToParts = (
       getDefaultFormatOptions(num, {
         ...options,
         useGrouping: false,
-      })
+      }),
     ).formatToParts(Number(num));
   }
 
   return [{ type: 'literal', value: num }];
-};
-
-/**
- * Generates default options for Intl.NumberFormat
- * @param num The number to be formatted
- * @param options The Intl.NumberFormatOptions that should be included in the returned options
- */
-const getDefaultFormatOptions = (
-  num, // string | number
-  options, // Intl.NumberFormatOptions
-) => {
-  const defaultOptions = { // Intl.NumberFormatOptions
-    maximumFractionDigits: 2,
-    ...options,
-  };
-
-  if (typeof num !== 'string') {
-    return defaultOptions;
-  }
-
-  // Keep decimal trailing zeros if they are present in a string numeric value
-  if (
-    !options ||
-    (options.minimumFractionDigits === undefined &&
-      options.maximumFractionDigits === undefined)
-  ) {
-    const digits = num.indexOf('.') > -1 ? num.split('.')[1].length : 0;
-    defaultOptions.minimumFractionDigits = digits;
-    defaultOptions.maximumFractionDigits = digits;
-  }
-
-  return defaultOptions;
 };
 
 export {

--- a/src/locale.js
+++ b/src/locale.js
@@ -52,7 +52,8 @@ export interface FrontendLocaleData {
 
 /**
  * Returns a possible language/languages based on a number format
- * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @param {FrontendLocaleData} localeOptions Object containing
+ * a user-selected language and formatting
  * @returns {string | string[] | undefined} Possible language/languages
  */
 const numberFormatToLocale = (localeOptions) => {
@@ -75,7 +76,8 @@ const numberFormatToLocale = (localeOptions) => {
 /**
  * Generates default options for Intl.NumberFormat
  * @param {string | number} num Number to format
- * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions that should be included in the returned options
+ * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions
+ * that should be included in the returned options
  * @returns {Intl.NumberFormatOptions} Default options for Intl.NumberFormat
  */
 const getDefaultFormatOptions = (
@@ -109,7 +111,8 @@ const getDefaultFormatOptions = (
  * Returns an array of objects containing the formatted number in parts.
  * Similar to Intl.NumberFormat.prototype.formatToParts()
  * @param {string | number} num Number to format
- * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @param {FrontendLocaleData} localeOptions Object containing
+ * a user-selected language and formatting
  * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
  */
 const formatNumberToParts = (
@@ -161,7 +164,8 @@ const formatNumberToParts = (
  * Formats a number based on the user's preference with thousands separator(s)
  * and decimal character for better legibility.
  * @param {string | number} num Number to format
- * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @param {FrontendLocaleData} localeOptions Object containing
+ * a user-selected language and formatting
  * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
  * @returns {string} Formatted number
  */

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,12 +1,14 @@
 // fragment of format_number.ts from HA frontend converted to JS
 
 // this var was converted from TS enum
+/* must be uncommented before nerging with https://github.com/kalkih/mini-graph-card/pull/1347
 const TimeFormat = Object.freeze({
   language: 'language',
   system: 'system',
   am_pm: '12',
   twenty_four: '24',
 });
+*/
 
 // this var was converted from TS enum
 const NumberFormat = Object.freeze({

--- a/src/locale.js
+++ b/src/locale.js
@@ -127,7 +127,8 @@ const formatNumberToParts = (
   if (
     !Number.isNaN(Number(num)) &&
     num !== "" &&
-    localeOptions?.number_format === NumberFormat.none
+    localeOptions &&
+    localeOptions.number_format === NumberFormat.none
   ) {
     // If NumberFormat is none, use en-US format without grouping.
     return new Intl.NumberFormat(

--- a/src/locale.js
+++ b/src/locale.js
@@ -161,7 +161,8 @@ const formatNumberToParts = (
 };
 
 /**
- * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
+ * Formats a number based on the user's preference with thousands separator(s)
+ * and decimal character for better legibility.
  *
  * @param num The number to format
  * @param localeOptions The user-selected language and formatting, from `hass.locale`
@@ -172,7 +173,7 @@ const formatNumber = (
   localeOptions, // FrontendLocaleData (optional)
   options, // Intl.NumberFormatOptions (optional)
 ) => formatNumberToParts(num, localeOptions, options)
-  .map((part) => part.value)
+  .map(part => part.value)
   .join('');
 
 export {

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,178 @@
+// fragment of format_number.ts from HA frontend converted to JS
+
+// this var was converted from TS enum
+const TimeFormat = Object.freeze({
+  language: 'language',
+  system: 'system',
+  am_pm: '12',
+  twenty_four: '24',
+});
+
+// this var was converted from TS enum
+const NumberFormat = Object.freeze({
+  language: 'language',
+  system: 'system',
+  comma_decimal: 'comma_decimal',
+  decimal_comma: 'decimal_comma',
+  quote_decimal: 'quote_decimal',
+  space_comma: 'space_comma',
+  none: 'none',
+});
+
+/* these types are used in FrontendLocaleData
+export enum TimeZone {
+  local = "local",
+  server = "server",
+}
+
+export enum DateFormat {
+  language = "language",
+  system = "system",
+  DMY = "DMY",
+  MDY = "MDY",
+  YMD = "YMD",
+}
+
+export enum FirstWeekday {
+  language = "language",
+  monday = "monday",
+  tuesday = "tuesday",
+  wednesday = "wednesday",
+  thursday = "thursday",
+  friday = "friday",
+  saturday = "saturday",
+  sunday = "sunday",
+}
+*/
+
+/* this type is used for hass.locale
+export interface FrontendLocaleData {
+  language: string;
+  number_format: NumberFormat;
+  time_format: TimeFormat;
+  date_format: DateFormat;
+  first_weekday: FirstWeekday;
+  time_zone: TimeZone;
+}
+*/
+
+const numberFormatToLocale = (
+  localeOptions // FrontendLocaleData
+) /* : string | string[] | undefined */ => {
+  switch (localeOptions.number_format) {
+    case NumberFormat.comma_decimal:
+      return ["en-US", "en"]; // Use United States with fallback to English formatting 1,234,567.89
+    case NumberFormat.decimal_comma:
+      return ["de", "es", "it"]; // Use German with fallback to Spanish then Italian formatting 1.234.567,89
+    case NumberFormat.space_comma:
+      return ["fr", "sv", "cs"]; // Use French with fallback to Swedish and Czech formatting 1 234 567,89
+    case NumberFormat.quote_decimal:
+      return ["de-CH"]; // Use German (Switzerland) formatting 1'234'567.89
+    case NumberFormat.system:
+      return undefined;
+    default:
+      return localeOptions.language;
+  }
+};
+
+/**
+ * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
+ *
+ * @param num The number to format
+ * @param localeOptions The user-selected language and formatting, from `hass.locale`
+ * @param options Intl.NumberFormatOptions to use
+ */
+const formatNumber = (
+  num, // string | number
+  localeOptions, // FrontendLocaleData (optional)
+  options // Intl.NumberFormatOptions (optional)
+) =>
+  formatNumberToParts(num, localeOptions, options)
+    .map((part) => part.value)
+    .join("");
+
+/**
+ * Returns an array of objects containing the formatted number in parts
+ * Similar to Intl.NumberFormat.prototype.formatToParts()
+ *
+ * Input params - same as for formatNumber()
+ */
+const formatNumberToParts = (
+  num, // string | number
+  localeOptions, // FrontendLocaleData (optional)
+  options // Intl.NumberFormatOptions (optional)
+) => {
+  const locale = localeOptions
+    ? numberFormatToLocale(localeOptions)
+    : undefined;
+
+  // Polyfill for Number.isNaN, which is more reliable than the global isNaN()
+  Number.isNaN =
+    Number.isNaN ||
+    function isNaN(input) {
+      return typeof input === "number" && isNaN(input);
+    };
+
+  if (
+    localeOptions?.number_format !== NumberFormat.none &&
+    !Number.isNaN(Number(num))
+  ) {
+    return new Intl.NumberFormat(
+      locale,
+      getDefaultFormatOptions(num, options)
+    ).formatToParts(Number(num));
+  }
+
+  if (
+    !Number.isNaN(Number(num)) &&
+    num !== "" &&
+    localeOptions?.number_format === NumberFormat.none
+  ) {
+    // If NumberFormat is none, use en-US format without grouping.
+    return new Intl.NumberFormat(
+      "en-US",
+      getDefaultFormatOptions(num, {
+        ...options,
+        useGrouping: false,
+      })
+    ).formatToParts(Number(num));
+  }
+
+  return [{ type: "literal", value: num }];
+};
+
+/**
+ * Generates default options for Intl.NumberFormat
+ * @param num The number to be formatted
+ * @param options The Intl.NumberFormatOptions that should be included in the returned options
+ */
+const getDefaultFormatOptions = (
+  num, // string | number
+  options // Intl.NumberFormatOptions
+) => {
+  const defaultOptions = { // Intl.NumberFormatOptions
+    maximumFractionDigits: 2,
+    ...options,
+  };
+
+  if (typeof num !== "string") {
+    return defaultOptions;
+  }
+
+  // Keep decimal trailing zeros if they are present in a string numeric value
+  if (
+    !options ||
+    (options.minimumFractionDigits === undefined &&
+      options.maximumFractionDigits === undefined)
+  ) {
+    const digits = num.indexOf(".") > -1 ? num.split(".")[1].length : 0;
+    defaultOptions.minimumFractionDigits = digits;
+    defaultOptions.maximumFractionDigits = digits;
+  }
+
+  return defaultOptions;
+};
+
+export {
+  formatNumber,
+};

--- a/src/locale.js
+++ b/src/locale.js
@@ -114,7 +114,8 @@ const formatNumberToParts = (
     };
 
   if (
-    localeOptions?.number_format !== NumberFormat.none &&
+    localeOptions &&
+    localeOptions.number_format !== NumberFormat.none &&
     !Number.isNaN(Number(num))
   ) {
     return new Intl.NumberFormat(

--- a/src/locale.js
+++ b/src/locale.js
@@ -164,7 +164,6 @@ const formatNumberToParts = (
 /**
  * Formats a number based on the user's preference with thousands separator(s)
  * and decimal character for better legibility.
- *
  * @param num Number to format
  * @param localeOptions Object containing a user-selected language and formatting
  * @param options Intl.NumberFormatOptions to use

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,17 +1,3 @@
-// This file is mainly a fragment of format_number.ts from HA frontend converted to JS
-
-/**
- * HA Frontend time format settings
- */
-/* must be uncommented before merging with https://github.com/kalkih/mini-graph-card/pull/1347
-const TimeFormat = Object.freeze({
-  language: 'language',
-  system: 'system',
-  am_pm: '12',
-  twenty_four: '24',
-});
-*/
-
 /**
  * HA Frontend number format settings
  */
@@ -64,9 +50,12 @@ export interface FrontendLocaleData {
 }
 */
 
-const numberFormatToLocale = (
-  localeOptions, // FrontendLocaleData
-) /* : string | string[] | undefined */ => {
+/**
+ * Returns a possible language/languages based on a number format
+ * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @returns {string | string[] | undefined}
+ */
+const numberFormatToLocale = (localeOptions) => {
   switch (localeOptions.number_format) {
     case NumberFormat.comma_decimal:
       return ['en-US', 'en']; // Use United States with fallback to English formatting 1,234,567.89
@@ -85,14 +74,15 @@ const numberFormatToLocale = (
 
 /**
  * Generates default options for Intl.NumberFormat
- * @param num Number to format
- * @param options Intl.NumberFormatOptions that should be included in the returned options
+ * @param {string | number} num Number to format
+ * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions that should be included in the returned options
+ * @returns {Intl.NumberFormatOptions} Default options for Intl.NumberFormat
  */
 const getDefaultFormatOptions = (
-  num, // string | number
-  options, // Intl.NumberFormatOptions
+  num,
+  options,
 ) => {
-  const defaultOptions = { // Intl.NumberFormatOptions
+  const defaultOptions = {
     maximumFractionDigits: 2,
     ...options,
   };
@@ -118,14 +108,14 @@ const getDefaultFormatOptions = (
 /**
  * Returns an array of objects containing the formatted number in parts.
  * Similar to Intl.NumberFormat.prototype.formatToParts()
- * @param num Number to format
- * @param localeOptions Object containing a user-selected language and formatting
- * @param options Intl.NumberFormatOptions to use
+ * @param {string | number} num Number to format
+ * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
  */
 const formatNumberToParts = (
-  num, // string | number
-  localeOptions, // FrontendLocaleData (optional)
-  options, // Intl.NumberFormatOptions (optional)
+  num,
+  localeOptions,
+  options,
 ) => {
   const locale = localeOptions
     ? numberFormatToLocale(localeOptions)
@@ -170,14 +160,15 @@ const formatNumberToParts = (
 /**
  * Formats a number based on the user's preference with thousands separator(s)
  * and decimal character for better legibility.
- * @param num Number to format
- * @param localeOptions Object containing a user-selected language and formatting
- * @param options Intl.NumberFormatOptions to use
+ * @param {string | number} num Number to format
+ * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
+ * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
+ * @returns {string} Formatted number
  */
 const formatNumber = (
-  num, // string | number
-  localeOptions, // FrontendLocaleData (optional)
-  options, // Intl.NumberFormatOptions (optional)
+  num,
+  localeOptions,
+  options,
 ) => formatNumberToParts(num, localeOptions, options)
   .map(part => part.value)
   .join('');

--- a/src/locale.js
+++ b/src/locale.js
@@ -53,7 +53,7 @@ export interface FrontendLocaleData {
 /**
  * Returns a possible language/languages based on a number format
  * @param {FrontendLocaleData} localeOptions Object containing
- * a user-selected language and formatting
+ * a user-selected language and formatting settings
  * @returns {string | string[] | undefined} Possible language/languages
  */
 const numberFormatToLocale = (localeOptions) => {
@@ -112,7 +112,7 @@ const getDefaultFormatOptions = (
  * Similar to Intl.NumberFormat.prototype.formatToParts()
  * @param {string | number} num Number to format
  * @param {FrontendLocaleData} localeOptions Object containing
- * a user-selected language and formatting
+ * a user-selected language and formatting settings
  * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
  */
 const formatNumberToParts = (
@@ -165,7 +165,7 @@ const formatNumberToParts = (
  * and decimal character for better legibility.
  * @param {string | number} num Number to format
  * @param {FrontendLocaleData} localeOptions Object containing
- * a user-selected language and formatting
+ * a user-selected language and formatting settings
  * @param {Intl.NumberFormatOptions} options Intl.NumberFormatOptions to use
  * @returns {string} Formatted number
  */

--- a/src/locale.js
+++ b/src/locale.js
@@ -10,7 +10,9 @@ const TimeFormat = Object.freeze({
 });
 */
 
-// this var was converted from TS enum
+/**
+ * HA Frontend number format settings
+ */
 const NumberFormat = Object.freeze({
   language: 'language',
   system: 'system',
@@ -22,6 +24,8 @@ const NumberFormat = Object.freeze({
 });
 
 /* these types are used in FrontendLocaleData
+Added here for a future need; now - for understaning wht FrontendLocaleData is
+
 export enum TimeZone {
   local = 'local',
   server = 'server',

--- a/src/locale.js
+++ b/src/locale.js
@@ -24,7 +24,7 @@ const NumberFormat = Object.freeze({
 });
 
 /* these types are used in FrontendLocaleData
-Added here for a future need; now - for understaning wht FrontendLocaleData is
+Added here for a future need; now - for understaning what FrontendLocaleData is
 
 export enum TimeZone {
   local = 'local',

--- a/src/locale.js
+++ b/src/locale.js
@@ -53,7 +53,7 @@ export interface FrontendLocaleData {
 /**
  * Returns a possible language/languages based on a number format
  * @param {FrontendLocaleData} localeOptions Object containing a user-selected language and formatting
- * @returns {string | string[] | undefined}
+ * @returns {string | string[] | undefined} Possible language/languages
  */
 const numberFormatToLocale = (localeOptions) => {
   switch (localeOptions.number_format) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -79,8 +79,8 @@ const numberFormatToLocale = (
 
 /**
  * Generates default options for Intl.NumberFormat
- * @param num The number to be formatted
- * @param options The Intl.NumberFormatOptions that should be included in the returned options
+ * @param num Number to format
+ * @param options Intl.NumberFormatOptions that should be included in the returned options
  */
 const getDefaultFormatOptions = (
   num, // string | number
@@ -110,10 +110,11 @@ const getDefaultFormatOptions = (
 };
 
 /**
- * Returns an array of objects containing the formatted number in parts
+ * Returns an array of objects containing the formatted number in parts.
  * Similar to Intl.NumberFormat.prototype.formatToParts()
- *
- * Input params - same as for formatNumber()
+ * @param num Number to format
+ * @param localeOptions Object containing a user-selected language and formatting
+ * @param options Intl.NumberFormatOptions to use
  */
 const formatNumberToParts = (
   num, // string | number
@@ -164,8 +165,8 @@ const formatNumberToParts = (
  * Formats a number based on the user's preference with thousands separator(s)
  * and decimal character for better legibility.
  *
- * @param num The number to format
- * @param localeOptions The user-selected language and formatting, from `hass.locale`
+ * @param num Number to format
+ * @param localeOptions Object containing a user-selected language and formatting
  * @param options Intl.NumberFormatOptions to use
  */
 const formatNumber = (

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,6 +1,8 @@
 // This file is mainly a fragment of format_number.ts from HA frontend converted to JS
 
-// this var was converted from TS enum
+/**
+ * HA Frontend time format settings
+ */
 /* must be uncommented before merging with https://github.com/kalkih/mini-graph-card/pull/1347
 const TimeFormat = Object.freeze({
   language: 'language',

--- a/src/locale.js
+++ b/src/locale.js
@@ -124,12 +124,6 @@ const formatNumberToParts = (
     ? numberFormatToLocale(localeOptions)
     : undefined;
 
-  // Polyfill for Number.isNaN, which is more reliable than the global isNaN()
-  Number.isNaN = Number.isNaN
-    || function isNaN(input) {
-      return typeof input === 'number' && isNaN(input);
-    };
-
   if (
     localeOptions
     && localeOptions.number_format !== NumberFormat.none

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,7 +1,7 @@
 // fragment of format_number.ts from HA frontend converted to JS
 
 // this var was converted from TS enum
-/* must be uncommented before nerging with https://github.com/kalkih/mini-graph-card/pull/1347
+/* must be uncommented before merging with https://github.com/kalkih/mini-graph-card/pull/1347
 const TimeFormat = Object.freeze({
   language: 'language',
   system: 'system',

--- a/src/main.js
+++ b/src/main.js
@@ -775,7 +775,6 @@ class MiniGraphCard extends LitElement {
         const entityId = this.config.entities[index].entity;
         const attribute = this.config.entities[index].attribute;
         const stateObj = this._hass.states[entityId];
-        let part;
         if (attribute) {
           // formatting attribute
           const attrParts = this._hass.formatEntityAttributeValueToParts(
@@ -783,8 +782,8 @@ class MiniGraphCard extends LitElement {
             attribute,
             state * value_factor,
           );
-          part = attrParts.find(part => part.type === 'value');
-          value = part && part.value;
+          const aPart = attrParts.find(part => part.type === 'value');
+          value = aPart && aPart.value;
           return value;
         } else {
           // formatting state
@@ -792,8 +791,8 @@ class MiniGraphCard extends LitElement {
             stateObj,
             state * value_factor,
           );
-          part = stateParts.find(part => part.type === 'value');
-          value = part && part.value;
+          const sPart = stateParts.find(part => part.type === 'value');
+          value = sPart && sPart.value;
           return value;
         }
       } else {

--- a/src/main.js
+++ b/src/main.js
@@ -788,9 +788,9 @@ class MiniGraphCard extends LitElement {
             state * value_factor,
           );
         }
-        const part = parts.find(part => part.type === 'value');
-        value = part && part.value;
-        return value;        
+        const partValue = parts.find(part => part.type === 'value');
+        value = partValue && partValue.value;
+        return value;
       } else {
         // formatting Y-axis (primary, secondary) labels
         value = Number.isNaN(state) ? state : state * value_factor;

--- a/src/main.js
+++ b/src/main.js
@@ -294,7 +294,7 @@ class MiniGraphCard extends LitElement {
       const { entity: tooltipEntity, value: tooltipValue } = this.tooltip;
       const isTooltip = isPrimary && tooltipEntity !== undefined;
       const value = isTooltip ? tooltipValue : state;
-      const entity = isTooltip ? tooltipEntity : id; // index of entity
+      const entity = isTooltip ? tooltipEntity : id;
       const entityConfig = this.config.entities[entity];
       return html`
         <div

--- a/src/main.js
+++ b/src/main.js
@@ -772,7 +772,9 @@ class MiniGraphCard extends LitElement {
       // default accuracy
       if (index >= 0) {
         // formatting a state or attribute
+        // eslint-disable-next-line prefer-destructuring
         const entityId = this.config.entities[index].entity;
+        // eslint-disable-next-line prefer-destructuring
         const attribute = this.config.entities[index].attribute;
         const stateObj = this._hass.states[entityId];
         if (attribute) {

--- a/src/main.js
+++ b/src/main.js
@@ -369,8 +369,6 @@ class MiniGraphCard extends LitElement {
 
   renderLegend() {
     if (this.visibleLegends.length <= 1 || !this.config.show.legend) return;
-
-    /* eslint-disable indent */
     return html`
       <div class="graph__legend">
         ${this.visibleLegends.map((entity) => {
@@ -387,7 +385,6 @@ class MiniGraphCard extends LitElement {
         })}
       </div>
     `;
-    /* eslint-enable indent */
   }
 
   renderIndicator(state, index) {

--- a/src/main.js
+++ b/src/main.js
@@ -775,26 +775,22 @@ class MiniGraphCard extends LitElement {
         const entityId = this.entity[index].entity_id;
         const { attribute } = this.config.entities[index];
         const stateObj = this._hass.states[entityId];
+        let parts;
         if (attribute) {
-          // formatting attribute
-          const attrParts = this._hass.formatEntityAttributeValueToParts(
+          parts = this._hass.formatEntityAttributeValueToParts(
             stateObj,
             attribute,
             state * value_factor,
           );
-          const aPart = attrParts.find(part => part.type === 'value');
-          value = aPart && aPart.value;
-          return value;
         } else {
-          // formatting state
-          const stateParts = this._hass.formatEntityStateToParts(
+          parts = this._hass.formatEntityStateToParts(
             stateObj,
             state * value_factor,
           );
-          const sPart = stateParts.find(part => part.type === 'value');
-          value = sPart && sPart.value;
-          return value;
         }
+        const part = parts.find(part => part.type === 'value');
+        value = part && part.value;
+        return value;        
       } else {
         // formatting Y-axis (primary, secondary) labels
         value = Number.isNaN(state) ? state : state * value_factor;

--- a/src/main.js
+++ b/src/main.js
@@ -279,7 +279,7 @@ class MiniGraphCard extends LitElement {
 
   /**
   * Check if an attribute represents an object (dictionary or list)
-  * @returns {boolean} true if an attribute is an object, false - otherwise
+  * @returns {boolean} True if an attribute is an object, false - otherwise
   * @param path Attribute defined as either a singular attribute or a tree-like path
   */
   isObjectAttr(path) {

--- a/src/main.js
+++ b/src/main.js
@@ -369,6 +369,7 @@ class MiniGraphCard extends LitElement {
 
   renderLegend() {
     if (this.visibleLegends.length <= 1 || !this.config.show.legend) return;
+    /* eslint-disable indent */
     return html`
       <div class="graph__legend">
         ${this.visibleLegends.map((entity) => {
@@ -385,6 +386,7 @@ class MiniGraphCard extends LitElement {
         })}
       </div>
     `;
+    /* eslint-enable indent */
   }
 
   renderIndicator(state, index) {

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,11 @@ import Graph from './graph';
 import style from './style';
 import handleClick from './handleClick';
 import buildConfig from './buildConfig';
+import {
+  formatNumber,
+} from './locale';
 import './initialize';
 import { version } from '../package.json';
-
 import {
   ICONS,
   UPDATE_PROPS,
@@ -292,7 +294,7 @@ class MiniGraphCard extends LitElement {
       const { entity: tooltipEntity, value: tooltipValue } = this.tooltip;
       const isTooltip = isPrimary && tooltipEntity !== undefined;
       const value = isTooltip ? tooltipValue : state;
-      const entity = isTooltip ? tooltipEntity : id;
+      const entity = isTooltip ? tooltipEntity : id; // index of entity
       const entityConfig = this.config.entities[entity];
       return html`
         <div
@@ -600,6 +602,7 @@ class MiniGraphCard extends LitElement {
 
   renderLabels() {
     if (!this.config.show.labels || this.primaryYaxisSeries.length === 0) return;
+    // index is not passed into computeState() for a primary axis
     return html`
       <div class="graph__labels --primary flex">
         <span class="label--max">${this.computeState(this.bound[1])}</span>
@@ -610,6 +613,7 @@ class MiniGraphCard extends LitElement {
 
   renderLabelsSecondary() {
     if (!this.config.show.labels_secondary || this.secondaryYaxisSeries.length === 0) return;
+    // index "-1" is passed into computeState() for a secondary axis
     return html`
       <div class="graph__labels --secondary flex">
         <span class="label--max">${this.computeState(this.boundSecondary[1], -1)}</span>
@@ -619,6 +623,7 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
+    // index "0" is passed into computeState() since "info" is shown for the 1st entity
     return this.abs.length > 0 ? html`
       <div class="info flex">
         ${this.abs.map(entry => html`
@@ -744,27 +749,68 @@ class MiniGraphCard extends LitElement {
 
     let dec;
     if (index === undefined) {
-      dec = this.config.decimals;
+      // for a primary Y-axis
+      dec = this.config.decimals_primary_labels !== undefined
+        ? this.config.decimals_primary_labels
+        : this.config.decimals;
     } else if (index === -1) {
-      dec = this.config.decimals_secondary !== undefined
-        ? this.config.decimals_secondary
+      // for a secondary Y-axis
+      dec = this.config.decimals_secondary_labels !== undefined
+        ? this.config.decimals_secondary_labels
         : this.config.decimals;
     } else {
+      // for a state or attribute value
       dec = this.config.entities[index].decimals !== undefined
         ? this.config.entities[index].decimals
         : this.config.decimals;
     }
 
     const value_factor = 10 ** this.config.value_factor;
+    let value;
 
     if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state)) {
-      return this.numberFormat(Math.round(state * value_factor * 100) / 100, this._hass.language);
+      // default accuracy
+      if (index >= 0) {
+        // formatting a state or attribute
+        const entityId = this.config.entities[index].entity;
+        const attribute = this.config.entities[index].attribute;
+        const stateObj = this._hass.states[entityId];
+        if (attribute) {
+          // formatting attribute
+          const attrParts = this._hass.formatEntityAttributeValueToParts(
+            stateObj,
+            attribute,
+            state * value_factor
+          );
+          value = attrParts.find((part) => part.type === "value")?.value;
+          return value;
+        } else {
+          // formatting state
+          const stateParts = this._hass.formatEntityStateToParts(
+            stateObj,
+            state * value_factor
+          );
+          value = stateParts.find((part) => part.type === "value")?.value;
+          return value;
+        }
+      } else {
+        // formatting Y-axis (primary, secondary) labels
+        value = Number.isNaN(state) ? state : state * value_factor;
+        const sss = formatNumber(
+          value,
+          this._hass.locale
+        );
+        return sss;
+      }
     }
 
-    const x = 10 ** dec;
-    return this.numberFormat(
-      (Math.round(state * value_factor * x) / x).toFixed(dec),
-      this._hass.language, dec,
+    // acuracy defined by dec
+    // const x = 10 ** dec;
+    value = state * value_factor;
+    return formatNumber(
+      value,
+      this._hass.locale,
+      { minimumFractionDigits: dec, maximumFractionDigits: dec }
     );
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -782,7 +782,8 @@ class MiniGraphCard extends LitElement {
             attribute,
             state * value_factor
           );
-          value = attrParts.find((part) => part.type === "value")?.value;
+          const part = attrParts.find((part) => part.type === "value");
+          value = part && part.value;
           return value;
         } else {
           // formatting state
@@ -790,7 +791,8 @@ class MiniGraphCard extends LitElement {
             stateObj,
             state * value_factor
           );
-          value = stateParts.find((part) => part.type === "value")?.value;
+          const part = stateParts.find((part) => part.type === "value");
+          value = part && part.value;
           return value;
         }
       } else {

--- a/src/main.js
+++ b/src/main.js
@@ -809,7 +809,8 @@ class MiniGraphCard extends LitElement {
             attribute,
             state,
           );
-          value = attrParts.find((part) => part.type === 'value')?.value;
+          const partValue = attrParts.find((part) => part.type === 'value');
+          value = partValue && partValue.value;
           return value;
         } else if (attribute && this.isObjectAttr(attribute)) {
           // formatting object attribute - similar to Y-axis labels
@@ -823,7 +824,8 @@ class MiniGraphCard extends LitElement {
             stateObj,
             state,
           );
-          value = stateParts.find((part) => part.type === 'value')?.value;
+          const partValue = stateParts.find((part) => part.type === 'value');
+          value = partValue && partValue.value;
           return value;
         }
       } else {

--- a/src/main.js
+++ b/src/main.js
@@ -796,11 +796,10 @@ class MiniGraphCard extends LitElement {
       } else {
         // formatting Y-axis (primary, secondary) labels
         value = Number.isNaN(state) ? state : state * value_factor;
-        const sss = formatNumber(
+        return formatNumber(
           value,
           this._hass.locale
         );
-        return sss;
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -800,7 +800,7 @@ class MiniGraphCard extends LitElement {
       if (index >= 0) {
         // formatting a state or attribute
         const entityId = this.config.entities[index].entity;
-        const attribute = this.config.entities[index].attribute;
+        const { attribute } = this.config.entities[index];
         const stateObj = this._hass.states[entityId];
         if (attribute && !this.isObjectAttr(attribute)) {
           // formatting not-object attribute
@@ -809,14 +809,14 @@ class MiniGraphCard extends LitElement {
             attribute,
             state,
           );
-          const partValue = attrParts.find((part) => part.type === 'value');
+          const partValue = attrParts.find(part => part.type === 'value');
           value = partValue && partValue.value;
           return value;
         } else if (attribute && this.isObjectAttr(attribute)) {
           // formatting object attribute - similar to Y-axis labels
           return formatNumber(
             state,
-            this._hass.locale
+            this._hass.locale,
           );
         } else {
           // formatting state
@@ -824,7 +824,7 @@ class MiniGraphCard extends LitElement {
             stateObj,
             state,
           );
-          const partValue = stateParts.find((part) => part.type === 'value');
+          const partValue = stateParts.find(part => part.type === 'value');
           value = partValue && partValue.value;
           return value;
         }
@@ -833,7 +833,7 @@ class MiniGraphCard extends LitElement {
         // use a default hard-coded accuracy
         return formatNumber(
           state,
-          this._hass.locale
+          this._hass.locale,
         );
       }
     }
@@ -842,7 +842,7 @@ class MiniGraphCard extends LitElement {
     return formatNumber(
       state,
       this._hass.locale,
-      { minimumFractionDigits: dec, maximumFractionDigits: dec }
+      { minimumFractionDigits: dec, maximumFractionDigits: dec },
     );
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -773,7 +773,7 @@ class MiniGraphCard extends LitElement {
       if (index >= 0) {
         // formatting a state or attribute
         const entityId = this.entity[index].entity_id;
-        const attribute = this.config.entities[index].attribute;
+        const { attribute } = this.config.entities[index];
         const stateObj = this._hass.states[entityId];
         if (attribute) {
           // formatting attribute

--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,8 @@ import {
   log,
 } from './utils';
 
+const isUnavailableState = value => ['unavailable', 'unknown'].includes(value);
+
 class MiniGraphCard extends LitElement {
   constructor() {
     super();
@@ -273,6 +275,15 @@ class MiniGraphCard extends LitElement {
 
   getObjectAttr(obj, path) {
     return path.split('.').reduce((res, key) => res && res[key], obj);
+  }
+
+  /**
+  * Check if an attribute represents an object (dictionary or list)
+  * @returns {boolean} true if an attribute is an object, false - otherwise
+  * @param path Attribute defined as either a singular attribute or a tree-like path
+  */
+  isObjectAttr(path) {
+    return path.includes('.');
   }
 
   getEntityState(id) {
@@ -727,6 +738,14 @@ class MiniGraphCard extends LitElement {
     );
   }
 
+  /**
+  * Returns a string value for a state/attrubute:
+  * localized, following locale settings,
+  * accounting possible individual accuracy settings & possible "decimals" options
+  * @returns {string} value of a state/attribute
+  * @param {number|string} inState Value of a state/attribute ("unformatted")
+  * @param {number} index Index of an entity in config.entities
+  */
   computeState(inState, index) {
     if (this.config.state_map.length > 0) {
       const stateMap = Number.isInteger(inState)
@@ -741,13 +760,22 @@ class MiniGraphCard extends LitElement {
     }
 
     let state;
-    if (typeof inState === 'string') {
+    if (isUnavailableState(inState)) {
+      // as is
+      state = inState;
+    } else if (typeof inState === 'string') {
+      // attempt to fix an unexpected number format
       state = parseFloat(inState.replace(/,/g, '.'));
     } else {
+      // as is presented as a number
       state = Number(inState);
     }
+    const value_factor = 10 ** this.config.value_factor;
+    // safely process with a value_factor
+    state = Number.isNaN(Number(state)) ? state : state * value_factor;
 
     let dec;
+    // attempting to get "decimals" settings
     if (index === undefined) {
       // for a primary Y-axis
       dec = this.config.decimals_primary_labels !== undefined
@@ -765,49 +793,54 @@ class MiniGraphCard extends LitElement {
         : this.config.decimals;
     }
 
-    const value_factor = 10 ** this.config.value_factor;
     let value;
 
-    if (dec === undefined || Number.isNaN(dec) || Number.isNaN(state)) {
-      // default accuracy
+    if (dec === undefined || Number.isNaN(Number(dec)) || Number.isNaN(Number(state))) {
+      // no valid "decimals" settings defined, use a default accuracy
       if (index >= 0) {
         // formatting a state or attribute
-        const entityId = this.entity[index].entity_id;
-        const { attribute } = this.config.entities[index];
+        const entityId = this.config.entities[index].entity;
+        const attribute = this.config.entities[index].attribute;
         const stateObj = this._hass.states[entityId];
-        let parts;
-        if (attribute) {
-          parts = this._hass.formatEntityAttributeValueToParts(
+        if (attribute && !this.isObjectAttr(attribute)) {
+          // formatting not-object attribute
+          const attrParts = this._hass.formatEntityAttributeValueToParts(
             stateObj,
             attribute,
-            state * value_factor,
+            state,
+          );
+          value = attrParts.find((part) => part.type === 'value')?.value;
+          return value;
+        } else if (attribute && this.isObjectAttr(attribute)) {
+          // formatting object attribute - similar to Y-axis labels
+          return formatNumber(
+            state,
+            this._hass.locale
           );
         } else {
-          parts = this._hass.formatEntityStateToParts(
+          // formatting state
+          const stateParts = this._hass.formatEntityStateToParts(
             stateObj,
-            state * value_factor,
+            state,
           );
+          value = stateParts.find((part) => part.type === 'value')?.value;
+          return value;
         }
-        const partValue = parts.find(part => part.type === 'value');
-        value = partValue && partValue.value;
-        return value;
       } else {
         // formatting Y-axis (primary, secondary) labels
-        value = Number.isNaN(state) ? state : state * value_factor;
+        // use a default hard-coded accuracy
         return formatNumber(
-          value,
-          this._hass.locale,
+          state,
+          this._hass.locale
         );
       }
     }
 
-    // acuracy defined by dec
-    // const x = 10 ** dec;
-    value = state * value_factor;
+    // use an acuracy defined by "dec" variable
     return formatNumber(
-      value,
+      state,
       this._hass.locale,
-      { minimumFractionDigits: dec, maximumFractionDigits: dec },
+      { minimumFractionDigits: dec, maximumFractionDigits: dec }
     );
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -772,9 +772,7 @@ class MiniGraphCard extends LitElement {
       // default accuracy
       if (index >= 0) {
         // formatting a state or attribute
-        // eslint-disable-next-line prefer-destructuring
-        const entityId = this.config.entities[index].entity;
-        // eslint-disable-next-line prefer-destructuring
+        const entityId = this.entity[index].entity_id;
         const attribute = this.config.entities[index].attribute;
         const stateObj = this._hass.states[entityId];
         if (attribute) {

--- a/src/main.js
+++ b/src/main.js
@@ -775,23 +775,24 @@ class MiniGraphCard extends LitElement {
         const entityId = this.config.entities[index].entity;
         const attribute = this.config.entities[index].attribute;
         const stateObj = this._hass.states[entityId];
+        let part;
         if (attribute) {
           // formatting attribute
           const attrParts = this._hass.formatEntityAttributeValueToParts(
             stateObj,
             attribute,
-            state * value_factor
+            state * value_factor,
           );
-          const part = attrParts.find((part) => part.type === "value");
+          part = attrParts.find(part => part.type === 'value');
           value = part && part.value;
           return value;
         } else {
           // formatting state
           const stateParts = this._hass.formatEntityStateToParts(
             stateObj,
-            state * value_factor
+            state * value_factor,
           );
-          const part = stateParts.find((part) => part.type === "value");
+          part = stateParts.find(part => part.type === 'value');
           value = part && part.value;
           return value;
         }
@@ -800,7 +801,7 @@ class MiniGraphCard extends LitElement {
         value = Number.isNaN(state) ? state : state * value_factor;
         return formatNumber(
           value,
-          this._hass.locale
+          this._hass.locale,
         );
       }
     }
@@ -811,7 +812,7 @@ class MiniGraphCard extends LitElement {
     return formatNumber(
       value,
       this._hass.locale,
-      { minimumFractionDigits: dec, maximumFractionDigits: dec }
+      { minimumFractionDigits: dec, maximumFractionDigits: dec },
     );
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,7 @@ const decompress = data => (typeof data === 'string' ? JSON.parse(lzStringDecomp
 
 const getFirstDefinedItem = (...collection) => collection.find(item => typeof item !== 'undefined');
 
+// eslint-disable-next-line max-len
 const compareArray = (a, b) => a.length === b.length && a.every((value, index) => value === b[index]);
 
 const log = (message) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise */
 import { compress as lzStringCompress, decompress as lzStringDecompress } from '@kalkih/lz-string';
 
 const getMin = (arr, val) => arr.reduce((min, p) => (

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,6 @@ const decompress = data => (typeof data === 'string' ? JSON.parse(lzStringDecomp
 
 const getFirstDefinedItem = (...collection) => collection.find(item => typeof item !== 'undefined');
 
-// eslint-disable-next-line max-len
 const compareArray = (a, b) => a.length === b.length && a.every((value, index) => value === b[index]);
 
 const log = (message) => {


### PR DESCRIPTION
1. Define `decimals` options per entity.
2. Override a card-wide `decimal` option for each Y-axis by using new `decimals_primary_labels` & `decimals_secondary_labels`.
3. If no `decimals` options are defined (card-wide or per entity) - use default entity accuracy settings (individual entity accuracy settings are accounted).
4. Use HA frontend number format settings.
