### PR TITLE
fix: Remove unneeded numberFormat() function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -991,12 +991,6 @@ class MiniGraphCard extends LitElement {
     );
   }
 
-  numberFormat(num, language, dec) {
-    if (!Number.isNaN(Number(num)) && Intl)
-      return new Intl.NumberFormat(language, { minimumFractionDigits: dec }).format(Number(num));
-    return num.toString();
-  }
-
   updateOnInterval() {
     if (this.stateChanged && !this.updating) {
       this.stateChanged = false;


### PR DESCRIPTION
Removed unneeded `numberFormat()` function (remained after https://github.com/kalkih/mini-graph-card/pull/1233)