### PR TITLE
fix: computeName() when no "friendly_name" available

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -691,7 +691,9 @@ class MiniGraphCard extends LitElement {
   }
 
   computeName(index) {
-    return this.config.entities[index].name || this.entity[index].attributes.friendly_name;
+    return this.config.entities[index].name
+      || this.entity[index].attributes.friendly_name
+      || this.entity[index].entity_id;
   }
 
   computeIcon(entity) {


### PR DESCRIPTION
Currently for numerical input helpers we see this:
![image](https://github.com/user-attachments/assets/b58a2515-41ef-4ab4-bf42-f88c06b39d8d)

No name is shown for the `input_number` entity (both on a top of the card & in a legend).

This happens because a `name` option was not defined for an entity & a `friendly_name` was not explicitly set as well.

With this PR:
![image](https://github.com/user-attachments/assets/e7972d2c-9f55-4be6-8883-0fbf93dca192)

Test code:
```
type: custom:mini-graph-card
entities:
  - entity: sensor.some_sensor
  - entity: input_number.testing_number
```