### PR TITLE
fix: style for icon[loc=right]

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -109,6 +109,9 @@ const style = css`
     margin-right: .6em;
     margin-left: 0;
   }
+  .icon[loc="right"] {
+    margin-left: auto;
+  }
   .icon[loc="state"] {
     align-self: center;
   }


### PR DESCRIPTION
When a name is hidden and `align_icon: right`, we can see an icon left-aligned:
```
  - type: custom:mini-graph-card
    entities:
      - sensor.xxx
    show:
      name: false
    align_icon: right
```
<img width="477" height="216" alt="image" src="https://github.com/user-attachments/assets/5e82448d-4e8f-4ab7-82a2-7ee8be148d06" />

After the fix:
<img width="474" height="218" alt="image" src="https://github.com/user-attachments/assets/15499b7a-a167-4498-b9d9-afb0ec1aa203" />
