### PR TITLE
feat: spacing between bar groups (multiple entities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
+| bar_spacing_group | number | `0` | NEXT_VERSION | Set an additional spacing between bar groups (multiple entities) in bar graph.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -124,6 +124,7 @@ export default (config) => {
     color_thresholds_transition: 'smooth',
     line_width: 5,
     bar_spacing: 4,
+    bar_spacing_group: 0,
     compress: true,
     smoothing: true,
     state_map: [],

--- a/src/graph.js
+++ b/src/graph.js
@@ -192,14 +192,16 @@ export default class Graph {
     return fill;
   }
 
-  getBars(position, total, spacing = 4) {
+  getBars(position, total, spacing = 4, spacing_group = 0) {
     const coords = this._calcY(this.coords);
-    const xRatio = ((this.width - spacing) / Math.ceil(this.hours * this.points)) / total;
+    const shrink = spacing_group / total;
+    const xRatio = (this.width / Math.ceil(this.hours * this.points)) / total;
     return coords.map((coord, i) => ({
-      x: (xRatio * i * total) + (xRatio * position) + spacing,
+      x: (xRatio * i * total) + ((xRatio - shrink) * position)
+        + this.margin[X] + (spacing_group + spacing) / 2,
       y: coord[Y],
       height: this.height - coord[Y] + this.margin[Y] * 4,
-      width: xRatio - spacing,
+      width: xRatio - (spacing + shrink),
       value: coord[V],
     }));
   }

--- a/src/main.js
+++ b/src/main.js
@@ -800,7 +800,8 @@ class MiniGraphCard extends LitElement {
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
           const numVisible = this.visibleEntities.length;
-          this.bar[i] = this.Graph[i].getBars(graphPos, numVisible, config.bar_spacing);
+          this.bar[i] = this.Graph[i]
+            .getBars(graphPos, numVisible, config.bar_spacing, config.bar_spacing_group);
           graphPos += 1;
         } else {
           const line = this.Graph[i].getPath();


### PR DESCRIPTION
This PR adds the config option `bar_spacing_group` to extend the space between bars which form a group as multiple entities for a specific interval. It's motivated by kalkih#1000.
It also fixes a spacing problem when the line_width option affects the bar spacing in case the fill option is set to false. 

<img width="310" height="260" alt="mcg_bar_group" src="https://github.com/user-attachments/assets/e7d461fb-c727-4da6-83e7-542afc41149b" />

```
bar_spacing: 2
bar_spacing_group: 8
```
