### PR TITLE
fix: getEntityState() for "last" & "bar"

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -276,7 +276,11 @@ class MiniGraphCard extends LitElement {
   getEntityState(id) {
     const entityConfig = this.config.entities[id];
     if (this.config.show.state === 'last') {
-      return this.points[id][this.points[id].length - 1][V];
+      if (this.config.show.graph === 'bar') {
+        return this.bar[id][this.bar[id].length - 1].value;
+      } else {
+        return this.points[id][this.points[id].length - 1][V];
+      }
     } else if (entityConfig.attribute) {
       return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);
     } else {

--- a/src/main.js
+++ b/src/main.js
@@ -271,9 +271,9 @@ class MiniGraphCard extends LitElement {
 
   /**
   * Returns an object attrubute value
-  * @returns {any} value of an attribute/subattribute
+  * @returns {any} Value of an attribute/subattribute
   * @param obj stateObj.attributes
-  * @param path attribute defined as either a singular attribute or a tree-like path
+  * @param path Attribute defined as either a singular attribute or a tree-like path
   */
   getObjectAttr(obj, path) {
     return path.split('.').reduce((res, key) => res && res[key], obj);

--- a/src/main.js
+++ b/src/main.js
@@ -275,12 +275,10 @@ class MiniGraphCard extends LitElement {
 
   getEntityState(id) {
     const entityConfig = this.config.entities[id];
-    if (this.config.show.state === 'last') {
-      if (this.config.show.graph === 'bar') {
-        return this.bar[id][this.bar[id].length - 1].value;
-      } else {
-        return this.points[id][this.points[id].length - 1][V];
-      }
+    if (this.config.show.state === 'last' && this.config.show.graph === 'bar') {
+      return this.bar[id][this.bar[id].length - 1].value;
+    } else if (this.config.show.state === 'last' && this.points[id] && this.points[id].length) {
+      return this.points[id][this.points[id].length - 1][V];
     } else if (entityConfig.attribute) {
       return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);
     } else {

--- a/src/main.js
+++ b/src/main.js
@@ -269,20 +269,36 @@ class MiniGraphCard extends LitElement {
       `;
   }
 
+  /**
+  * Returns an object attrubute value
+  * @returns {any} value of an attribute/subattribute
+  * @param obj stateObj.attributes
+  * @param path attribute defined as either a singular attribute or a tree-like path
+  */
   getObjectAttr(obj, path) {
     return path.split('.').reduce((res, key) => res && res[key], obj);
   }
 
-  getEntityState(id) {
-    const entityConfig = this.config.entities[id];
+  /**
+  * Returns a state/attrubute value 
+  * @returns {any} value of a state/attribute
+  * @param {number} index Index of an entity in config.entities
+  */
+  getEntityState(index) {
+    const entityConfig = this.config.entities[index];
     if (this.config.show.state === 'last' && this.config.show.graph === 'bar') {
-      return this.bar[id][this.bar[id].length - 1].value;
-    } else if (this.config.show.state === 'last' && this.points[id] && this.points[id].length) {
-      return this.points[id][this.points[id].length - 1][V];
+      // last "bar" value
+      return this.bar[index][this.bar[index].length - 1].value;
+    } else if (this.config.show.state === 'last' && this.points[index] && this.points[index].length) {
+      // last "point" value
+      // only if "points" exist (show_points: true)
+      return this.points[index][this.points[index].length - 1][V];
     } else if (entityConfig.attribute) {
-      return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);
+      // current attribute value
+      return this.getObjectAttr(this.entity[index].attributes, entityConfig.attribute);
     } else {
-      return this.entity[id].state;
+      // current state value
+      return this.entity[index].state;
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -280,7 +280,7 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-  * Returns a state/attrubute value 
+  * Returns a state/attrubute value
   * @returns {any} value of a state/attribute
   * @param {number} index Index of an entity in config.entities
   */


### PR DESCRIPTION
Currently using "last" & "bar" causes a card to be not rendered due to an error.
```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
show:
  state: last
  graph: bar
```
<img width="1539" height="845" alt="image" src="https://github.com/user-attachments/assets/c413baef-e7f4-4d73-bb2e-90a2bfc006e9" />

It happens because "this.points" is not defined if graph type = "bar".

After the fix:
<img width="1447" height="611" alt="image" src="https://github.com/user-attachments/assets/cdc38368-5886-4e56-a959-46c9b31eb8ef" />