### PR TITLE
fix: Migrate to ha-spinner 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -343,7 +343,7 @@ class MiniGraphCard extends LitElement {
             </div>
             ${this.renderLegend()}
         ` : html`
-          <ha-circular-progress indeterminate></ha-circular-progress>
+          <ha-spinner aria-label="Loading" size="small"></ha-spinner>
         `}
       </div>` : '';
   }

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import {
   getFirstDefinedItem,
   compareArray,
   log,
+  isPre2025_5,
 } from './utils';
 
 class MiniGraphCard extends LitElement {
@@ -332,6 +333,9 @@ class MiniGraphCard extends LitElement {
       && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator === false;
+    const loadingElement = isPre2025_5(this._hass)
+      ? html`<ha-circular-progress indeterminate></ha-circular-progress>`
+      : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`
@@ -343,9 +347,7 @@ class MiniGraphCard extends LitElement {
               </div>
             </div>
             ${this.renderLegend()}
-        ` : html`
-          <ha-spinner aria-label="Loading" size="small"></ha-spinner>
-        `}
+        ` : loadingElement}
       </div>` : '';
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,6 @@ import {
   getFirstDefinedItem,
   compareArray,
   log,
-  isPre2025_5,
 } from './utils';
 
 class MiniGraphCard extends LitElement {
@@ -333,9 +332,6 @@ class MiniGraphCard extends LitElement {
       && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator === false;
-    const loadingElement = isPre2025_5(this._hass)
-      ? html`<ha-circular-progress indeterminate></ha-circular-progress>`
-      : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`;
     return this.config.show.graph ? html`
       <div class="graph">
         ${ready ? html`
@@ -347,7 +343,7 @@ class MiniGraphCard extends LitElement {
               </div>
             </div>
             ${this.renderLegend()}
-        ` : loadingElement}
+        ` : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`}
       </div>` : '';
   }
 

--- a/src/style.js
+++ b/src/style.js
@@ -62,9 +62,6 @@ const style = css`
   ha-card[hover] {
     cursor: pointer;
   }
-  ha-circular-progress {
-    margin: auto; /*pre 2025.5*/
-  }
   ha-spinner {
     margin: 4px auto;
   }

--- a/src/style.js
+++ b/src/style.js
@@ -62,6 +62,9 @@ const style = css`
   ha-card[hover] {
     cursor: pointer;
   }
+  ha-circular-progress {
+    margin: auto; /*pre 2025.5*/
+  }
   ha-spinner {
     display: block;
     margin: 4px auto;

--- a/src/style.js
+++ b/src/style.js
@@ -67,8 +67,10 @@ const style = css`
   ha-card[hover] {
     cursor: pointer;
   }
-  ha-circular-progress {
-    margin: auto;
+  ha-spinner {
+    display: block;
+    margin: 4px auto;
+    text-align: center;
   }
   .flex {
     display: flex;

--- a/src/style.js
+++ b/src/style.js
@@ -66,9 +66,7 @@ const style = css`
     margin: auto; /*pre 2025.5*/
   }
   ha-spinner {
-    display: block;
     margin: 4px auto;
-    text-align: center;
   }
   .flex {
     display: flex;

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
-const isPre2025_5 = (hass) => hass && hass.config.version.split(".")[0] === "2025" && Number(hass.config.version.split(".")[1]) < 5;
+const isPre2025_5 = (hass) => hass && hass.config.version.split('.')[0] === '2025' && Number(hass.config.version.split('.')[1]) < 5;
 
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,9 +27,9 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
-const isPre2025_5 = hass => hass &&
-  Number(hass.config.version.split('.')[0]) <= 2025 &&
-  Number(hass.config.version.split('.')[1]) < 5;
+const isPre2025_5 = hass => hass
+  && Number(hass.config.version.split('.')[0]) <= 2025
+  && Number(hass.config.version.split('.')[1]) < 5;
 
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,13 +27,8 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
-const isPre2025_5 = hass => hass
-  && Number(hass.config.version.split('.')[0]) <= 2025
-  && Number(hass.config.version.split('.')[1]) < 5;
-
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,
   getFirstDefinedItem,
   compareArray,
-  isPre2025_5,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ const log = (message) => {
 };
 
 const isPre2025_5 = hass => hass &&
-  Number(hass.config.version.split('.')[0]) <= '2025' &&
+  Number(hass.config.version.split('.')[0]) <= 2025 &&
   Number(hass.config.version.split('.')[1]) < 5;
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
-const isPre2025_5 = (hass) => hass && hass.config.version.split('.')[0] === '2025' && Number(hass.config.version.split('.')[1]) < 5;
+const isPre2025_5 = hass => hass && hass.config.version.split('.')[0] === '2025' && Number(hass.config.version.split('.')[1]) < 5;
 
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,11 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
+const isPre2025_5 = (hass) => hass && hass.config.version.split(".")[0] === "2025" && Number(hass.config.version.split(".")[1]) < 5;
+
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,
   getFirstDefinedItem,
   compareArray,
+  isPre2025_5,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,9 @@ const log = (message) => {
   console.warn('mini-graph-card: ', message);
 };
 
-const isPre2025_5 = hass => hass && hass.config.version.split('.')[0] === '2025' && Number(hass.config.version.split('.')[1]) < 5;
+const isPre2025_5 = hass => hass &&
+  Number(hass.config.version.split('.')[0]) <= '2025' &&
+  Number(hass.config.version.split('.')[1]) < 5;
 
 export {
   getMin, getAvg, getMax, getTime, getMilli, compress, decompress, log,


### PR DESCRIPTION
Implements https://github.com/kalkih/mini-graph-card/issues/1222

The old `ha-circular-progress` was removed from HA (https://github.com/home-assistant/frontend/releases/tag/20250326.0).