### PR TITLE
feat: Allow showing a "legend" & "extrema / average" elements below a graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ All properties are optional.
 | graph | `line` | `line` / `bar` / `false` | Display option for the graph. If set to `bar` a maximum of `96` bars will be displayed.
 | fill | `true` | `true` / `false` / `fade` | Display the line graph fill.
 | points | `hover` | `true` / `false` / `hover` | Display graph data points.
-| legend | `true` | `true` / `false` | Display the graph legend (only shown when graph contains multiple entities).
-| average | `false` | `true` / `false` | Display average information.
-| extrema | `false` | `true` / `false` | Display max/min information.
+| legend | `true` | `true` / `false` / `below` | Display the graph legend (only shown when graph contains multiple entities); `below` - place below a graph.
+| average | `false` | `true` / `false` / `below` | Display average information; `below` - place below a graph.
+| extrema | `false` | `true` / `false` / `below` | Display max/min information; `below` - place below a graph.
 | labels | `hover` | `true` / `false` / `hover` | Display Y-axis labels.
 | labels_secondary | `hover` | `true` / `false` / `hover` | Display secondary Y-axis labels.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.

--- a/src/main.js
+++ b/src/main.js
@@ -369,10 +369,10 @@ class MiniGraphCard extends LitElement {
 
   renderLegend() {
     if (this.visibleLegends.length <= 1 || !this.config.show.legend) return;
-
+    const location = this.config.show.legend === 'below' ? 'below' : 'above';
     /* eslint-disable indent */
     return html`
-      <div class="graph__legend">
+      <div class="graph__legend" loc=${location}>
         ${this.visibleLegends.map((entity) => {
           const legend = this.computeLegend(entity.index);
           return html`
@@ -620,8 +620,10 @@ class MiniGraphCard extends LitElement {
   }
 
   renderInfo() {
+    const { extrema, average } = this.config.show;
+    const location = extrema === 'below' || average === 'below' ? 'below' : 'above';
     return this.abs.length > 0 ? html`
-      <div class="info flex">
+      <div class="info flex" loc=${location}>
         ${this.abs.map(entry => html`
           <div class="info__item">
             <span class="info__item__type">${entry.type}</span>

--- a/src/main.js
+++ b/src/main.js
@@ -639,7 +639,7 @@ class MiniGraphCard extends LitElement {
 
   renderInfo() {
     const { extrema, average } = this.config.show;
-    const location = extrema === 'below' || average === 'below' ? 'below' : 'above';
+    const location = (extrema === 'below' || average === 'below') ? 'below' : 'above';
     return this.abs.length > 0 ? html`
       <div class="info flex" loc=${location}>
         ${this.abs.map(entry => html`

--- a/src/style.js
+++ b/src/style.js
@@ -42,9 +42,13 @@ const style = css`
     stroke-linecap: initial;
     stroke-linejoin: initial;
   }
-  ha-card .graph__legend {
+  .graph__legend {
     order: -1;
     padding: 0 16px 8px 16px;
+  }
+  .graph__legend[loc="below"] {
+    order: 9;
+    padding: 4px 16px;
   }
   ha-card[group] {
     box-shadow: none;
@@ -343,7 +347,6 @@ const style = css`
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
-    padding-top: 16px;
     flex-wrap: wrap;
   }
   .graph__legend__item {
@@ -364,6 +367,11 @@ const style = css`
   .info {
     justify-content: space-between;
     align-items: middle;
+  }
+  .info[loc="below"] {
+    order: 99;
+    padding-top: 4px;
+    padding-bottom: 4px;
   }
   .info__item {
     display: flex;


### PR DESCRIPTION
Add a possibility to place a "legend" & "extrema / average" elements below a graph:

<img width="1008" height="263" alt="image" src="https://github.com/user-attachments/assets/84fea011-28c1-47cb-aabc-32b1ee3fb5bb" />

<img width="931" height="285" alt="image" src="https://github.com/user-attachments/assets/71726b81-5f19-42f8-8238-8c4b3a639bc6" />

