### PR TITLE
fix: Order reversed for value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -375,7 +375,7 @@ class MiniGraphCard extends LitElement {
       const entityIndex = isTooltip ? tooltipEntityIndex : index;
       const entityConfig = this.config.entities[entityIndex];
       // check if a unit should precend a value
-      const { directOrder } = this.computeStateOrder(entityIndex); 
+      const { directOrder } = this.computeStateOrder(entityIndex);
       return html`
         <div
           reversed=${!directOrder}

--- a/src/main.js
+++ b/src/main.js
@@ -374,8 +374,11 @@ class MiniGraphCard extends LitElement {
       const value = isTooltip ? tooltipValue : state;
       const entityIndex = isTooltip ? tooltipEntityIndex : index;
       const entityConfig = this.config.entities[entityIndex];
+      // check if a unit should precend a value
+      const { directOrder } = this.computeStateOrder(entityIndex); 
       return html`
         <div
+          reversed=${!directOrder}
           class="state ${!isPrimary ? 'state--small' : ''}"
           @click=${e => this.handlePopup(e, this.entity[index])}
           style=${entityConfig.state_adaptive_color ? `color: ${this.computeColor(value, entityIndex)}` : ''}

--- a/src/style.js
+++ b/src/style.js
@@ -208,7 +208,7 @@ const style = css`
     line-height: 1.2em;
   }
   .state[reversed="true"] .state__value {
-    order: 5;
+    order: 9;
   }
   .state__uom {
     flex: 1;


### PR DESCRIPTION
Related to a reversed order of displaying a value (unit - delimiter - value).
Added lines which were forgotten to be added to https://github.com/kalkih/mini-graph-card/pull/1350
