### PR TITLE
feat: Use native localized units & order "value - delimiter - unit"

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -10,6 +10,7 @@ rules:
   class-methods-use-this: 0
   no-nested-ternary: 0
   camelcase: 0
+  import/prefer-default-export: 0
 globals:
   window: true
   Event: true

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | type ***(required)*** | string |  | v0.0.1 | `custom:mini-graph-card`.
 | entities ***(required)*** | list |  | v0.2.0 | One or more sensor entities in a list, see [entities object](#entities-object) for additional entity options.
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
-| icon_image | string |  | v0.12.0 | Override icon with an image url
+| icon_image | string |  | v0.12.0 | Override icon with an image url.
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
 | unit | string |  | v0.0.1 | Set a custom unit of measurement (`''` value for an empty unit).
 | tap_action | [action object](#action-object-options) |  | v0.7.0 | Action on click/tap.
@@ -117,7 +117,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
 | value_factor | number | 0 | v0.9.4 | Scale value by order of magnitude (e.g. convert Watts to kilo Watts), use negative value to scale down.
-| logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph
+| logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph.
 
 
 #### Entities object
@@ -168,6 +168,7 @@ All properties are optional.
 | legend | `true` | `true` / `false` | Display the graph legend (only shown when graph contains multiple entities).
 | average | `false` | `true` / `false` | Display average information.
 | extrema | `false` | `true` / `false` | Display max/min information.
+| info_hide_unit | `false` | `true` / `false` | Do not show a unit for the average & max/min information.
 | labels | `hover` | `true` / `false` / `hover` | Display Y-axis labels.
 | labels_secondary | `hover` | `true` / `false` / `hover` | Display secondary Y-axis labels.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.

--- a/src/locale.js
+++ b/src/locale.js
@@ -20,7 +20,6 @@ const blankBeforePercent = (
   }
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export {
   blankBeforePercent,
 };

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,7 +1,7 @@
 /**
  * Checks if a whitespace is needed before a "%" unit dependently on a locale
  * @param {FrontendLocaleData} localeOptions Object containing
- * a user-selected language and formatting
+ * a user-selected language and formatting settings
  * @returns {string} Whitespace if needed before "%", empty otherwise
  */
 const blankBeforePercent = (localeOptions) => {

--- a/src/locale.js
+++ b/src/locale.js
@@ -8,15 +8,15 @@ const blankBeforePercent = (
   localeOptions, // FrontendLocaleData
 ) => {
   switch (localeOptions.language) {
-    case "cs":
-    case "de":
-    case "fi":
-    case "fr":
-    case "sk":
-    case "sv":
-      return " ";
+    case 'cs':
+    case 'de':
+    case 'fi':
+    case 'fr':
+    case 'sk':
+    case 'sv':
+      return ' ';
     default:
-      return "";
+      return '';
   }
 };
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -20,6 +20,7 @@ const blankBeforePercent = (
   }
 };
 
+// eslint-disable-next-line import/prefer-default-export
 export {
   blankBeforePercent,
 };

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,12 +1,10 @@
-// This function is taken from HA Frontend
 /**
  * Checks if a whitespace is needed before a "%" unit dependently on a locale
- * @param localeOptions Object containing a user-selected language and formatting
+ * @param {FrontendLocaleData} localeOptions Object containing
+ * a user-selected language and formatting
  * @returns {string} Whitespace if needed before "%", empty otherwise
  */
-const blankBeforePercent = (
-  localeOptions, // FrontendLocaleData
-) => {
+const blankBeforePercent = localeOptions => {
   switch (localeOptions.language) {
     case 'cs':
     case 'de':

--- a/src/locale.js
+++ b/src/locale.js
@@ -4,7 +4,7 @@
  * a user-selected language and formatting
  * @returns {string} Whitespace if needed before "%", empty otherwise
  */
-const blankBeforePercent = localeOptions => {
+const blankBeforePercent = (localeOptions) => {
   switch (localeOptions.language) {
     case 'cs':
     case 'de':

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,7 +1,7 @@
 // This function is taken from HA Frontend
 /**
- * Check if a whitespace is needed before a "%" unit dependently on a locale
- * @param localeOptions The user-selected language and formatting, from `hass.locale`
+ * Checks if a whitespace is needed before a "%" unit dependently on a locale
+ * @param localeOptions Object containing a user-selected language and formatting
  * @returns {string} Whitespace if needed before "%", empty otherwise
  */
 const blankBeforePercent = (

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,25 @@
+// This function is taken from HA Frontend
+/**
+ * Check if a whitespace is needed before a "%" unit dependently on a locale
+ * @param localeOptions The user-selected language and formatting, from `hass.locale`
+ * @returns {string} Whitespace if needed before "%", empty otherwise
+ */
+const blankBeforePercent = (
+  localeOptions, // FrontendLocaleData
+) => {
+  switch (localeOptions.language) {
+    case "cs":
+    case "de":
+    case "fi":
+    case "fr":
+    case "sk":
+    case "sv":
+      return " ";
+    default:
+      return "";
+  }
+};
+
+export {
+  blankBeforePercent,
+};

--- a/src/locale.js
+++ b/src/locale.js
@@ -553,8 +553,8 @@ const formatNumber = (
   localeOptions,
   options,
 ) => formatNumberToParts(num, localeOptions, options)
-    .map(part => part.value)
-    .join('');
+  .map(part => part.value)
+  .join('');
 
 /**
  * Checks if a whitespace is needed before a "%" unit dependently on a locale

--- a/src/main.js
+++ b/src/main.js
@@ -618,13 +618,14 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
+    const hideUnit = this.config.show.info_hide_unit;
     return this.abs.length > 0 ? html`
       <div class="info flex">
         ${this.abs.map(entry => html`
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
-              ${this.computeStateWithUom(entry.state, 0)}
+              ${this.computeStateWithUom(entry.state, 0, hideUnit)}
             </span>
             <span class="info__item__time">
               ${entry.type !== 'avg' ? getTime(new Date(entry.last_changed), this.config.format, this._hass.language) : ''}
@@ -829,30 +830,35 @@ class MiniGraphCard extends LitElement {
   * @returns {string} State/attrubute value presentation
   * @param {number|string} inState Value of a state/attribute
   * @param {number} index Index of an entity in config.entities
+  * @param {boolean} [hideUnit] Do not show a unit for a value
   */
-  computeStateWithUom(inState, index) {
+  computeStateWithUom(inState, index, hideUnit) {
     // get a state/attribute value
     const state = this.computeState(inState, index);
+
     // get a unit
-    const unit = this.computeUom(index);
-    // get an order & delimiter
-    const { directOrder, delimiter } = this.computeStateOrder(index);
-    let revisedDelimiter;
+    const unit = hideUnit ? '' : this.computeUom(index);
+
+    // get native order & delimiter
+    const { directOrder, delimiter: nativeDelimiter } = this.computeStateOrder(index);
+
+    let delimiter;
     if (unit === '') {
-      revisedDelimiter = '';
+      delimiter = '';
     } else if (directOrder
       && !delimiter
       && (this.config.unit || this.config.entities[index].unit)
       && (unit !== '%'
         || blankBeforePercent(this._hass.locale) === ' ')) {
       // add a delimiter for a user-defined unit (except for "%" for some locales)
-      revisedDelimiter = ' ';
+      delimiter = ' ';
     } else {
-      revisedDelimiter = delimiter;
+      delimiter = nativeDelimiter;
     }
+
     // compose a string
     const composed = directOrder
-      ? `${state}${revisedDelimiter}${unit}`
+      ? `${state}${delimiter}${unit}`
       : `${unit}${delimiter}${state}`;
     return composed;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -299,7 +299,7 @@ class MiniGraphCard extends LitElement {
       const value = isTooltip ? tooltipValue : state;
       const entity = isTooltip ? tooltipEntity : id;
       const entityConfig = this.config.entities[entity];
-      // check if a unit shold precend a value
+      // check if a unit should precend a value
       const { directOrder } = this.computeStateOrder(entity);
       return html`
         <div

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,8 @@ import {
   log,
 } from './utils';
 
+const isUnavailableState = value => ['unavailable', 'unknown'].includes(value);
+
 class MiniGraphCard extends LitElement {
   constructor() {
     super();
@@ -813,10 +815,10 @@ class MiniGraphCard extends LitElement {
       const directOrder = indexUnit === -1 || indexUnit > indexValue;
       const delimiterPart = parts.find(part => part.type === 'literal');
       const delimiter = delimiterPart && delimiterPart.value;
-      return { directOrder, delimiter: delimiter || ''};
+      return { directOrder, delimiter: delimiter || '' };
     } else {
       // object attribute
-      return { directOrder: true, delimiter: ' '};
+      return { directOrder: true, delimiter: ' ' };
     }
   }
 
@@ -836,7 +838,7 @@ class MiniGraphCard extends LitElement {
     let revisedDelimiter;
     if (unit === '') {
       revisedDelimiter = '';
-    } else  if (directOrder
+    } else if (directOrder
       && !delimiter
       && (this.config.unit || this.config.entities[index].unit)
       && (unit !== '%'

--- a/src/main.js
+++ b/src/main.js
@@ -712,8 +712,10 @@ class MiniGraphCard extends LitElement {
     if (!stateObj || isUnavailableState(stateObj.state)) {
       unit = '';
     } else if (this.config.entities[index].unit !== undefined) {
+      // eslint-disable-next-line prefer-destructuring
       unit = this.config.entities[index].unit;
     } else if (this.config.unit !== undefined) {
+      // eslint-disable-next-line prefer-destructuring
       unit = this.config.unit;
     } else {
       // retrieving a native unit

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,9 @@ import Graph from './graph';
 import style from './style';
 import handleClick from './handleClick';
 import buildConfig from './buildConfig';
+import {
+  blankBeforePercent,
+} from './locale';
 import './initialize';
 import { version } from '../package.json';
 
@@ -294,8 +297,11 @@ class MiniGraphCard extends LitElement {
       const value = isTooltip ? tooltipValue : state;
       const entity = isTooltip ? tooltipEntity : id;
       const entityConfig = this.config.entities[entity];
+      // check if a unit shold precend a value
+      const { directOrder } = this.computeStateOrder(index);
       return html`
         <div
+          reversed=${!directOrder}
           class="state ${!isPrimary && 'state--small'}"
           @click=${e => this.handlePopup(e, this.entity[id])}
           style=${entityConfig.state_adaptive_color ? `color: ${this.computeColor(value, entity)}` : ''}>
@@ -350,20 +356,10 @@ class MiniGraphCard extends LitElement {
   computeLegend(index) {
     let legend = this.computeName(index);
     const state = this.getEntityState(index);
-
     const { show_legend_state = false } = this.config.entities[index];
-
     if (show_legend_state) {
-      legend += ` (${this.computeState(state)}`;
-      if (!(['unavailable'].includes(state))) {
-        const uom = this.computeUom(index);
-        if (!(['%', ''].includes(uom)))
-          legend += ' ';
-        legend += `${uom}`;
-      }
-      legend += ')';
+      legend += ` (${this.computeStateWithUom(state, index)})`;
     }
-
     return legend;
   }
 
@@ -626,7 +622,7 @@ class MiniGraphCard extends LitElement {
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>
             <span class="info__item__value">
-              ${this.computeState(entry.state)} ${this.computeUom(0)}
+              ${this.computeStateWithUom(entry.state, 0)}
             </span>
             <span class="info__item__time">
               ${entry.type !== 'avg' ? getTime(new Date(entry.last_changed), this.config.format, this._hass.language) : ''}
@@ -708,19 +704,39 @@ class MiniGraphCard extends LitElement {
   }
 
   computeUom(index) {
-    return (
-      this.config.entities[index].unit !== undefined
-        ? this.config.entities[index].unit
-        : (
-          this.config.unit !== undefined
-            ? this.config.unit
-            : (
-              !this.config.entities[index].attribute
-                ? (this.entity[index].attributes.unit_of_measurement || '')
-                : ''
-            )
-        )
-    );
+    const entityId = this.entity[index].entity_id;
+    const stateObj = this._hass.states[entityId];
+    let unit;
+    if (!stateObj || isUnavailableState(stateObj.state)) {
+      unit = '';
+    } else if (this.config.entities[index].unit !== undefined) {
+      unit = this.config.entities[index].unit;
+    } else if (this.config.unit !== undefined) {
+      unit = this.config.unit;
+    } else {
+      // retrieving a native unit
+      const { attribute } = this.config.entities[index];
+      if (!attribute || !this.isObjectAttr(attribute)) {
+        // any cases except an object attribute
+        let parts;
+        if (attribute) {
+          parts = this._hass.formatEntityAttributeValueToParts(
+            stateObj,
+            attribute,
+          );
+        } else {
+          parts = this._hass.formatEntityStateToParts(
+            stateObj,
+          );
+        }
+        const unitPart = parts.find(part => part.type === 'unit');
+        unit = unitPart && unitPart.value;
+      } else {
+        // object attribute - considered as unitless
+        unit = '';
+      }
+    }
+    return (unit || '');
   }
 
   computeState(inState) {
@@ -767,6 +783,74 @@ class MiniGraphCard extends LitElement {
       this.stateChanged = false;
       this.updateData();
     }
+  }
+
+  /**
+  * Returns settings defining an order of a state/attrubute value presentation
+  * @returns {Object}
+  * directOrder - true: "value literal unit", false: "unit literal value";
+  *
+  * delimiter - an optional literal separator between value & unit
+  * @param index Index of an entity in config.entities
+  */
+  computeStateOrder(index) {
+    const entityId = this.config.entities[index].entity;
+    const { attribute } = this.config.entities[index];
+    if (!attribute || !this.isObjectAttr(attribute)) {
+      // any cases except an object attribute
+      const stateObj = this._hass.states[entityId];
+      let parts;
+      if (attribute) {
+        parts = this._hass.formatEntityAttributeValueToParts(
+          stateObj,
+          attribute,
+        );
+      } else {
+        parts = this._hass.formatEntityStateToParts(stateObj);
+      }
+      const indexUnit = parts.findIndex(part => part.type === 'unit');
+      const indexValue = parts.findIndex(part => part.type === 'value');
+      const directOrder = indexUnit === -1 || indexUnit > indexValue;
+      const delimiterPart = parts.find(part => part.type === 'literal');
+      const delimiter = delimiterPart && delimiterPart.value;
+      return { directOrder, delimiter: delimiter || ''};
+    } else {
+      // object attribute
+      return { directOrder: true, delimiter: ' '};
+    }
+  }
+
+  /**
+  * Returns a string state/attrubute value presentation
+  * @returns {string} State/attrubute value presentation
+  * @param {number|string} inState Value of a state/attribute
+  * @param {number} index Index of an entity in config.entities
+  */
+  computeStateWithUom(inState, index) {
+    // get a state/attribute value
+    const state = this.computeState(inState, index);
+    // get a unit
+    const unit = this.computeUom(index);
+    // get an order & delimiter
+    const { directOrder, delimiter } = this.computeStateOrder(index);
+    let revisedDelimiter;
+    if (unit === '') {
+      revisedDelimiter = '';
+    } else  if (directOrder
+      && !delimiter
+      && (this.config.unit || this.config.entities[index].unit)
+      && (unit !== '%'
+        || blankBeforePercent(this._hass.locale) === ' ')) {
+      // add a delimiter for a user-defined unit (except for "%" for some locales)
+      revisedDelimiter = ' ';
+    } else {
+      revisedDelimiter = delimiter;
+    }
+    // compose a string
+    const composed = directOrder
+      ? `${state}${revisedDelimiter}${unit}`
+      : `${unit}${delimiter}${state}`;
+    return composed;
   }
 
   async updateData({ config } = this) {

--- a/src/main.js
+++ b/src/main.js
@@ -300,7 +300,7 @@ class MiniGraphCard extends LitElement {
       const entity = isTooltip ? tooltipEntity : id;
       const entityConfig = this.config.entities[entity];
       // check if a unit shold precend a value
-      const { directOrder } = this.computeStateOrder(index);
+      const { directOrder } = this.computeStateOrder(entity);
       return html`
         <div
           reversed=${!directOrder}

--- a/src/style.js
+++ b/src/style.js
@@ -165,6 +165,7 @@ const style = css`
     flex-wrap: nowrap;
     max-width: 100%;
     min-width: 0;
+    gap: .25rem;
   }
   .state > svg {
     align-self: center;
@@ -197,8 +198,10 @@ const style = css`
   .state__value {
     display: inline-block;
     font-size: 2.4em;
-    margin-right: .25rem;
     line-height: 1.2em;
+  }
+  .state[reversed="true"] .state__value {
+    order: 5;
   }
   .state__uom {
     flex: 1;


### PR DESCRIPTION
Adds more features to https://github.com/kalkih/mini-graph-card/pull/1233.
So, suggest to test along with https://github.com/kalkih/mini-graph-card/pull/1233 merged.

Additionally - implements https://github.com/kalkih/mini-graph-card/issues/1287.

---

**Features:**

Support of native units for attributes; example - temperatures in `climate.ecobee` of Demo integration:

<img width="630" height="422" alt="image" src="https://github.com/user-attachments/assets/16b15061-5d6b-4198-ae62-edd5700fc7a8" />

---

Support of native presentation of "percentage" values: some locales like “German” demand a presence of a whitespace between a value & "%", some like “English” do not place a whitespace:

<img width="719" height="563" alt="image" src="https://github.com/user-attachments/assets/4b128d42-ab00-48ab-9a3a-40e9377ec63c" />

---

Support of native localized units dependently on a locale.
Support of native reversed order for a state/attribute value presentation dependently on a locale.
Example - monetary values:

Language: "English (GB)"
Number format: "Use system locale"

<img width="778" height="650" alt="image" src="https://github.com/user-attachments/assets/709591ea-449b-49cc-a8f7-1e215776931c" />

Language: "English"
Number format: "Use language settings"

<img width="780" height="647" alt="image" src="https://github.com/user-attachments/assets/6399a567-c97e-4051-88f1-6388ddb8b0f0" />

---

Support of translated units; example - Github integration:
Language: “German”

<img width="722" height="327" alt="image" src="https://github.com/user-attachments/assets/2a2906e4-a642-4e86-8aff-08ecd95ac95b" />

---

Allow to hide a unit for extrema & average info for a compactness (https://github.com/kalkih/mini-graph-card/issues/1287):

<img width="505" height="287" alt="image" src="https://github.com/user-attachments/assets/6002c9bd-2ec6-4a3e-913f-694410f3dd85" />




