### PR TITLE
feat: Line style

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
+| line_style | string |  | v0.14.0 | Set the style of the line (see [Line styles](#line-styles)).
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).
 | color_thresholds_transition | string | `smooth` | v0.4.3 | Color threshold transition, `smooth` or `hard`.
@@ -138,6 +139,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | decimals | integer |    | Override the exact number of decimals to show for number values, see [Number format](#number-format).
+| line_style | string |  | v0.14.0 | Override the style of the line (see [Line styles](#line-styles)).
 | show_state | boolean |         | Display the current state.
 | show_legend_state | boolean |  false  | Display the current state as part of the legend.
 | show_indicator | boolean |         | Display a color indicator next to the state.
@@ -351,6 +353,9 @@ Normally gaps between numbers on the graph are equal; the gap between 1 and 2 on
 
 Note that this option rounds up the input to 1 so negative numbers or numbers less than 1 are rendered as 0; this is different from the formal definition of logarithm, where `log(x) == 0` when `x<1` and $\infty$ when `x<0`.
 
+### Line styles
+
+A default line style is a "solid line". A style should be defined in a format used for a standard CSS `stroke-dasharray` property. Examples: `10,10` (dashes), `20,10` (long dashes). It is better to use along with a `line_width` option.
 
 ### Graphs order
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | decimals | integer |    | Override the exact number of decimals to show for number values, see [Number format](#number-format).
-| line_style | string |  | v0.14.0 | Override the style of the line (see [Line styles](#line-styles)).
+| line_style | string |   | Override the style of the line (see [Line styles](#line-styles)).
 | show_state | boolean |         | Display the current state.
 | show_legend_state | boolean |  false  | Display the current state as part of the legend.
 | show_indicator | boolean |         | Display a color indicator next to the state.

--- a/src/main.js
+++ b/src/main.js
@@ -523,6 +523,10 @@ class MiniGraphCard extends LitElement {
   renderSvgLine(line, i) {
     if (!line) return;
 
+    const strokeDashArray = (this.config.animate
+      ? this.length[i]
+      : this.config.entities[i].line_style || this.config.line_style)
+      || 'none';
     const path = svg`
       <path
         class='line'
@@ -530,7 +534,7 @@ class MiniGraphCard extends LitElement {
         anim=${this.config.animate} ?init=${this.length[i]}
         style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
         fill='none'
-        stroke-dasharray=${this.length[i] || 'none'} stroke-dashoffset=${this.length[i] || 'none'}
+        stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[i] || 'none'}
         stroke=${'white'}
         stroke-width=${this.config.line_width}
         d=${this.line[i]}


### PR DESCRIPTION
Partially implements https://github.com/kalkih/mini-graph-card/issues/555

A new `line_style` option is proposed (card-wide & per-entity).
Not applied if `animation: true` option is set.

```
type: custom:mini-graph-card
entities:
  - entity: sensor.xiaomi_cg_1_temperature
line_style: 20,10
```
<img width="478" height="221" alt="image" src="https://github.com/user-attachments/assets/8b334702-e5b8-492b-a226-7e09392d054e" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.xiaomi_cg_1_temperature
    line_style: 20,10
  - entity: sensor.xiaomi_cg_2_temperature
    line_style: 6,6
```
<img width="485" height="259" alt="image" src="https://github.com/user-attachments/assets/40f4c04a-753d-44e3-bea6-16cb67844a11" />


