### PR TITLE
fix: Process absent UoM in computeLegend()

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -355,11 +355,15 @@ class MiniGraphCard extends LitElement {
     const { show_legend_state = false } = this.config.entities[index];
 
     if (show_legend_state) {
-      if (this.computeUom(index) === '%') {
-        legend += ` (${this.computeState(state)}${this.computeUom(index)})`;
-      } else {
-        legend += ` (${this.computeState(state)} ${this.computeUom(index)})`;
+      legend += ' (' + this.computeState(state);
+      if (state !== 'unavailable') {
+        const uom = this.computeUom(index);
+        if (uom !== '%' && uom !== '')
+          legend += ' ';
+        else
+          legend += uom;
       }
+      legend += ')';
     }
 
     return legend;

--- a/src/main.js
+++ b/src/main.js
@@ -355,13 +355,13 @@ class MiniGraphCard extends LitElement {
     const { show_legend_state = false } = this.config.entities[index];
 
     if (show_legend_state) {
-      legend += ' (' + this.computeState(state);
+      legend += ` (${this.computeState(state)}`;
       if (state !== 'unavailable') {
         const uom = this.computeUom(index);
         if (uom !== '%' && uom !== '')
           legend += ' ';
         else
-          legend += uom;
+          legend += `${uom}`;
       }
       legend += ')';
     }

--- a/src/main.js
+++ b/src/main.js
@@ -360,8 +360,7 @@ class MiniGraphCard extends LitElement {
         const uom = this.computeUom(index);
         if (uom !== '%' && uom !== '')
           legend += ' ';
-        else
-          legend += `${uom}`;
+        legend += `${uom}`;
       }
       legend += ')';
     }

--- a/src/main.js
+++ b/src/main.js
@@ -356,7 +356,7 @@ class MiniGraphCard extends LitElement {
 
     if (show_legend_state) {
       legend += ` (${this.computeState(state)}`;
-      if (state !== 'unavailable') {
+      if (!(['unavailable'].include(state))) {
         const uom = this.computeUom(index);
         if (!(['%', ''].includes(uom)))
           legend += ' ';

--- a/src/main.js
+++ b/src/main.js
@@ -356,7 +356,7 @@ class MiniGraphCard extends LitElement {
 
     if (show_legend_state) {
       legend += ` (${this.computeState(state)}`;
-      if (!(['unavailable'].include(state))) {
+      if (!(['unavailable'].includes(state))) {
         const uom = this.computeUom(index);
         if (!(['%', ''].includes(uom)))
           legend += ' ';

--- a/src/main.js
+++ b/src/main.js
@@ -358,7 +358,7 @@ class MiniGraphCard extends LitElement {
       legend += ` (${this.computeState(state)}`;
       if (state !== 'unavailable') {
         const uom = this.computeUom(index);
-        if (uom !== '%' && uom !== '')
+        if (!(['%', ''].includes(uom)))
           legend += ' ';
         legend += `${uom}`;
       }


### PR DESCRIPTION
If `computeUom()` returns `''` - do not include UoM in a legend (causing a trailing whitespace).

Before:
![image](https://github.com/user-attachments/assets/7b8346ab-0420-4cb2-8e31-d4a42d9d1383)

After:
![image](https://github.com/user-attachments/assets/dad97a0c-d6e9-43dc-bbf8-edbf2665325a)

Test code:
```
type: custom:mini-graph-card
entities:
  - entity: input_number.testing_number
    name: some number
    show_legend_state: true
  - entity: sensor.ac66u_nvram_free
```