### PR TITLE
fix: state: last to use value from last Graph coordinate

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -276,7 +276,7 @@ class MiniGraphCard extends LitElement {
   getEntityState(id) {
     const entityConfig = this.config.entities[id];
     if (this.config.show.state === 'last') {
-      return this.points[id][this.points[id].length - 1][V];
+      return this.Graph[id].coords[this.Graph[id].coords.length - 1][V];
     } else if (entityConfig.attribute) {
       return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);
     } else {


### PR DESCRIPTION
Currently, `state: last` breaks rendering with bar charts (#1248) because `points` are not calculated for bar charts.
This fix accesses the value of the last coordinate from the `Graph` instead, which is exactly what I want to have displayed when using this option.
To my understanding (and testing), using the last `coord` is a simpler and more reliable fix than always calculating `points` (ref #1075), because the last `point` for a grouped bar chart is not the value of the last coordinate (the last `point` is actually the average of the last two states, so a completely different value). (Surprisingly, the same is true for grouped line graphs, where the point is selectable and shows this incorrect value as the hover state, but that may be a different issue.)