### PR TITLE
feat: Add card picker suggestion for numeric sensors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1079,6 +1079,18 @@ class MiniGraphCard extends LitElement {
 
 customElements.define('mini-graph-card', MiniGraphCard);
 
+const NUMERIC_DOMAINS = ['counter', 'input_number', 'number'];
+
+const isNumericEntity = (hass, entityId) => {
+  const domain = entityId.split('.')[0];
+  if (NUMERIC_DOMAINS.includes(domain)) return true;
+  if (domain !== 'sensor') return false;
+
+  const stateObj = hass.states[entityId];
+  if (!stateObj) return false;
+  return !!stateObj.attributes.unit_of_measurement || !!stateObj.attributes.state_class;
+};
+
 // Configure the preview in the Lovelace card picker
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -1087,18 +1099,12 @@ window.customCards.push({
   preview: false,
   description: 'The Mini Graph card is a minimalistic and customizable graph card',
   getEntitySuggestion: (hass, entityId) => {
-    if (entityId.split('.')[0] !== 'sensor') return null;
-
-    const stateObj = hass.states[entityId];
-    if (!stateObj) return null;
-
-    const { state_class: stateClass, unit_of_measurement: unit } = stateObj.attributes;
-    if (!unit && !stateClass) return null;
+    if (!isNumericEntity(hass, entityId)) return null;
 
     return {
       config: {
         type: 'custom:mini-graph-card',
-        entities: [entityId],
+        entities: [{ entity: entityId }],
       },
     };
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1086,4 +1086,20 @@ window.customCards.push({
   name: 'Mini Graph Card',
   preview: false,
   description: 'The Mini Graph card is a minimalistic and customizable graph card',
+  getEntitySuggestion: (hass, entityId) => {
+    if (entityId.split('.')[0] !== 'sensor') return null;
+
+    const stateObj = hass.states[entityId];
+    if (!stateObj) return null;
+
+    const { state_class: stateClass, unit_of_measurement: unit } = stateObj.attributes;
+    if (!unit && !stateClass) return null;
+
+    return {
+      config: {
+        type: 'custom:mini-graph-card',
+        entities: [entityId],
+      },
+    };
+  },
 });


### PR DESCRIPTION
Mini Graph Card now suggests itself in the card picker when you pick a
numeric sensor (temperature, humidity, power, energy, and so on). It shows
up under the Community section, next to the built-in suggestions.

Requires Home Assistant 2026.6 or later.

Docs: https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity

<img width="1021" height="719" alt="CleanShot 2026-06-03 at 11 17 03" src="https://github.com/user-attachments/assets/8588ac03-3d36-49a8-b623-4f725dbca760" />
