### PR TITLE
feat: add per-entity logarithmic override

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The card works with entities from within the **sensor** & **binary_sensor** doma
 
 ## Install
 
-### HACS (recommended) 
+### HACS (recommended)
 
 This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community Store).
 
@@ -210,7 +210,7 @@ color_thresholds:
   - value: 4
     color: "#0000ff"
 ```
-The example above will result in the following colors of the graph: if value is 
+The example above will result in the following colors of the graph: if value is
 * between `0` (including this value) and  `1.33333`, the color is `#ff0000`,
 * between `1.33333` (including this value) and `2.666667`, the color is `#ffff00`,
 * between `2.666667` (including this value) and `4`, the color is `#00ff00`,
@@ -258,6 +258,12 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `sum` | v0.9.2 |
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
+
+### Logarithmic options
+
+Normally gaps between numbers on the graph are equal; the gap between 1 and 2 on the graph is the same as the gap between 100 and 101. The `logarithmic` option applies a [logarithmic transformation](https://en.wikipedia.org/wiki/Log_transformation_(statistics)) to the graph. With `logarithmic`, the graph is scaled by powers of 10, so the gap between 1, 10, 100, etc are equal. This is useful when your values span a wide range. Illuminance, for example, can swing from 1 to 5000 over the course of a day, and without a transformation it's hard to read the smaller values on the graph.
+
+Note that this option rounds up the input to 1 so negative numbers or numbers less than 1 are rendered as 0; this is different from the formal definition of logarithm, where `log(x) == 0` when `x<1` and $\infty$ when `x<0`.
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
 | value_factor | number | 0 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
-| logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph
+| logarithmic | boolean | `false` | v0.10.0 | Use a logarithmic scale for the graph.
 
 
 #### Entities object
@@ -144,6 +144,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | y_axis | string |         | If 'secondary', displays using the secondary y-axis on the right.
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
+| logarithmic | boolean |         | Override logarithmic scaling for this entity only.
 
 ```yaml
 entities:

--- a/src/graph.js
+++ b/src/graph.js
@@ -43,6 +43,10 @@ export default class Graph {
 
   set min(min) { this._min = min; }
 
+  get logarithmic() { return this._logarithmic; }
+
+  set logarithmic(logarithmic) { this._logarithmic = logarithmic; }
+
   set history(data) { this._history = data; }
 
   update(history = undefined) {
@@ -153,8 +157,8 @@ export default class Graph {
     return path;
   }
 
-  computeGradient(thresholds, logarithmic) {
-    const scale = logarithmic
+  computeGradient(thresholds) {
+    const scale = this._logarithmic
       ? Math.log10(Math.max(1, this._max)) - Math.log10(Math.max(1, this._min))
       : this._max - this._min;
 
@@ -170,7 +174,7 @@ export default class Graph {
       let offset;
       if (scale <= 0) {
         offset = 0;
-      } else if (logarithmic) {
+      } else if (this._logarithmic) {
         offset = (Math.log10(Math.max(1, this._max))
           - Math.log10(Math.max(1, stop.value)))
           * (100 / scale);

--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,7 @@ class MiniGraphCard extends LitElement {
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
       this.Graph = this.config.entities.map(
-        entity => new Graph(
+        (entity, index) => new Graph(
           500,
           this.config.height,
           [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
@@ -121,7 +121,7 @@ class MiniGraphCard extends LitElement {
             this.config.smoothing,
             !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
           ),
-          this.config.logarithmic,
+          this.computeUsesLogarithmic(index),
         ),
       );
     }
@@ -667,6 +667,19 @@ class MiniGraphCard extends LitElement {
     return this.secondaryYaxisEntities.map(entity => this.Graph[entity.index]);
   }
 
+  /**
+   * Checks whether an entity uses logarithmic scaling.
+   * @param {number} index Index of an entity in config.entities
+   * @returns {boolean} True if the entity uses logarithmic scaling, otherwise false
+   */
+  computeUsesLogarithmic(index) {
+    return getFirstDefinedItem(
+      this.config.entities[index].logarithmic,
+      this.config.logarithmic,
+      false,
+    );
+  }
+
   computeColor(inState, i) {
     const { color_thresholds, line_color } = this.config;
     const state = Number(inState) || 0;
@@ -796,6 +809,7 @@ class MiniGraphCard extends LitElement {
       let graphPos = 0;
       this.entity.forEach((entity, i) => {
         if (!entity || this.Graph[i].coords.length === 0) return;
+        this.Graph[i].logarithmic = this.computeUsesLogarithmic(i);
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
@@ -811,9 +825,7 @@ class MiniGraphCard extends LitElement {
             this.points[i] = this.Graph[i].getPoints();
           }
           if (config.color_thresholds.length > 0 && !config.entities[i].color)
-            this.gradient[i] = this.Graph[i].computeGradient(
-              config.color_thresholds, this.config.logarithmic,
-            );
+            this.gradient[i] = this.Graph[i].computeGradient(config.color_thresholds);
         }
       });
       this.line = [...this.line];


### PR DESCRIPTION
Adds per-entity logarithmic configuration so mixed-scale graphs work correctly.

Specifying 'secondary' for the y-axis isn't enough for my use-case. I have a graph with two waveforms: one waveform is brightness on the primary y-axis (roughly 1 to 5000), while another waveform is sunrise/sunset on the secondary y-axis (boolean 0/1). With only global `logarithmic: true`, the sunrise/sunset waveform breaks; this change allows keeping brightness logarithmic while leaving sunrise/sunset linear via entity-level override.

Resolves https://github.com/kalkih/mini-graph-card/issues/862


| Current | Example of why `logarithmic: true` globally doesn't work | Example with the fix |
|--------|--------|--------|
| <img src="https://github.com/user-attachments/assets/81b27df4-949a-43bb-a19a-7e4b3a97bae6" /> | <img src="https://github.com/user-attachments/assets/d73f03e6-48be-48d7-a138-b3e6d8efe0e6" /> | <img src="https://github.com/user-attachments/assets/5a3f2d70-bc23-466d-9f0b-6960fdd10c26" /> | 
