### PR TITLE
feat: spacing between bar groups (multiple entities) (#2) + Overlapping bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
-| bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
-| bar_spacing_group | number |   | 0.14.0 | Set an additional spacing between bar groups (multiple entities) in bar graph. Fallback to `bar_spacing` if undefined.
+| bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph. Value `-1` is used to place bars on each other. See [examples](#bar-spacing-examples).
+| bar_spacing_group | number |   | 0.14.0 | Set an additional spacing between bar groups (multiple entities) in bar graph. Fallback to `bar_spacing` if undefined; if `bar_spacing: -1` - then a default `4` value is used. See [examples](#bar-spacing-examples).
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_style | string |  | v0.14.0 | Set the style of the line (see [Line styles](#line-styles)).
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.
@@ -458,6 +458,57 @@ name: ENERGY CONSUMPTION
 show:
   graph: bar
 ```
+
+#### Bar spacing examples
+
+Custom `bar_spacing` & `bar_spacing_group`:
+
+<img width="476" height="305" alt="image" src="https://github.com/user-attachments/assets/0f0bd87b-13d0-4237-b8ab-0c457d3df1d5" />
+
+```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.ac68u_cpu_usage
+    state_adaptive_color: true
+  - entity: sensor.system_monitor_processor_use
+    show_state: true
+    state_adaptive_color: true
+hours_to_show: 0.75
+points_per_hour: 60
+height: 200
+smoothing: false
+aggregate_func: last
+bar_spacing: 1
+bar_spacing_group: 4
+show:
+  graph: bar
+  icon: false
+  name: false
+```
+Placing bars on each other with `bar_spacing: -1`:
+
+<img width="485" height="311" alt="image" src="https://github.com/user-attachments/assets/8fd8bdae-cd0e-4519-860c-b0bf54e824f4" />
+
+```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.ac68u_cpu_usage
+    state_adaptive_color: true
+  - entity: sensor.system_monitor_processor_use
+    show_state: true
+    state_adaptive_color: true
+hours_to_show: 0.75
+points_per_hour: 60
+height: 200
+smoothing: false
+aggregate_func: last
+bar_spacing: -1
+show:
+  graph: bar
+  icon: false
+  name: false
+```
+
 
 #### Show data from the past week
 ![Show data from the past week](https://user-images.githubusercontent.com/457678/52009167-913df680-24d2-11e9-8732-52fc65e3f0d8.png)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph.
+| bar_spacing_group | number |   | 0.14.0 | Set an additional spacing between bar groups (multiple entities) in bar graph. Fallback to `bar_spacing` if undefined.
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.
 | line_style | string |  | v0.14.0 | Set the style of the line (see [Line styles](#line-styles)).
 | line_color | string/list | `var(--accent-color)` | v0.0.1 | Set a custom color for the graph line, provide a list of colors for multiple graph entries.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Warning: the `line_style` option is not accounted if `animation: true` option is
 
 ### Graphs order
 
-Note: this section applies to `line` graphs only.
+Note: this section only applies to line graphs & stacked bars graphs (with `bar_spacing: -1`).
 
 For each entity/[static value](#static-lines), a `line` graph consists of 3 basic parts: a "line" part (curve), a "fill" part (if displaying a fill is configured), a "points" part (if displaying points is configured).
 
@@ -394,8 +394,13 @@ Within each category, parts are shown in the following order:
 
 I.e. the last entity's/static value's graph will be shown as topmost.
 
-This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for `1st entity's/static value's graph is topmost`.
+This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for "1st entity's/static value's graph is topmost".
 
+Similarly for stacked bars graphs (when `bar_spacing: -1`): by default (or with `graph_order: direct`), bars are processed in the following order:
+1. First, a bar for the 1st entity/static value in the `entities` list is processed.
+2. Last, a bar for the last entity/static value in the `entities` list is processed.
+
+With `graph_order: reversed`, a bar for the last entity/static value becomes bottommost.
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.

--- a/README.md
+++ b/README.md
@@ -396,11 +396,11 @@ I.e. the last entity's/static value's graph will be shown as topmost.
 
 This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for "1st entity's/static value's graph is topmost".
 
-Similarly for stacked bars graphs (when `bar_spacing: -1`): by default (or with `graph_order: direct`), bars are processed in the following order:
+Similarly for stacked bars graphs (when `bar_spacing: -1`): by default (or with `graph_order: direct`), bars for each point are processed in the following order:
 1. First, a bar for the 1st entity/static value in the `entities` list is processed.
 2. Last, a bar for the last entity/static value in the `entities` list is processed.
 
-With `graph_order: reversed`, a bar for the last entity/static value becomes bottommost.
+With `graph_order: reversed`, bars for the 1st entity/static value become topmost.
 
 ### Theme variables
 The following theme variables can be set in your HA theme to customize the appearance of the card.

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ show:
   graph: bar
 ```
 
-#### Bar spacing examples
+#### Bar spacing
 
 Custom `bar_spacing` & `bar_spacing_group`:
 

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -7,6 +7,7 @@ import {
   MAX_BARS,
   DEFAULT_COLORS,
   DEFAULT_SHOW,
+  DEFAULT_MARGIN,
 } from './const';
 
 /**
@@ -122,7 +123,7 @@ export default (config) => {
     line_color: [...DEFAULT_COLORS],
     color_thresholds: [],
     color_thresholds_transition: 'smooth',
-    line_width: 5,
+    line_width: DEFAULT_MARGIN,
     bar_spacing: 4,
     compress: true,
     smoothing: true,

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -8,6 +8,7 @@ import {
   DEFAULT_COLORS,
   DEFAULT_SHOW,
   DEFAULT_MARGIN,
+  DEFAULT_BAR_SPACING,
 } from './const';
 
 /**
@@ -124,7 +125,7 @@ export default (config) => {
     color_thresholds: [],
     color_thresholds_transition: 'smooth',
     line_width: DEFAULT_MARGIN,
-    bar_spacing: 4,
+    bar_spacing: DEFAULT_BAR_SPACING,
     compress: true,
     smoothing: true,
     state_map: [],
@@ -159,6 +160,13 @@ export default (config) => {
   // parse a possibly defined "datetime_format" option;
   // fallback to "day_weekday" if undefined
   conf.datetimeFormatParsed = parseDateTimeFormat(conf.datetime_format);
+
+  // set valid values for bar_spacing options
+  conf.bar_spacing = config.bar_spacing < 0
+    ? DEFAULT_BAR_SPACING : config.bar_spacing;
+  conf.bar_spacing_group = config.bar_spacing_group !== undefined
+    ? config.bar_spacing_group
+    : conf.bar_spacing;
 
   // override points per hour to mach group_by function
   switch (conf.group_by) {

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -176,10 +176,10 @@ export default (config) => {
   conf.datetimeFormatParsed = parseDateTimeFormat(conf.datetime_format);
 
   // set valid values for bar_spacing options
-  conf.bar_spacing = config.bar_spacing < 0
-    ? DEFAULT_BAR_SPACING : config.bar_spacing;
-  conf.bar_spacing_group = config.bar_spacing_group !== undefined
-    ? config.bar_spacing_group
+  conf.bar_spacing = conf.bar_spacing < 0
+    ? -1 : conf.bar_spacing; // "-1" stands for stacked bars
+  conf.bar_spacing_group = conf.bar_spacing_group !== undefined
+    ? conf.bar_spacing_group
     : conf.bar_spacing;
 
   // override points per hour to mach group_by function

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -180,7 +180,8 @@ export default (config) => {
     ? -1 : conf.bar_spacing; // "-1" stands for stacked bars
   conf.bar_spacing_group = conf.bar_spacing_group !== undefined
     ? conf.bar_spacing_group
-    : conf.bar_spacing;
+    : conf.bar_spacing < 0
+      ? DEFAULT_BAR_SPACING : conf.bar_spacing;
 
   // override points per hour to mach group_by function
   switch (conf.group_by) {

--- a/src/const.js
+++ b/src/const.js
@@ -2,6 +2,7 @@ const URL_DOCS = 'https://github.com/kalkih/mini-graph-card/blob/master/README.m
 const FONT_SIZE = 14;
 const FONT_SIZE_HEADER = 14;
 const MAX_BARS = 96;
+const DEFAULT_MARGIN = 5;
 const ICONS = {
   humidity: 'hass:water-percent',
   illuminance: 'hass:brightness-5',
@@ -55,6 +56,7 @@ export {
   FONT_SIZE,
   FONT_SIZE_HEADER,
   MAX_BARS,
+  DEFAULT_MARGIN,
   ICONS,
   DEFAULT_COLORS,
   UPDATE_PROPS,

--- a/src/const.js
+++ b/src/const.js
@@ -3,6 +3,7 @@ const FONT_SIZE = 14;
 const FONT_SIZE_HEADER = 14;
 const MAX_BARS = 96;
 const DEFAULT_MARGIN = 5;
+const DEFAULT_BAR_SPACING = 4;
 const ICONS = {
   humidity: 'hass:water-percent',
   illuminance: 'hass:brightness-5',
@@ -57,6 +58,7 @@ export {
   FONT_SIZE_HEADER,
   MAX_BARS,
   DEFAULT_MARGIN,
+  DEFAULT_BAR_SPACING,
   ICONS,
   DEFAULT_COLORS,
   UPDATE_PROPS,

--- a/src/graph.js
+++ b/src/graph.js
@@ -25,8 +25,8 @@ export default class Graph {
     this.margin = margin;
     this._max = 0;
     this._min = 0;
-    this.points = points;
-    this.hours = hours;
+    this.points = points;  // stands for "points_per_hour"
+    this.hours = hours; // stands for "hours_to_show"
     this.aggregateFuncName = aggregateFuncName;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
@@ -196,14 +196,30 @@ export default class Graph {
     return fill;
   }
 
-  getBars(position, total, spacing = 4) {
+  /**
+   * Get bars for an entity
+   * @param {number} position Index of a bar (0,1,..) (i.e. index of an entity with a shown graph)
+   * @param {number} total Number of bars (i.e. number of entities with a shown graph)
+   * @param {number} spacing Spacing between bars
+   * @param {number} spacing_group Spacing between groups of bars
+   * @returns Bars for an entity to be shown at a `position` index
+   */
+  getBars(position, total, spacing, spacing_group) {
     const coords = this._calcY(this.coords);
-    const xRatio = ((this.width - spacing) / Math.ceil(this.hours * this.points)) / total;
+    // number of measures
+    const total_groups = Math.ceil(this.hours * this.points);
+    // width of a group of bars
+    const group_width = (this.width - spacing_group * (total_groups - 1))
+      / total_groups;
+    // a width of a bar
+    const bar_width = (group_width - spacing * (total - 1)) / total;
     return coords.map((coord, i) => ({
-      x: (xRatio * i * total) + (xRatio * position) + spacing,
+      x: this.margin[X]
+        + (group_width + spacing_group) * i
+        + (bar_width + spacing) * position,
       y: coord[Y],
       height: this.height - coord[Y] + this.margin[Y] * 4,
-      width: xRatio - spacing,
+      width: bar_width,
       value: coord[V],
     }));
   }

--- a/src/graph.js
+++ b/src/graph.js
@@ -199,7 +199,8 @@ export default class Graph {
 
   /**
    * Get bars for an entity
-   * @param {number} position Index of a bar (0,1,..) (i.e. index of an entity with a shown bar graph)
+   * @param {number} position Index of a bar (0,1,..)
+   * (i.e. index of an entity with a shown bar graph)
    * @param {number} total Number of bars (i.e. number of entities with a shown bar graph)
    * @param {number} spacing Spacing between bars
    * @param {number} spacing_group Spacing between groups of bars

--- a/src/graph.js
+++ b/src/graph.js
@@ -213,7 +213,7 @@ export default class Graph {
     const group_width = (this.width - spacing_group * (total_groups - 1))
       / total_groups;
     // a width of a bar
-    const bar_width = spacing == -1
+    const bar_width = spacing === -1
       ? group_width
       : (group_width - spacing * (total - 1)) / total;
     return coords.map((coord, i) => ({

--- a/src/graph.js
+++ b/src/graph.js
@@ -25,7 +25,7 @@ export default class Graph {
     this.margin = margin;
     this._max = 0;
     this._min = 0;
-    this.points = points;  // stands for "points_per_hour"
+    this.points = points; // stands for "points_per_hour"
     this.hours = hours; // stands for "hours_to_show"
     this.aggregateFuncName = aggregateFuncName;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;

--- a/src/graph.js
+++ b/src/graph.js
@@ -213,11 +213,13 @@ export default class Graph {
     const group_width = (this.width - spacing_group * (total_groups - 1))
       / total_groups;
     // a width of a bar
-    const bar_width = (group_width - spacing * (total - 1)) / total;
+    const bar_width = spacing == -1
+      ? group_width
+      : (group_width - spacing * (total - 1)) / total;
     return coords.map((coord, i) => ({
       x: this.margin[X]
         + (group_width + spacing_group) * i
-        + (bar_width + spacing) * position,
+        + (spacing === -1 ? 0 : (bar_width + spacing) * position),
       y: coord[Y],
       height: this.height - coord[Y] + this.margin[Y] * 4,
       width: bar_width,

--- a/src/graph.js
+++ b/src/graph.js
@@ -200,7 +200,7 @@ export default class Graph {
   /**
    * Get bars for an entity
    * @param {number} position Index of a bar (0,1,..) (i.e. index of an entity with a shown graph)
-   * @param {number} total Number of bars (i.e. number of entities with a shown graph)
+   * @param {number} total Number of bars (i.e. number of entities with a shown bar graph)
    * @param {number} spacing Spacing between bars
    * @param {number} spacing_group Spacing between groups of bars
    * @returns Bars for an entity to be shown at a `position` index

--- a/src/graph.js
+++ b/src/graph.js
@@ -199,7 +199,7 @@ export default class Graph {
 
   /**
    * Get bars for an entity
-   * @param {number} position Index of a bar (0,1,..) (i.e. index of an entity with a shown graph)
+   * @param {number} position Index of a bar (0,1,..) (i.e. index of an entity with a shown bar graph)
    * @param {number} total Number of bars (i.e. number of entities with a shown bar graph)
    * @param {number} spacing Spacing between bars
    * @param {number} spacing_group Spacing between groups of bars

--- a/src/main.js
+++ b/src/main.js
@@ -122,12 +122,12 @@ class MiniGraphCard extends LitElement {
   getMinMaxLineWidth() {
     const arr = this.config.entities
       .filter(entityConfig => entityConfig.show_graph !== false)
-      .map(entityConfig => ({
+      .map(entityConfig => {
         const value = entityConfig.line_width;
         return (typeof value === 'number'
           && !Number.isNaN(value))
           ? value : this.config.line_width;
-      }));
+      });
     return ({
       min: Math.min(...arr),
       max: Math.max(...arr),

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,6 @@ class MiniGraphCard extends LitElement {
 
     // initailize memoized arrays
     this._visibleEntitiesCache = null;
-    this._visibleBarEntitiesCache = null;
     this._primaryYaxisEntitiesCache = null;
     this._secondaryYaxisEntitiesCache = null;
     this._visibleLegendsCache = null;
@@ -1019,15 +1018,6 @@ class MiniGraphCard extends LitElement {
         .filter(entity => entity.show_graph !== false);
     }
     return this._visibleEntitiesCache;
-  }
-
-  get visibleBarEntities() {
-    if (!this._visibleBarEntitiesCache) {
-      this._visibleBarEntitiesCache = this.config.show.graph === 'bar'
-        ? this.visibleEntities
-        : this.visibleEntities.filter(entity => entity.graph === 'bar');
-    }
-    return this._visibleBarEntitiesCache;
   }
 
   get primaryYaxisEntities() {

--- a/src/main.js
+++ b/src/main.js
@@ -114,6 +114,26 @@ class MiniGraphCard extends LitElement {
     };
   }
 
+/**
+  * Returns min & max "line_width" values defined globally for a card
+  * & for all entities individually
+  * @returns {object} min & max "line_width" values
+  */
+  getMinMaxLineWidth() {
+    const arr = this.config.entities
+      .filter(entityConfig => entityConfig.show_graph !== false)
+      .map(entityConfig => {
+        let value = entityConfig.line_width;
+        return (typeof value === 'number'
+          && !Number.isNaN(value))
+          ? value : this.config.line_width;
+      });
+    return ({
+      min: Math.min(...arr),
+      max: Math.max(...arr),
+    });
+  }
+
   setConfig(config) {
     this.config = buildConfig(config);
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));

--- a/src/main.js
+++ b/src/main.js
@@ -881,7 +881,7 @@ class MiniGraphCard extends LitElement {
           ${this.renderSvgPart(this.fill, this.renderSvgFillRect, reversed)}
           ${this.renderSvgPart(this.line, this.renderSvgLine, reversed)}
           ${this.renderSvgPart(this.line, this.renderSvgLineRect, reversed)}
-          ${this.bar.map((bars, i) => this.renderSvgBars(bars, i))}
+          ${this.renderSvgPart(this.bar, this.renderSvgBars, this.config.bar_spacing === -1 && reversed)}
         </g>
         ${this.renderSvgPart(this.points, this.renderSvgPoints, reversed)}
       </svg>`;

--- a/src/main.js
+++ b/src/main.js
@@ -1153,7 +1153,8 @@ class MiniGraphCard extends LitElement {
     this.updateBounds();
 
     if (config.show.graph) {
-      let graphPos = 0; // index of a bar (only used for bars & only increments if a particular graph to be shown)
+      // index of a bar (only used for bars & only increments if a particular graph to be shown)
+      let graphPos = 0;
       this.entity.forEach((entity, i) => {
         if (!entity || this.Graph[i].coords.length === 0) return;
         this.Graph[i].logarithmic = this.computeUsesLogarithmic(i);
@@ -1163,7 +1164,12 @@ class MiniGraphCard extends LitElement {
           const numVisible = this.visibleEntities.length;
           const bar_spacing_group = config.bar_spacing_group !== undefined
             ? config.bar_spacing_group : config.bar_spacing;
-          this.bar[i] = this.Graph[i].getBars(graphPos, numVisible, config.bar_spacing, bar_spacing_group);
+          this.bar[i] = this.Graph[i].getBars(
+            graphPos,
+            numVisible,
+            config.bar_spacing,
+            bar_spacing_group
+          );
           graphPos += 1;
         } else {
           const line = this.Graph[i].getPath();

--- a/src/main.js
+++ b/src/main.js
@@ -1168,7 +1168,7 @@ class MiniGraphCard extends LitElement {
             graphPos,
             numVisible,
             config.bar_spacing,
-            bar_spacing_group
+            bar_spacing_group,
           );
           graphPos += 1;
         } else {

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import {
   UPDATE_PROPS,
   X, Y, V,
   ONE_HOUR,
+  DEFAULT_MARGIN,
 } from './const';
 import { getFactor } from './others';
 import {
@@ -124,11 +125,18 @@ class MiniGraphCard extends LitElement {
 
     if (!this.Graph || entitiesChanged) {
       if (this._hass) this.hass = this._hass;
+      const min_line_width = this.getMinMaxLineWidth().min;
+      const max_line_width = this.getMinMaxLineWidth().max;
+      const margin = this.config.show.graph === 'bar'
+        ? [DEFAULT_MARGIN, DEFAULT_MARGIN]
+        : this.config.show.fill
+          ? [0, max_line_width]
+          : [min_line_width, max_line_width];
       this.Graph = this.config.entities.map(
         (entity, index) => new Graph(
           500,
           this.config.height,
-          [this.config.show.fill ? 0 : this.config.line_width, this.config.line_width],
+          margin,
           this.config.hours_to_show,
           this.config.points_per_hour,
           entity.aggregate_func || this.config.aggregate_func,

--- a/src/main.js
+++ b/src/main.js
@@ -122,7 +122,7 @@ class MiniGraphCard extends LitElement {
   getMinMaxLineWidth() {
     const arr = this.config.entities
       .filter(entityConfig => entityConfig.show_graph !== false)
-      .map(entityConfig => {
+      .map((entityConfig) => {
         const value = entityConfig.line_width;
         return (typeof value === 'number'
           && !Number.isNaN(value))

--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,7 @@ class MiniGraphCard extends LitElement {
 
     // initailize memoized arrays
     this._visibleEntitiesCache = null;
+    this._visibleBarEntitiesCache = null;
     this._primaryYaxisEntitiesCache = null;
     this._secondaryYaxisEntitiesCache = null;
     this._visibleLegendsCache = null;
@@ -1018,6 +1019,15 @@ class MiniGraphCard extends LitElement {
         .filter(entity => entity.show_graph !== false);
     }
     return this._visibleEntitiesCache;
+  }
+
+  get visibleBarEntities() {
+    if (!this._visibleBarEntitiesCache) {
+      this._visibleBarEntitiesCache = this.config.show.graph === 'bar'
+        ? this.visibleEntities
+        : this.visibleEntities.filter(entity => entity.graph === 'bar');
+    }
+    return this._visibleBarEntitiesCache;
   }
 
   get primaryYaxisEntities() {

--- a/src/main.js
+++ b/src/main.js
@@ -1153,7 +1153,7 @@ class MiniGraphCard extends LitElement {
     this.updateBounds();
 
     if (config.show.graph) {
-      let graphPos = 0;
+      let graphPos = 0; // index of a bar (only used for bars & only increments if a particular graph to be shown)
       this.entity.forEach((entity, i) => {
         if (!entity || this.Graph[i].coords.length === 0) return;
         this.Graph[i].logarithmic = this.computeUsesLogarithmic(i);
@@ -1161,7 +1161,9 @@ class MiniGraphCard extends LitElement {
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
           const numVisible = this.visibleEntities.length;
-          this.bar[i] = this.Graph[i].getBars(graphPos, numVisible, config.bar_spacing);
+          const bar_spacing_group = config.bar_spacing_group !== undefined
+            ? config.bar_spacing_group : config.bar_spacing;
+          this.bar[i] = this.Graph[i].getBars(graphPos, numVisible, config.bar_spacing, bar_spacing_group);
           graphPos += 1;
         } else {
           const line = this.Graph[i].getPath();

--- a/src/main.js
+++ b/src/main.js
@@ -114,7 +114,7 @@ class MiniGraphCard extends LitElement {
     };
   }
 
-/**
+  /**
   * Returns min & max "line_width" values defined globally for a card
   * & for all entities individually
   * @returns {object} min & max "line_width" values
@@ -122,12 +122,12 @@ class MiniGraphCard extends LitElement {
   getMinMaxLineWidth() {
     const arr = this.config.entities
       .filter(entityConfig => entityConfig.show_graph !== false)
-      .map(entityConfig => {
-        let value = entityConfig.line_width;
+      .map(entityConfig => ({
+        const value = entityConfig.line_width;
         return (typeof value === 'number'
           && !Number.isNaN(value))
           ? value : this.config.line_width;
-      });
+      }));
     return ({
       min: Math.min(...arr),
       max: Math.max(...arr),

--- a/src/main.js
+++ b/src/main.js
@@ -1182,13 +1182,11 @@ class MiniGraphCard extends LitElement {
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
           const numVisible = this.visibleEntities.length;
-          const bar_spacing_group = config.bar_spacing_group !== undefined
-            ? config.bar_spacing_group : config.bar_spacing;
           this.bar[i] = this.Graph[i].getBars(
             graphPos,
             numVisible,
             config.bar_spacing,
-            bar_spacing_group,
+            config.bar_spacing_group,
           );
           graphPos += 1;
         } else {


### PR DESCRIPTION
Main idea of @fran68.
Based on https://github.com/kalkih/mini-graph-card/pull/1363 & discussions there.

Differences from https://github.com/kalkih/mini-graph-card/pull/1363:
1) Margins passed to Graph are fixed.
2) Formulae in `getBars()` are reviewed.

Formulae in `getBars()` are based on this picture:
<img width="1157" height="822" alt="изображение" src="https://github.com/user-attachments/assets/18ad1d48-68ef-48cb-86a9-c3ff12f121b2" />

Implements https://github.com/kalkih/mini-graph-card/issues/1000