### PR TITLE
feat: Add a reversed order for displaying graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All properties are optional.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.
 | icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity color.
 | loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
-| graphs_order | `direct` | `direct` / `reverse` | Define an order of displaying graphs (see [Graphs order](#graphs-order)).
+| graphs_order | `direct` | `direct` / `reversed` | Define an order of displaying graphs (see [Graphs order](#graphs-order)).
 
 
 #### Line color object

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | value_factor | number or object |   | v0.9.4<br>v0.14.0 | Scale a value, see [Value factor](#value-factor).
 | value_factor_secondary | number or object |   | v0.14.0 | Scale a value, see [Value factor](#value-factor).
 | logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph.
-
+| order_reversed | boolean | `false` | v0.14.0 | Display graphs in a reversed order: graphs for entities with smaller indexes will be displayed on a top (i.e. the 1st entity will be topmost).
 
 #### Entities object
 Entities may be listed directly (as per `sensor.temperature` in the example below), or defined using

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | value_factor | number or object |   | v0.9.4<br>v0.14.0 | Scale a value, see [Value factor](#value-factor).
 | value_factor_secondary | number or object |   | v0.14.0 | Scale a value, see [Value factor](#value-factor).
 | logarithmic | boolean | `false` | v0.10.0 | Use a Logarithmic scale for the graph.
-| order_reversed | boolean | `false` | v0.14.0 | Display graphs in a reversed order: graphs for entities with smaller indexes will be displayed on a top (i.e. the 1st entity will be topmost).
+
 
 #### Entities object
 Entities may be listed directly (as per `sensor.temperature` in the example below), or defined using

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ By default, graphs are shown in the following order:
 Within each category, parts are shown in the following order:
 1. First, a part for the 1st entity in the `entities` list is processed.
 2. Last, a part for the last entity in the `entities` list is processed.
+
 I.e. the last entity's graph will be shown as topmost.
 
 This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for `1st entity's graph is topmost`.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ All properties are optional.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.
 | icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity color.
 | loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
+| graphs_order | `direct` | `direct` / `reverse` | Define an on order of displaying graphs (see [Graphs order](#graphs-order)).
 
 
 #### Line color object
@@ -341,6 +342,25 @@ A singular whitespace must be used to separate date & time formats. Letter case 
 
 Any values which do not match the pattern - lead to a fallback to a "day weekday" format (used as the only and default format till v.0.13).
 For clarity, it is recommended to explicitly define a `day_weekday` value in case the legacy "day weekday" format is needed.
+
+### Graphs order
+
+Note: this section applies to `line` graphs only.
+
+For each entity, a `line` graph consists of 3 basic parts: a "line" part (curve), a "fill" part (if displaying a fill is configured), a "points" part (if displaying points is configured).
+
+By default, graphs are shown in the following order:
+1. All "fill" parts are shown (if configured).
+2. All "line" parts are shown.
+3. All "points" parts are shown (if configured).
+Within each category, parts are shown in the following order:
+1. First, a part for the 1st entity in the `entities` list is processed.
+2. Last, a part for the last entity in the `entities` list is processed.
+I.e. the last entity's graph will be shown as topmost.
+
+This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for `1st entity's graph is topmost`.
+
+
 
 
 ### Theme variables

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All properties are optional.
 | name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.
 | icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity color.
 | loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
-| graphs_order | `direct` | `direct` / `reverse` | Define an on order of displaying graphs (see [Graphs order](#graphs-order)).
+| graphs_order | `direct` | `direct` / `reverse` | Define an order of displaying graphs (see [Graphs order](#graphs-order)).
 
 
 #### Line color object
@@ -353,6 +353,7 @@ By default, graphs are shown in the following order:
 1. All "fill" parts are shown (if configured).
 2. All "line" parts are shown.
 3. All "points" parts are shown (if configured).
+
 Within each category, parts are shown in the following order:
 1. First, a part for the 1st entity in the `entities` list is processed.
 2. Last, a part for the last entity in the `entities` list is processed.

--- a/src/main.js
+++ b/src/main.js
@@ -654,10 +654,12 @@ class MiniGraphCard extends LitElement {
     // how JS processes arrays with empty elements un "map()"
     // (also for a higher performance)
     if (reversed) {
+      /* eslint-disable-next-line no-plusplus */
       for (let i = len - 1; i >= 0; i--) {
         result[len - 1 - i] = renderFunc(data[i], i);
       }
     } else {
+      /* eslint-disable-next-line no-plusplus */
       for (let i = 0; i < len; i++) {
         result[i] = renderFunc(data[i], i);
       }

--- a/src/main.js
+++ b/src/main.js
@@ -647,7 +647,7 @@ class MiniGraphCard extends LitElement {
   * @param {boolean} reversed True if a reversed order
   */
   renderSvgPart(data, renderFunc, reversed) {
-    renderFunc = renderFunc.bind(this);
+    const renderFuncBound = renderFunc.bind(this);
     const len = data.length;
     const result = new Array(len);
     // "for" loop is used to avoid issues caused by
@@ -656,12 +656,12 @@ class MiniGraphCard extends LitElement {
     if (reversed) {
       /* eslint-disable-next-line no-plusplus */
       for (let i = len - 1; i >= 0; i--) {
-        result[len - 1 - i] = renderFunc(data[i], i);
+        result[len - 1 - i] = renderFuncBound(data[i], i);
       }
     } else {
       /* eslint-disable-next-line no-plusplus */
       for (let i = 0; i < len; i++) {
-        result[i] = renderFunc(data[i], i);
+        result[i] = renderFuncBound(data[i], i);
       }
     }
     return result;

--- a/src/main.js
+++ b/src/main.js
@@ -639,8 +639,38 @@ class MiniGraphCard extends LitElement {
     return svg`<g class='bars' ?anim=${this.config.animate}>${items}</g>`;
   }
 
+  /** Returns a rendered SVG part (fill, line, bars, points)
+   * in a direct or a reversed order
+  * @returns {any} SVG part
+  * @param {any[]} data Array of data to render an SVG part
+  * @param {()} renderFunc Function to render an SVG part
+  * @param {boolean} reversed True if a reversed order
+  */
+  renderSvgPart(data, renderFunc, reversed) {
+    renderFunc = renderFunc.bind(this);
+    const len = data.length;
+    const result = new Array(len);
+    // "for" loop is used to avoid issues caused by
+    // how JS processes arrays with empty elements un "map()"
+    // (also for a higher performance)
+    if (reversed) {
+      for (let i = len - 1; i >= 0; i--) {
+        result[len - 1 - i] = renderFunc(data[i], i);
+      }
+    } else {
+      for (let i = 0; i < len; i++) {
+        result[i] = renderFunc(data[i], i);
+      }
+    }
+    return result;
+  }
+
+  /** Returns all rendered SVG parts (fill, line, bars, points)
+  * @returns {any} SVG
+  */
   renderSvg() {
-    const { height } = this.config;
+    const { height, show } = this.config;
+    const reversed = show.graph_order === 'reversed';
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
         @click=${e => e.stopPropagation()}>
@@ -648,13 +678,13 @@ class MiniGraphCard extends LitElement {
           <defs>
             ${this.renderSvgGradient(this.gradient)}
           </defs>
-          ${this.fill.map((fill, i) => this.renderSvgFill(fill, i))}
-          ${this.fill.map((fill, i) => this.renderSvgFillRect(fill, i))}
-          ${this.line.map((line, i) => this.renderSvgLine(line, i))}
-          ${this.line.map((line, i) => this.renderSvgLineRect(line, i))}
+          ${this.renderSvgPart(this.fill, this.renderSvgFill, reversed)}
+          ${this.renderSvgPart(this.fill, this.renderSvgFillRect, reversed)}
+          ${this.renderSvgPart(this.line, this.renderSvgLine, reversed)}
+          ${this.renderSvgPart(this.line, this.renderSvgLineRect, reversed)}
           ${this.bar.map((bars, i) => this.renderSvgBars(bars, i))}
         </g>
-        ${this.points.map((points, i) => this.renderSvgPoints(points, i))}
+        ${this.renderSvgPart(this.points, this.renderSvgPoints, reversed)}
       </svg>`;
   }
 


### PR DESCRIPTION
Added a new option - `graph_order` (direct/reversed)
The option intentionally is not a boolean value for a possible future development.

Default (`direct`):
<img width="452" height="200" alt="image" src="https://github.com/user-attachments/assets/324bfeca-7b78-4ed6-a750-c570ff169f03" />

`reversed`:
<img width="450" height="192" alt="image" src="https://github.com/user-attachments/assets/776fcff4-c531-4747-a1df-988fa4a00ce0" />

Implements https://github.com/kalkih/mini-graph-card/issues/269