### PR TITLE
fix: computeUom() for attribute & empty unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
 | icon_image | string |  | v0.12.0 | Override icon with an image url
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
-| unit | string |  | v0.0.1 | Set a custom unit of measurement.
+| unit | string |  | v0.0.1 | Set a custom unit of measurement (`''` value for an empty unit).
 | tap_action | [action object](#action-object-options) |  | v0.7.0 | Action on click/tap.
 | group | boolean | `false` | v0.2.0 | Disable paddings and box-shadow, useful when nesting the card.
 | hours_to_show | integer | `24` | v0.0.2 | Specify how many hours of history the graph should present.
@@ -127,7 +127,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state
 | name | string |         | Set a custom display name, defaults to entity's friendly_name.
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
-| unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config.
+| unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | show_state | boolean |         | Display the current state.
 | show_legend_state | boolean |  false  | Display the current state as part of the legend.

--- a/src/main.js
+++ b/src/main.js
@@ -707,8 +707,11 @@ class MiniGraphCard extends LitElement {
     return (
       this.config.entities[index].unit
       || this.config.unit
-      || this.entity[index].attributes.unit_of_measurement
-      || ''
+      || (
+        !this.config.entities[index].attribute
+          ? (this.entity[index].attributes.unit_of_measurement || '')
+          : ''
+      )
     );
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -705,13 +705,17 @@ class MiniGraphCard extends LitElement {
 
   computeUom(index) {
     return (
-      this.config.entities[index].unit
-      || this.config.unit
-      || (
-        !this.config.entities[index].attribute
-          ? (this.entity[index].attributes.unit_of_measurement || '')
-          : ''
-      )
+      this.config.entities[index].unit !== undefined
+        ? this.config.entities[index].unit
+        : (
+          this.config.unit !== undefined
+            ? this.config.unit
+            : (
+              !this.config.entities[index].attribute
+                ? (this.entity[index].attributes.unit_of_measurement || '')
+                : ''
+            )
+        )
     );
   }
 


### PR DESCRIPTION
Two issues are fixed:

1. When an `attribute` option is defined & no `unit` is set - ignore `unit_of_measurement`.

Entity:
![image](https://github.com/user-attachments/assets/f2346512-3c48-4054-8d61-66ba5e4d2642)

Before:
![image](https://github.com/user-attachments/assets/2604f972-e8c5-489b-8d3b-a68b5a98fb27)

After:
![image](https://github.com/user-attachments/assets/09141bc9-a4cf-4ac3-a2e5-1ce7ed6fcc16)


Test card:
```
type: custom:mini-graph-card
entities:
  - entity: sensor.carbon_dioxide
    attribute: battery_level
```

Actually, HA frontend has a support of uoms for attributes; this hopefully will be implemented in `mini-graph-card` in future.

2. When an empty unit is defined - a default uom is still used:
Before:
![image](https://github.com/user-attachments/assets/5ec731cd-1f1f-42d3-b85d-7fbc85006ba6)

After:
![image](https://github.com/user-attachments/assets/901d72a5-bac6-45b3-b547-f7c30faba064)

Test cards:
```
      - type: custom:mini-graph-card
        name: empty for entity
        entities:
          - entity: sensor.carbon_dioxide
            unit: ''

      - type: custom:mini-graph-card
        name: empty for card
        entities:
          - entity: sensor.carbon_dioxide
        unit: ''
```
