### PR TITLE
fix: gradient for color thresholds

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -177,6 +177,9 @@ export default class Graph {
       } else {
         offset = (this._max - stop.value) * (100 / scale);
       }
+      // Update position of gradient by accounting the margin into the offset
+      offset = (this.margin[Y] * 2 * 100 + offset * this.height)
+        / (this.height + this.margin[Y] * 4);
       return {
         color: color || stop.color,
         offset,

--- a/src/graph.js
+++ b/src/graph.js
@@ -269,6 +269,9 @@ export default class Graph {
       } else {
         offset = (this._max - stop.value) * (100 / scale);
       }
+      // Update position of gradient by accounting the margin into the offset
+      offset = (this.margin[Y] * 2 * 100 + offset * this.height)
+        / (this.height + this.margin[Y] * 4);
       return {
         color: color || stop.color,
         offset,

--- a/src/graph.js
+++ b/src/graph.js
@@ -262,16 +262,19 @@ export default class Graph {
       let offset;
       if (scale <= 0) {
         offset = 0;
-      } else if (this._logarithmic) {
-        offset = (Math.log10(Math.max(1, this._max))
-          - Math.log10(Math.max(1, stop.value)))
-          * (100 / scale);
       } else {
-        offset = (this._max - stop.value) * (100 / scale);
+        // limit stopValue within max/min
+        const stopValue = (stop.value >= this._max)
+          ? this._max
+          : (stop.value <= this._min)
+            ? this._min
+            : stop.value;
+        // get Y coord for stopValue
+        const [stopCoord] = this._calcY([[0, 0, stopValue]]);
+        const [, coordY] = stopCoord;
+        // calculate absolute offset
+        offset = coordY / (this.height + this.margin[Y] * 4) * 100;
       }
-      // Update position of gradient by accounting the margin into the offset
-      offset = (this.margin[Y] * 2 * 100 + offset * this.height)
-        / (this.height + this.margin[Y] * 4);
       return {
         color: color || stop.color,
         offset,

--- a/src/graph.js
+++ b/src/graph.js
@@ -195,16 +195,19 @@ export default class Graph {
       let offset;
       if (scale <= 0) {
         offset = 0;
-      } else if (this.logarithmic) {
-        offset = (Math.log10(Math.max(1, this._max))
-          - Math.log10(Math.max(1, stop.value)))
-          * (100 / scale);
       } else {
-        offset = (this._max - stop.value) * (100 / scale);
+        // limit stopValue within max/min
+        const stopValue = (stop.value >= this._max)
+          ? this._max
+          : (stop.value <= this._min)
+            ? this._min
+            : stop.value;
+        // get Y coord for stopValue
+        const [stopCoord] = this._calcY([[0, 0, stopValue]]);
+        const [, coordY] = stopCoord;
+        // calculate absolute offset
+        offset = coordY / (this.height + this.margin[Y] * 4) * 100;
       }
-      // Update position of gradient by accounting the margin into the offset
-      offset = (this.margin[Y] * 2 * 100 + offset * this.height)
-        / (this.height + this.margin[Y] * 4);
       return {
         color: color || stop.color,
         offset,

--- a/src/graph.js
+++ b/src/graph.js
@@ -202,6 +202,9 @@ export default class Graph {
       } else {
         offset = (this._max - stop.value) * (100 / scale);
       }
+      // Update position of gradient by accounting the margin into the offset
+      offset = (this.margin[Y] * 2 * 100 + offset * this.height)
+        / (this.height + this.margin[Y] * 4);
       return {
         color: color || stop.color,
         offset,


### PR DESCRIPTION
IMO this should fix the problem with the color thresholds. In function computeGradient in src/graph.js the thresholds are evaluated as real values. When displaying the graph the gradient course is distorted since the margins at top and bottom affect the gradient offset. So the offset of the gradient needs to be adapted by considering the margin.

This might fix
kalkih#1080
kalkih#1108
kalkih#1137
kalkih#723


Before:
<img width="330" height="210" alt="fix_fill01b" src="https://github.com/user-attachments/assets/2b68b1fa-4045-4279-a59f-d42fb5b403f2" /><img width="330" height="210" alt="fix_fill01a" src="https://github.com/user-attachments/assets/2d6f8e6b-7b11-4274-815e-7e09ce6f6d63" />


After applying the patch:
<img width="330" height="210" alt="fix_fill01d" src="https://github.com/user-attachments/assets/04280dda-f117-4732-ad26-44662b819140" />
<img width="330" height="210" alt="fix_fill01c" src="https://github.com/user-attachments/assets/ba240488-0025-49de-8c29-62711ad5f776" />


```
line_width: 6
color_thresholds_transition: hard
color_thresholds:
  - value: 14
    color: red
  - value: 15
    color: cyan
  - value: 16
    color: green
  - value: 17
    color: red
```