### PR TITLE
fix: Fixes for show_indicator

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -174,7 +174,8 @@ const style = css`
     min-width: 0;
     gap: .25rem;
   }
-  .state > svg {
+  .state > svg,
+  .states--secondary > div:only-child svg {
     align-self: center;
     border-radius: 100%;
   }
@@ -183,7 +184,7 @@ const style = css`
     margin-bottom: .6rem;
     flex-wrap: nowrap;
   }
-  .state--small > svg {
+  .states--secondary > :not(div:only-child) svg {
     position: absolute;
     left: -1.6em;
     align-self: center;
@@ -195,12 +196,9 @@ const style = css`
   .state--small:last-child {
     margin-bottom: 0;
   }
-  .states--secondary > :only-child {
+  .states--secondary > div:only-child {
     font-size: 1em;
     margin-bottom: 0;
-  }
-  .states--secondary > :only-child svg {
-    display: none;
   }
   .state__value {
     display: inline-block;


### PR DESCRIPTION
Related to https://github.com/kalkih/mini-graph-card/discussions/1319 & https://github.com/kalkih/mini-graph-card/pull/1320:
although Docs were cleared in https://github.com/kalkih/mini-graph-card/pull/1320, the code still contained an undesired behaviour: the indicator was not shown for the ONLY secondary state.
This PR fixes it:

<img width="504" height="782" alt="image" src="https://github.com/user-attachments/assets/b973f1e7-c53a-4951-a106-c6a8fd20ed89" />

