### PR TITLE
feat: Static line

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 ### Static lines
 
 A static horizontal line is drawn for a user-defined static value.
-Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
+Can be used in various applications like drawing a threshold line or a zeroth X-axis.
 
 Notes:
 1. Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `line_width`, `line_style`, `color`, `unit`, `decimals`, `show_...`, `state_adaptive_color`, `y_axis`.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ properties of the Entity object detailed in the following table (as per `sensor.
 
 | Name | Type | Default | Description |
 |------|:----:|:-------:|-------------|
-| entity ***(required)*** | string |         | Entity id of the sensor.
-| attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state
+| entity | string |         | Entity id of the sensor. Either `entity` or `static_value` must be defined.
+| attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state.
+| static_value | number |         | Set a static value for a (preset line)](#preset-lines). Either `entity` or `static_value` must be defined.
 | name | string |         | Set a custom display name, defaults to entity's friendly_name.
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
@@ -576,6 +577,21 @@ entities:
     name: value_1 from first element of list attribute
 ```
 ![image](https://github.com/ildar170975/mini-graph-card/assets/71872483/eebd0cea-da93-4bf5-97a1-118edd2a9c5e)
+
+#### Preset lines
+
+A preset horizontal line is drawn for a user-defined static value.
+Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
+Like a dynamic graph for an entity (defined by an `entity` option), a preset line (defined by a `static_value` option) can use other applicable options: `name`, `color`, `unit`, `show_...`, `state_adaptive_color`, `y_axis`.
+
+Example with a threshold line (with a fill) with displaying a threshold's value:
+```
+```
+
+Example with a zeroth X-axis:
+```
+```
+
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | entity ***(required)*** | string |         | Entity id of the sensor. Either `entity` or `static_value` must be defined.
 | attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state
 | static_value | number |         | Set a value for a [static line](#static-lines). Either `entity` or `static_value` must be defined.
-| name | string |         | Set a custom display name, defaults to entity's friendly_name or a `Static` label for a `static_value` entry (see [Static lines](#static-lines)).
+| name | string |         | Set a custom display name, defaults to entity's friendly_name or a `Static` label for a [static value](#static-lines).
 | line_width | number |         | Override for a thickness of the line.
 | line_style | string |   | Override the style of the line (see [Line styles](#line-styles)).
 | color | string |         | Set a custom color, overrides all other color options including thresholds.

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ entities:
 #### Displaying static lines
 
 Example with a threshold line:
+
 <img width="485" height="257" alt="image" src="https://github.com/user-attachments/assets/7d668913-1811-48e8-9a24-d6bed93f7ee9" />
 ```yaml
 type: custom:mini-graph-card

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ entities:
 Example with a threshold line:
 
 <img width="485" height="257" alt="image" src="https://github.com/user-attachments/assets/7d668913-1811-48e8-9a24-d6bed93f7ee9" />
+
 ```yaml
 type: custom:mini-graph-card
 entities:
@@ -608,6 +609,7 @@ show:
 ```
 
 Example with a zeroth X-axis:
+
 ```yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,12 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 
 A static horizontal line is drawn for a user-defined static value.
 Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
-Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `line_width`, `line_style`, `color`, `unit`, `decimals`, `show_...`, `state_adaptive_color`, `y_axis`.
+
+Notes:
+1. Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `line_width`, `line_style`, `color`, `unit`, `decimals`, `show_...`, `state_adaptive_color`, `y_axis`.
+2. When `graph: bar`, a `static_value` entry is rendered as a set of constant bars.
+3. Displaying extrema/average values is not supported for `static_value` entries.
+
 See examples [below](#displaying-static-lines).
 
 ### Number format

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ properties of the Entity object detailed in the following table (as per `sensor.
 |------|:----:|:-------:|-------------|
 | entity | string |         | Entity id of the sensor. Either `entity` or `static_value` must be defined.
 | attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state.
-| static_value | number |         | Set a static value for a [preset line](#preset-lines). Either `entity` or `static_value` must be defined.
-| name | string |         | Set a custom display name, defaults to entity's friendly_name.
+| static_value | number |         | Set a value for a [static line](#static-lines). Either `entity` or `static_value` must be defined.
+| name | string |         | Set a custom display name, defaults to entity's friendly_name or a `Static` label for a `static_value` entry (see [Static lines](#static-lines)).
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
@@ -578,11 +578,11 @@ entities:
 ```
 ![image](https://github.com/ildar170975/mini-graph-card/assets/71872483/eebd0cea-da93-4bf5-97a1-118edd2a9c5e)
 
-#### Preset lines
+#### Static lines
 
-A preset horizontal line is drawn for a user-defined static value.
+A static horizontal line is drawn for a user-defined static value.
 Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
-Like a dynamic graph for an entity (defined by an `entity` option), a preset line (defined by a `static_value` option) can use other applicable options: `name`, `color`, `unit`, `show_...`, `state_adaptive_color`, `y_axis`.
+Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `color`, `unit`, `show_...`, `state_adaptive_color`, `y_axis`.
 
 Example with a threshold line (with a fill) with displaying a threshold's value:
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 |------|:----:|:-------:|-------------|
 | entity | string |         | Entity id of the sensor. Either `entity` or `static_value` must be defined.
 | attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state.
-| static_value | number |         | Set a static value for a (preset line)](#preset-lines). Either `entity` or `static_value` must be defined.
+| static_value | number |         | Set a static value for a [preset line](#preset-lines). Either `entity` or `static_value` must be defined.
 | name | string |         | Set a custom display name, defaults to entity's friendly_name.
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).

--- a/README.md
+++ b/README.md
@@ -610,9 +610,22 @@ show:
 
 Example with a zeroth X-axis:
 
-```yaml
-```
+<img width="480" height="219" alt="image" src="https://github.com/user-attachments/assets/2fe260f2-439c-4652-b817-feec461cbee8" />
 
+```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.temperature
+  - static_value: 0
+    show_state: false
+    show_points: false
+    show_fill: false
+    show_legend: false
+    line_width: 1
+    color: grey
+show:
+  labels: true
+```
 
 
 #### Grouping by date

--- a/README.md
+++ b/README.md
@@ -585,8 +585,25 @@ entities:
 
 #### Displaying static lines
 
-Example with a threshold line (with a fill) with displaying a threshold's value:
+Example with a threshold line:
+<img width="485" height="257" alt="image" src="https://github.com/user-attachments/assets/7d668913-1811-48e8-9a24-d6bed93f7ee9" />
 ```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.system_monitor_processor_use
+  - static_value: 50
+    name: Threshold
+    unit: "%"
+    show_legend_state: true
+    show_state: false
+    show_points: false
+    show_fill: false
+    line_width: 1
+    line_style: 4,7
+    color: red
+lower_bound: ~0
+show:
+  labels: true
 ```
 
 Example with a zeroth X-axis:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | Name | Type | Default | Since | Description |
 |------|:----:|:-------:|:-----:|-------------|
 | type ***(required)*** | string |  | v0.0.1 | `custom:mini-graph-card`.
-| entities ***(required)*** | list |  | v0.2.0 | One or more sensor entities in a list, see [entities object](#entities-object) for additional entity options.
+| entities ***(required)*** | list |  | v0.2.0 | One or more sensor entities (along with [static values](#static-lines)) in a list, see [entities object](#entities-object) for additional entity/static value options.
 | icon | string |  | v0.0.1 | Set a custom icon from any of the available mdi icons.
 | icon_image | string |  | v0.12.0 | Override icon with an image url.
 | name | string |  | v0.0.1 | Set a custom name which is displayed beside the icon.
@@ -137,20 +137,20 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | static_value | number |         | Set a value for a [static line](#static-lines). Either `entity` or `static_value` must be defined.
 | name | string |         | Set a custom display name, defaults to entity's friendly_name or a `Static` label for a `static_value` entry (see [Static lines](#static-lines)).
 | line_width | number |         | Override for a thickness of the line.
+| line_style | string |   | Override the style of the line (see [Line styles](#line-styles)).
 | color | string |         | Set a custom color, overrides all other color options including thresholds.
 | unit | string |         | Set a custom unit of measurement, overrides `unit` set in base config (`''` value for an empty unit).
 | aggregate_func | string |         | Override for aggregate function used to calculate point on the graph, `avg`, `median`, `min`, `max`, `first`, `last`, `sum`.
 | decimals | integer |    | Override the exact number of decimals to show for number values, see [Number format](#number-format).
-| line_style | string |   | Override the style of the line (see [Line styles](#line-styles)).
 | show_state | boolean |         | Display the current state.
 | show_legend_state | boolean |  false  | Display the current state as part of the legend.
 | show_indicator | boolean |         | Display a color indicator next to the state.
-| show_graph | boolean |         | Set to false to completely hide the entity in the graph.
+| show_graph | boolean |         | Set to false to completely hide the graph.
 | show_line | boolean |         | Set to false to hide the line.
 | show_fill | boolean |         | Set to false to hide the fill.
 | show_points | boolean |         | Set to false to hide the points (see a note below).
 | show_legend | boolean |         | Set to false to turn hide from the legend.
-| state_adaptive_color | boolean |         | Make the color of the state adapt to the entity color.
+| state_adaptive_color | boolean |         | Make the color of the state adapt to the entity/static value color.
 | y_axis | string |         | If 'secondary', displays using the secondary Y-axis on the right.
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
@@ -184,8 +184,8 @@ All properties are optional.
 | info_hide_unit | `false` | `true` / `false` | Do not show a unit for the average & max/min information.
 | labels | `hover` | `true` / `false` / `hover` | Display Y-axis labels.
 | labels_secondary | `hover` | `true` / `false` / `hover` | Display secondary Y-axis labels.
-| name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity color.
-| icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity color.
+| name_adaptive_color | `false` | `true` / `false` | Make the name color adapt with the primary entity/static value color.
+| icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity/static value color.
 | loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
 | graphs_order | `direct` | `direct` / `reversed` | Define an order of displaying graphs (see [Graphs order](#graphs-order)).
 
@@ -245,9 +245,9 @@ As a shorthand, you can just use a color string for the stops that you want inte
 
 All card's area - except a graph part - supports processing of actions.
 By default, tapping on an element opens a `more-info` dialog:
-1. For "state" elements - the dialog is opened for a corresponding graph entity.
+1. For "state" elements - the dialog is opened for a corresponding graph entity (not processed for a [static value](#static-lines)).
 2. For "legend" elements - same as above.
-3. For other card's areas (except a graph part) - the dialog is opened for the 1st graph entity.
+3. For other card's areas (except a graph part) - the dialog is opened for the 1st graph entity (not processed for a [static value](#static-lines)).
 
 | Name | Type | Default | Options | Description |
 |------|:----:|:-------:|:-----------:|-------------|
@@ -304,10 +304,17 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
 
+### Static lines
+
+A static horizontal line is drawn for a user-defined static value.
+Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
+Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `line_width`, `line_style`, `color`, `unit`, `decimals`, `show_...`, `state_adaptive_color`, `y_axis`.
+See examples [below](#displaying-static-lines).
+
 ### Number format
 
-Options `decimals` defined "card-wide" and/or for some entity are used to set an exact number of decimals according to the following rules:
-1. For state & attribute values:
+Options `decimals` defined "card-wide" and/or for some entity/[static value](#static-lines) are used to set an exact number of decimals according to the following rules:
+1. For state & attribute values, static values:
 - if none `decimals` option is defined - a default presentation (see a note below) is used;
 - if "card-wide" `decimals` is defined - this value is used;
 - if `decimals` for some entity is defined - this value is used for this entity.
@@ -327,7 +334,7 @@ Options `decimals` defined "card-wide" and/or for some entity are used to set an
 A "default presentation" refers to a default look in HA:
 1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).
 2. For an attribute value (also for extrema & average): default HA settings are used (for template sensors - a user-defined accuracy set in jinja templates is used).
-3. For Y-axis labels: "maximum 2 decimals" accuracy is used.
+3. For Y-axis labels, [static values](#static-lines): "maximum 2 decimals" accuracy is used.
 And for all values, HA number format settings (like `xxxx.xx` or `x xxx.x` or `x,xxx.x`) are used.
 
 
@@ -364,7 +371,7 @@ A default line style is a "solid line". A style should be defined in a format us
 
 Note: this section applies to `line` graphs only.
 
-For each entity, a `line` graph consists of 3 basic parts: a "line" part (curve), a "fill" part (if displaying a fill is configured), a "points" part (if displaying points is configured).
+For each entity/[static value](#static-lines), a `line` graph consists of 3 basic parts: a "line" part (curve), a "fill" part (if displaying a fill is configured), a "points" part (if displaying points is configured).
 
 By default, graphs are shown in the following order:
 1. All "fill" parts are shown (if configured).
@@ -372,12 +379,12 @@ By default, graphs are shown in the following order:
 3. All "points" parts are shown (if configured).
 
 Within each category, parts are shown in the following order:
-1. First, a part for the 1st entity in the `entities` list is processed.
-2. Last, a part for the last entity in the `entities` list is processed.
+1. First, a part for the 1st entity/static value in the `entities` list is processed.
+2. Last, a part for the last entity/static value in the `entities` list is processed.
 
-I.e. the last entity's graph will be shown as topmost.
+I.e. the last entity's/static value's graph will be shown as topmost.
 
-This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for `1st entity's graph is topmost`.
+This can be altered by setting a `graph_order` option: `direct` (default) stands for the described default order, `reversed` stands for `1st entity's/static value's graph is topmost`.
 
 
 ### Theme variables
@@ -571,6 +578,15 @@ entities:
     line_style: 6,6
 ```
 
+#### Displaying static lines
+
+Example with a threshold line (with a fill) with displaying a threshold's value:
+```yaml
+```
+
+Example with a zeroth X-axis:
+```yaml
+```
 
 
 
@@ -727,22 +743,6 @@ entities:
     name: value_1 from first element of list attribute
 ```
 ![image](https://github.com/ildar170975/mini-graph-card/assets/71872483/eebd0cea-da93-4bf5-97a1-118edd2a9c5e)
-
-#### Static lines
-
-A static horizontal line is drawn for a user-defined static value.
-Can be used in various applcations like drawing a threshold line or a zeroth X-axis.
-Like a dynamic graph for an entity (defined by an `entity` option), a static line (defined by a `static_value` option) can use other applicable options: `name`, `color`, `unit`, `show_...`, `state_adaptive_color`, `y_axis`.
-
-Example with a threshold line (with a fill) with displaying a threshold's value:
-```
-```
-
-Example with a zeroth X-axis:
-```
-```
-
-
 
 ## Development
 

--- a/src/main.js
+++ b/src/main.js
@@ -872,8 +872,8 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
-    if ((entity
-         && this.config.tap_action === 'more-info') || this.config.tap_action !== 'more-info')) {
+    if ((entity && this.config.tap_action === 'more-info')
+        || this.config.tap_action !== 'more-info') {
       e.stopPropagation();
       handleClick(
         this,

--- a/src/main.js
+++ b/src/main.js
@@ -60,7 +60,7 @@ class MiniGraphCard extends LitElement {
     const queue = [];
     this.config.entities.forEach((entity, index) => {
       this.config.entities[index].index = index; // Required for filtered views
-      const entityState = hass && hass.states[entity.entity] || undefined;
+      const entityState = hass && entity.entity && hass.states[entity.entity] || undefined;
       if (entityState && this.entity[index] !== entityState) {
         this.entity[index] = entityState;
         queue.push(`${entityState.entity_id}-${index}`);
@@ -178,7 +178,9 @@ class MiniGraphCard extends LitElement {
   render({ config } = this) {
     if (!config || !this.entity || !this._hass)
       return html``;
-    if (this.config.entities.some((_, index) => this.entity[index] === undefined)) {
+    if (this.config.entities.some(
+      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index)
+    )) {
       return this.renderWarnings();
     }
     return html`
@@ -203,11 +205,12 @@ class MiniGraphCard extends LitElement {
     return html`
       <hui-warning>
         <div>mini-graph-card</div>
-        ${this.config.entities.map((_, index) => (!this.entity[index] ? html`
-          <div>
-            Entity not available: ${this.config.entities[index].entity}
-          </div>
-        ` : html``))}
+        ${this.config.entities.map(
+          (_, index) => (!this.entity[index] && !this.isStaticValue(index)
+            ? html`<div>
+                Entity not available: ${this.config.entities[index].entity}
+              </div>`
+            : html``))}
       </hui-warning>
     `;
   }
@@ -269,6 +272,16 @@ class MiniGraphCard extends LitElement {
       `;
   }
 
+  /**
+   * Check if an entity config contains a valid `static_value` option
+   * @param {number} index Index of an entity in config.entities
+   * @returns `true` if a valid `static_value` option defined
+   */
+  isStaticValue(index) {
+    const entity = this.config.entities[index];
+    return typeof entity.static_value === 'number' && !Number.isNaN(entity.static_value);
+  }
+
   getObjectAttr(obj, path) {
     return path.split('.').reduce((res, key) => res && res[key], obj);
   }
@@ -279,6 +292,8 @@ class MiniGraphCard extends LitElement {
       return this.points[id][this.points[id].length - 1][V];
     } else if (entityConfig.attribute) {
       return this.getObjectAttr(this.entity[id].attributes, entityConfig.attribute);
+    } else if (this.isStaticValue(id)) {
+      return this.config.entities[id].static_value;
     } else {
       return this.entity[id].state;
     }
@@ -294,6 +309,7 @@ class MiniGraphCard extends LitElement {
       const value = isTooltip ? tooltipValue : state;
       const entity = isTooltip ? tooltipEntity : id;
       const entityConfig = this.config.entities[entity];
+      // ??? account preset line
       return html`
         <div
           class="state ${!isPrimary && 'state--small'}"
@@ -465,7 +481,7 @@ class MiniGraphCard extends LitElement {
 
   renderSvgPoints(points, i) {
     if (!points) return;
-    const color = this.computeColor(this.entity[i].state, i);
+    const color = this.computeColor(this.entity[i].state, i); // ?? preset line
     return svg`
       <g class='line--points'
         ?tooltip=${this.tooltip.entity === i}
@@ -498,7 +514,7 @@ class MiniGraphCard extends LitElement {
     if (!line) return;
     const fill = this.gradient[i]
       ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(this.entity[i].state, i);
+      : this.computeColor(this.entity[i].state, i); // ??? preset line
     return svg`
       <rect class='line--rect'
         ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
@@ -512,7 +528,7 @@ class MiniGraphCard extends LitElement {
     if (!fill) return;
     const svgFill = this.gradient[i]
       ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(this.entity[i].state, i);
+      : this.computeColor(this.entity[i].state, i); // ??? preset line
     return svg`
       <rect class='fill--rect'
         ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
@@ -638,8 +654,10 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
-    e.stopPropagation();
-    handleClick(this, this._hass, this.config, this.config.tap_action, entity.entity_id || entity);
+    if (entity) {
+      e.stopPropagation();
+      handleClick(this, this._hass, this.config, this.config.tap_action, entity.entity_id || entity);
+    }
   }
 
   get visibleEntities() {
@@ -695,7 +713,8 @@ class MiniGraphCard extends LitElement {
   computeName(index) {
     return this.config.entities[index].name
       || this.entity[index].attributes.friendly_name
-      || this.entity[index].entity_id;
+      || this.entity[index].entity_id
+      || (this.isStaticValue(index) && '');
   }
 
   computeIcon(entity) {
@@ -787,6 +806,7 @@ class MiniGraphCard extends LitElement {
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
         if (entity) this.Graph[i].update();
+        // ???? preset line
       });
     }
 
@@ -795,6 +815,7 @@ class MiniGraphCard extends LitElement {
     if (config.show.graph) {
       let graphPos = 0;
       this.entity.forEach((entity, i) => {
+        // ???? preset line
         if (!entity || this.Graph[i].coords.length === 0) return;
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];

--- a/src/main.js
+++ b/src/main.js
@@ -872,8 +872,8 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
-    e.stopPropagation();
-    if (entity) {
+    if (entity || (!entity && this.config.tap_action !== 'more-info')) {
+      e.stopPropagation();
       handleClick(
         this,
         this._hass,

--- a/src/main.js
+++ b/src/main.js
@@ -294,6 +294,7 @@ class MiniGraphCard extends LitElement {
   }
 
   renderWarnings() {
+    /* eslint-disable indent */
     return html`
       <hui-warning>
         <div>mini-graph-card</div>
@@ -302,6 +303,7 @@ class MiniGraphCard extends LitElement {
           : html``))}
       </hui-warning>
     `;
+    /* eslint-enable indent */
   }
 
   /**
@@ -493,7 +495,7 @@ class MiniGraphCard extends LitElement {
     const ready = ((this.entity[0] || this.isStaticValue(0))
       && !this.Graph.some(
         (element, index) => element._history === undefined
-        && this.config.entities[index].show_graph !== false,
+          && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator === false;
     return this.config.show.graph ? html`
@@ -534,6 +536,7 @@ class MiniGraphCard extends LitElement {
     // do not show a legend for only 1 entry or when a legend is globally disabled
     if (this.visibleLegends.length <= 1 || !this.config.show.legend) return;
     const location = this.config.show.legend === 'below' ? 'below' : 'above';
+    /* eslint-disable indent */
     return html`
       <div class="graph__legend" loc=${location}>
         ${this.visibleLegends.map((entity) => {
@@ -550,6 +553,7 @@ class MiniGraphCard extends LitElement {
         })}
       </div>
     `;
+    /* eslint-enable indent */
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -881,6 +881,8 @@ class MiniGraphCard extends LitElement {
         this.config.tap_action,
         entity.entity_id || entity,
       );
+    } else if (!entity && this.config.tap_action.action === 'more-info') {
+      e.stopPropagation();
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -872,7 +872,8 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
-    if (entity || (!entity && this.config.tap_action.action !== 'more-info')) {
+    if ((entity
+         && this.config.tap_action === 'more-info') || this.config.tap_action !== 'more-info')) {
       e.stopPropagation();
       handleClick(
         this,
@@ -881,8 +882,6 @@ class MiniGraphCard extends LitElement {
         this.config.tap_action,
         entity.entity_id || entity,
       );
-    } else if (!entity && this.config.tap_action.action === 'more-info') {
-      e.stopPropagation();
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -872,7 +872,7 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
-    if (entity || (!entity && this.config.tap_action !== 'more-info')) {
+    if (entity || (!entity && this.config.tap_action.action !== 'more-info')) {
       e.stopPropagation();
       handleClick(
         this,

--- a/src/main.js
+++ b/src/main.js
@@ -270,7 +270,7 @@ class MiniGraphCard extends LitElement {
     if (!config || !this.entity || !this._hass)
       return html``;
     if (this.config.entities.some(
-      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index)
+      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index),
     )) {
       return this.renderWarnings();
     }

--- a/src/main.js
+++ b/src/main.js
@@ -192,7 +192,7 @@ class MiniGraphCard extends LitElement {
    * @returns True if smoothing is applicable for an entity, false - otherwise
    */
   getDefaultSmoothing(index) {
-    const entity = this.config.entities[index].entity;
+    const { entity } = this.config.entities[index];
     if (entity) {
       // Turn off default smoothing for binary_sensor entities.
       // Can be also refactored for other non-numerical domains if needed.
@@ -270,8 +270,8 @@ class MiniGraphCard extends LitElement {
     if (!config || !this.entity || !this._hass)
       return html``;
     if (this.config.entities.some(
-      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index))
-    ) {
+      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index)
+    )) {
       return this.renderWarnings();
     }
     this.updateFormatFromLocale();
@@ -496,7 +496,7 @@ class MiniGraphCard extends LitElement {
       && !this.Graph.some(
         (element, index) => element._history === undefined
           && this.config.entities[index].show_graph !== false,
-    ))
+      ))
     || this.config.show.loading_indicator === false;
     return this.config.show.graph ? html`
       <div class="graph">

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ class MiniGraphCard extends LitElement {
     this.bound = [0, 0];
     this.boundSecondary = [0, 0];
     this.length = [];
-    this.entity = [];
+    this.entity = []; // stateObj for each entity in config.entities
     this.line = [];
     this.bar = [];
     this.abs = [];
@@ -54,6 +54,8 @@ class MiniGraphCard extends LitElement {
     this.tooltip = {};
     this.updateQueue = [];
     this.updating = false;
+    // set once to "true" when a history is set for a particular entry[index] with static_value
+    this.staticValueUpdated = [];
     this.stateChanged = false;
     this.initial = true;
     this._md5Config = undefined;
@@ -79,10 +81,17 @@ class MiniGraphCard extends LitElement {
     this.config.entities.forEach((entity, index) => {
       this.config.entities[index].index = index; // Required for filtered views
       // entityState stands for "stateObj"
-      const entityState = hass && hass.states[entity.entity] || undefined;
+      const entityState = hass && entity.entity && hass.states[entity.entity] || undefined;
+      // initiate an update if stateObj changed
       if (entityState && this.entity[index] !== entityState) {
         this.entity[index] = entityState;
         queue.push(`${entityState.entity_id}-${index}`);
+        updated = true;
+      } else if (!entity.entity
+          && this.isStaticValue(index) && !this.staticValueUpdated[index]) {
+        this.entity[index] = undefined;
+        queue.push(`static_value-${index}`);
+        this.staticValueUpdated[index] = true; // updated only once
         updated = true;
       }
     });
@@ -169,12 +178,29 @@ class MiniGraphCard extends LitElement {
           getFirstDefinedItem(
             entity.smoothing,
             this.config.smoothing,
-            !entity.entity.startsWith('binary_sensor.'), // turn off for binary sensor by default
+            this.getDefaultSmoothing(index),
           ),
           this.computeUsesLogarithmic(index),
         ),
       );
     }
+  }
+
+  /**
+   * Check if smoothing can be defaulted to `true` for an entity
+   * @param {number} index Index of an entry in config.entities
+   * @returns True if smoothing is applicable for an entity, false - otherwise
+   */
+  getDefaultSmoothing(index) {
+    const entity = this.config.entities[index].entity;
+    if (entity) {
+      // Turn off default smoothing for binary_sensor entities.
+      // Can be also refactored for other non-numerical domains if needed.
+      // Smoothing should be manually turned on in config in case of addressing a numerical attribute.
+      return !entity.startsWith('binary_sensor.');
+    }
+    // processing a possible `static_value` entry
+    return false;
   }
 
   /**
@@ -243,8 +269,8 @@ class MiniGraphCard extends LitElement {
     if (!config || !this.entity || !this._hass)
       return html``;
     if (this.config.entities.some(
-      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index)
-    )) {
+      (_, index) => this.entity[index] === undefined && !this.isStaticValue(index))
+    ) {
       return this.renderWarnings();
     }
     this.updateFormatFromLocale();
@@ -353,6 +379,16 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
+   * Check if an entity config contains a valid `static_value` option
+   * @param {number} index Index of an entry in config.entities
+   * @returns True if a valid `static_value` option defined, false - otherwise
+   */
+  isStaticValue(index) {
+    const entity = this.config.entities[index];
+    return typeof entity.static_value === 'number' && !Number.isNaN(entity.static_value);
+  }
+
+  /**
   * Returns an object attrubute value
   * @returns {any} Value of an attribute/subattribute
   * @param obj stateObj.attributes
@@ -371,9 +407,9 @@ class MiniGraphCard extends LitElement {
     return path.includes('.');
   }
 
-  /** Returns a state/attrubute value
-  * @returns {any} value of a state/attribute
-  * @param {number} index Index of an entity in config.entities
+  /** Returns a state/attrubute value or a static_value
+  * @returns {any} value of a state/attribute or a static_value
+  * @param {number} index Index of an entry in config.entities
   */
   getEntityState(index) {
     const entityConfig = this.config.entities[index];
@@ -384,6 +420,8 @@ class MiniGraphCard extends LitElement {
       // last "point" value
       // only if "points" exist (show_points: true)
       return this.points[index][this.points[index].length - 1][V];
+    } else if (this.isStaticValue(index)) {
+      return this.config.entities[index].static_value;
     } else if (entityConfig.attribute) {
       // current attribute value
       return this.getObjectAttr(this.entity[index].attributes, entityConfig.attribute);
@@ -394,20 +432,20 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-  * Renders a state/attrubute value (if "show_state: true")
+  * Renders a state/attrubute value or a static_value (if "show_state: true")
   * @returns HTML element
-  * @param {number} index Index of an entity in config.entities
+  * @param {number} index Index of an entry in config.entities
   */
   renderState(index) {
-    const isPrimary = index === 0; // rendering main entity state element?
+    const isPrimary = index === 0; // rendering main entry state element?
     if (isPrimary || this.config.entities[index].show_state) {
-      // get a state/attribute value
+      // get a state/attribute value or a static_value
       const state = this.getEntityState(index);
-      // use tooltip data for main entity state element, if tooltip is active
+      // use tooltip data for main entry state element, if tooltip is active
       // "tooltip" - a selected point/bar
       const { entity: tooltipEntityIndex, value: tooltipValue } = this.tooltip;
       const isTooltip = isPrimary && tooltipEntityIndex !== undefined;
-      // either a state/attr for a selected point/bar - or a "native" state/attr
+      // either a state/attr/static_value for a selected point/bar - or a "native" state/attr/static_value
       const value = isTooltip ? tooltipValue : state;
       const entityIndex = isTooltip ? tooltipEntityIndex : index;
       const entityConfig = this.config.entities[entityIndex];
@@ -453,7 +491,8 @@ class MiniGraphCard extends LitElement {
   }
 
   renderGraph() {
-    const ready = (this.entity[0] && !this.Graph.some(
+    const ready = ((this.entity[0] || this.isStaticValue(0))
+      && !this.Graph.some(
       (element, index) => element._history === undefined
       && this.config.entities[index].show_graph !== false,
     ))
@@ -474,9 +513,9 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-  * Renders a legend entry for an entity
+  * Renders a legend entry for an entity/static_value
   * @returns HTML element
-  * @param {number} index Index of an entity in config.entities
+  * @param {number} index Index of an entry in config.entities
   */
   computeLegend(index) {
     let legend = this.computeName(index);
@@ -493,10 +532,9 @@ class MiniGraphCard extends LitElement {
   * @returns HTML element
   */
   renderLegend() {
-    // do not show a legend for only 1 entity or when a legend is globally disabled
+    // do not show a legend for only 1 entry or when a legend is globally disabled
     if (this.visibleLegends.length <= 1 || !this.config.show.legend) return;
     const location = this.config.show.legend === 'below' ? 'below' : 'above';
-    /* eslint-disable indent */
     return html`
       <div class="graph__legend" loc=${location}>
         ${this.visibleLegends.map((entity) => {
@@ -513,14 +551,13 @@ class MiniGraphCard extends LitElement {
         })}
       </div>
     `;
-    /* eslint-enable indent */
   }
 
   /**
-  * Renders an indicator for an entity
+  * Renders an indicator for an entity/static_value
   * @returns HTML element
-  * @param {string | number} state Value of a state/attribute
-  * @param {number} index Index of an entity in config.entities
+  * @param {string | number} state Value of a state/attribute or a static_value
+  * @param {number} index Index of an entry in config.entities
   */
   renderIndicator(state, index) {
     return svg`
@@ -601,7 +638,10 @@ class MiniGraphCard extends LitElement {
 
   renderSvgPoints(points, i) {
     if (!points) return;
-    const color = this.computeColor(this.entity[i].state, i); // ?? preset line
+    const state = this.entity[i] !== undefined
+      ? this.entity[i].state
+      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
+    const color = this.computeColor(state, i);
     return svg`
       <g class='line--points'
         ?tooltip=${this.tooltip.entity === i}
@@ -632,9 +672,12 @@ class MiniGraphCard extends LitElement {
 
   renderSvgLineRect(line, i) {
     if (!line) return;
+    const state = this.entity[i] !== undefined
+      ? this.entity[i].state
+      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
     const fill = this.gradient[i]
       ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(this.entity[i].state, i); // ??? preset line
+      : this.computeColor(state, i);
     return svg`
       <rect class='line--rect'
         ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
@@ -646,9 +689,12 @@ class MiniGraphCard extends LitElement {
 
   renderSvgFillRect(fill, i) {
     if (!fill) return;
+    const state = this.entity[i] !== undefined
+      ? this.entity[i].state
+      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
     const svgFill = this.gradient[i]
       ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(this.entity[i].state, i); // ??? preset line
+      : this.computeColor(state, i);
     return svg`
       <rect class='fill--rect'
         ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
@@ -804,7 +850,7 @@ class MiniGraphCard extends LitElement {
     const hideUnit = this.config.show.info_hide_unit;
     const { extrema, average } = this.config.show;
     const location = (extrema === 'below' || average === 'below') ? 'below' : 'above';
-    // index "0" is passed into computeStateWithUom() since "info" is shown for the 1st entity
+    // index "0" is passed into computeStateWithUom() since "info" is shown for the 1st entry
     return this.abs.length > 0 ? html`
       <div class="info flex" loc=${location}>
         ${this.abs.map(entry => html`
@@ -856,7 +902,7 @@ class MiniGraphCard extends LitElement {
 
   /**
    * Checks whether an entity uses logarithmic scaling.
-   * @param {number} index Index of an entity in config.entities
+   * @param {number} index Index of an entry in config.entities
    * @returns {boolean} True if the entity uses logarithmic scaling, false - otherwise
    */
   computeUsesLogarithmic(index) {
@@ -868,11 +914,11 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-  * Returns a color for an entity
+  * Returns a color for an entity/static_value
   * accounting `color_thresholds`, global `line_color` & individual `color` settings
   * @returns Color
-  * @param {string | number} inState Value of a state/attribute
-  * @param {number} index Index of an entity in config.entities
+  * @param {string | number} inState Value of a state/attribute or a static_value
+  * @param {number} index Index of an entry in config.entities
   */
   computeColor(inState, index) {
     const { color_thresholds, line_color } = this.config;
@@ -902,15 +948,15 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-  * Returns a name of an entity accounting a `name` option
+  * Returns a name of an entity/static_value accounting a `name` option
   * @returns {string} Name of an entity
-  * @param {number} index Index of an entity in config.entities
+  * @param {number} index Index of an entry in config.entities
   */
   computeName(index) {
     return this.config.entities[index].name
-      || this.entity[index].attributes.friendly_name
-      || this.entity[index].entity_id
-      || (this.isStaticValue(index) && '');
+      || this.entity[index] && (this.entity[index].attributes.friendly_name
+        || this.entity[index].entity_id)
+      || (this.isStaticValue(index) && 'Static');
   }
 
   /**
@@ -923,8 +969,8 @@ class MiniGraphCard extends LitElement {
   computeIcon(entity) {
     return (
       this.config.icon
-      || entity.attributes.icon
-      || stateIcon(entity)
+      || entity && entity.attributes.icon
+      || entity && stateIcon(entity)
       || ICONS.temperature
     );
   }
@@ -932,7 +978,7 @@ class MiniGraphCard extends LitElement {
   /**
   * Returns a unit
   * @returns {string} Unit
-  * @param {number} index Index of an entity in config.entities
+  * @param {number} index Index of an entry in config.entities
   * @param {number|string} inState Value of a state/attribute,
   * only used to process a preserved unit for a currently unavailable entity
   */
@@ -940,70 +986,82 @@ class MiniGraphCard extends LitElement {
     const entityUnit = this.config.entities[index].unit;
     const cardUnit = this.config.unit;
     let unit;
-    const entityId = this.entity[index].entity_id;
-    const stateObj = this._hass.states[entityId];
-    if (!stateObj || isUnavailableState(stateObj.state)) {
-      // processing unavailable state
-      if (inState !== undefined && !isUnavailableState(inState)) {
-        // we need to get a unit for a historical non-unavailable entity
-        if (this.preserved_uom[index] !== undefined) {
-          // use a preserved unit
-          unit = this.preserved_uom[index];
-        } else {
-          // try using a unit from config & attributes
-          unit = this.config.entities[index].unit
-            || this.config.unit
-            || stateObj.attributes.unit_of_measurement
-            || '';
-        }
-      } else {
-        unit = '';
-      }
-      return unit;
-    } else {
-      // processing normal state
+
+    if (!this.entity[index] && this.isStaticValue(index)) {
+      // processing static_value
       if (entityUnit !== undefined) {
         unit = entityUnit;
       } else if (cardUnit !== undefined) {
         unit = cardUnit;
-      } else {
-        // retrieving a native unit
-        const { attribute } = this.config.entities[index];
-        if (!attribute || !this.isObjectAttr(attribute)) {
-          // any cases except an object attribute
-          let parts;
-          if (attribute) {
-            parts = this._hass.formatEntityAttributeValueToParts(
-              stateObj,
-              attribute,
-            );
-          } else {
-            parts = this._hass.formatEntityStateToParts(
-              stateObj,
-            );
-          }
-          const unitPart = parts.find(part => part.type === 'unit');
-          unit = unitPart && unitPart.value;
-        } else {
-          // object attribute - considered as unitless
-          unit = '';
-        }
-      }
-      // preserve a computed unit
-      if (this.preserved_uom[index] === undefined) {
-        this.preserved_uom[index] = unit || '';
       }
       return (unit || '');
+    } else {
+      // processing entity
+      const entityId = this.entity[index].entity_id;
+      const stateObj = this._hass.states[entityId];
+      if (!stateObj || isUnavailableState(stateObj.state)) {
+        // processing unavailable state
+        if (inState !== undefined && !isUnavailableState(inState)) {
+          // we need to get a unit for a historical non-unavailable entity
+          if (this.preserved_uom[index] !== undefined) {
+            // use a preserved unit
+            unit = this.preserved_uom[index];
+          } else {
+            // try using a unit from config & attributes
+            unit = this.config.entities[index].unit
+              || this.config.unit
+              || stateObj.attributes.unit_of_measurement
+              || '';
+          }
+        } else {
+          unit = '';
+        }
+        return unit;
+      } else {
+        // processing normal state
+        if (entityUnit !== undefined) {
+          unit = entityUnit;
+        } else if (cardUnit !== undefined) {
+          unit = cardUnit;
+        } else {
+          // retrieving a native unit
+          const { attribute } = this.config.entities[index];
+          if (!attribute || !this.isObjectAttr(attribute)) {
+            // any cases except an object attribute
+            let parts;
+            if (attribute) {
+              parts = this._hass.formatEntityAttributeValueToParts(
+                stateObj,
+                attribute,
+              );
+            } else {
+              parts = this._hass.formatEntityStateToParts(
+                stateObj,
+              );
+            }
+            const unitPart = parts.find(part => part.type === 'unit');
+            unit = unitPart && unitPart.value;
+          } else {
+            // object attribute - considered as unitless
+            unit = '';
+          }
+        }
+        // preserve a computed unit
+        if (this.preserved_uom[index] === undefined) {
+          this.preserved_uom[index] = unit || '';
+        }
+        return (unit || '');
+      }
     }
   }
 
   /**
-  * Returns a string value for a state/attrubute:
+  * Returns a string value for a state/attrubute or a static_value:
   * localized, following locale settings,
-  * accounting possible individual accuracy settings & possible "decimals" options
+  * (for entities:) accounting possible individual accuracy settings & possible "decimals" options
   * @returns {string} value of a state/attribute
-  * @param {number|string} inState Value of a state/attribute ("unformatted")
-  * @param {number} index Index of an entity in config.entities
+  * @param {number|string} inState Value of a state/attribute ("unformatted") or a static_value
+  * @param {number} index Index of an entry in config.entities
   */
   computeState(inState, index) {
     if (this.config.state_map.length > 0) {
@@ -1056,8 +1114,8 @@ class MiniGraphCard extends LitElement {
 
     if (dec === undefined || Number.isNaN(Number(dec)) || Number.isNaN(Number(state))) {
       // no valid "decimals" settings defined, use a default accuracy
-      if (index >= 0) {
-        // formatting a state or attribute
+      if (index >= 0 && !this.isStaticValue(index)) {
+        // formatting a state or attribute of an entity
         const entityId = this.config.entities[index].entity;
         const { attribute } = this.config.entities[index];
         const stateObj = this._hass.states[entityId];
@@ -1088,7 +1146,7 @@ class MiniGraphCard extends LitElement {
           return value;
         }
       } else {
-        // formatting Y-axis (primary, secondary) labels
+        // formatting Y-axis (primary, secondary) labels or a static_value
         // use a default hard-coded accuracy
         return formatNumber(
           state,
@@ -1105,28 +1163,25 @@ class MiniGraphCard extends LitElement {
     );
   }
 
-  updateOnInterval() {
-    if (this.stateChanged && !this.updating) {
-      this.stateChanged = false;
-      this.updateData();
-    }
-  }
-
   /**
-  * Returns settings defining an order of a state/attrubute value presentation
+  * Returns settings defining an order of a state/attrubute value presentation;
+  * fallback to default settings in case of a static_value
   * @returns {Object}
   * directOrder - true: "value literal unit", false: "unit literal value";
   *
   * delimiter - an optional literal separator between value & unit
-  * @param index Index of an entity in config.entities
+  * @param index Index of an entry in config.entities
   * @param {number|string} inState Value of a state/attribute,
   * only used to process a preserved unit for a currently unavailable entity
   */
   computeStateOrder(index, inState = undefined) {
     const entityId = this.config.entities[index].entity;
     const { attribute } = this.config.entities[index];
-    if (!attribute || !this.isObjectAttr(attribute)) {
-      // processing any cases except an object attribute
+    if (!entityId && this.isStaticValue(index)) {
+      // processing static_value
+      return { directOrder: true, delimiter: '' };
+    } else if (!attribute || !this.isObjectAttr(attribute)) {
+      // processing entity, any cases except an object attribute
       const stateObj = this._hass.states[entityId];
       if (!stateObj || isUnavailableState(stateObj.state)) {
         // processing unavailable state
@@ -1175,20 +1230,20 @@ class MiniGraphCard extends LitElement {
         return { directOrder, delimiter };
       }
     } else {
-      // processing object attribute
+      // processing entity, object attribute
       return { directOrder: true, delimiter: ' ' };
     }
   }
 
   /**
-  * Returns a string state/attrubute value presentation
-  * @returns {string} State/attrubute value presentation
-  * @param {number|string} inState Value of a state/attribute
-  * @param {number} index Index of an entity in config.entities
+  * Returns a string state/attrubute value or static_value presentation
+  * @returns {string} State/attrubute value or static_value presentation
+  * @param {number|string} inState Value of a state/attribute/static_value
+  * @param {number} index Index of an entry in config.entities
   * @param {boolean} [hideUnit] Do not show a unit for a value
   */
   computeStateWithUom(inState, index, hideUnit) {
-    // get a state/attribute value
+    // get a state/attribute value or a static_value
     const state = this.computeState(inState, index);
 
     // get a unit
@@ -1218,6 +1273,13 @@ class MiniGraphCard extends LitElement {
     return composed;
   }
 
+  updateOnInterval() {
+    if (this.stateChanged && !this.updating) {
+      this.stateChanged = false;
+      this.updateData();
+    }
+  }
+
   async updateData({ config } = this) {
     this.updating = true;
 
@@ -1235,8 +1297,11 @@ class MiniGraphCard extends LitElement {
 
     if (config.show.graph) {
       this.entity.forEach((entity, i) => {
-        if (entity) this.Graph[i].update();
-        // ???? preset line
+        if (entity
+          || (!entity && this.isStaticValue(i))
+        ) {
+          this.Graph[i].update();
+        }
       });
     }
 
@@ -1245,8 +1310,9 @@ class MiniGraphCard extends LitElement {
     if (config.show.graph) {
       let graphPos = 0;
       this.entity.forEach((entity, i) => {
-        // ???? preset line
-        if (!entity || this.Graph[i].coords.length === 0) return;
+        if ((!entity && !this.isStaticValue(i))
+          || this.Graph[i].coords.length === 0)
+          return;
         this.Graph[i].logarithmic = this.computeUsesLogarithmic(i);
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
@@ -1353,10 +1419,20 @@ class MiniGraphCard extends LitElement {
   }
 
   async updateEntity(entity, index, initStart, end) {
-    if (!entity
-      || !this.updateQueue.includes(`${entity.entity_id}-${index}`)
+    if ((!entity && !this.isStaticValue(index))
+      || (!entity && this.isStaticValue(index) && !this.updateQueue.includes(`static_value-${index}`))
+      || (entity && !this.updateQueue.includes(`${entity.entity_id}-${index}`))
       || this.config.entities[index].show_graph === false
     ) return;
+
+    if (this.isStaticValue(index)) {
+      // process a fake static_value history
+      const staticValue = this.config.entities[index].static_value;
+      this.Graph[index].history = [{ state: staticValue }, { state: staticValue }];
+      this.updateQueue = this.updateQueue.filter(entry => entry !== `static_value-${index}`);
+      return;
+    }
+
     this.updateQueue = this.updateQueue.filter(entry => entry !== `${entity.entity_id}-${index}`);
 
     let stateHistory = [];
@@ -1411,9 +1487,7 @@ class MiniGraphCard extends LitElement {
       if (this.config.state_map.length > 0 || this.config.entities[index].attribute) {
         newStateHistory[0].forEach((item) => {
           if (this.config.entities[index].attribute) {
-            // eslint-disable-next-line no-param-reassign
             item.state = this.getObjectAttr(item.attributes, this.config.entities[index].attribute);
-            // eslint-disable-next-line no-param-reassign
             delete item.attributes;
           }
           if (this.config.state_map.length > 0)

--- a/src/main.js
+++ b/src/main.js
@@ -492,8 +492,8 @@ class MiniGraphCard extends LitElement {
   renderGraph() {
     const ready = ((this.entity[0] || this.isStaticValue(0))
       && !this.Graph.some(
-      (element, index) => element._history === undefined
-      && this.config.entities[index].show_graph !== false,
+        (element, index) => element._history === undefined
+        && this.config.entities[index].show_graph !== false,
     ))
     || this.config.show.loading_indicator === false;
     return this.config.show.graph ? html`

--- a/src/main.js
+++ b/src/main.js
@@ -196,7 +196,8 @@ class MiniGraphCard extends LitElement {
     if (entity) {
       // Turn off default smoothing for binary_sensor entities.
       // Can be also refactored for other non-numerical domains if needed.
-      // Smoothing should be manually turned on in config in case of addressing a numerical attribute.
+      // Smoothing should be manually turned on in config
+      // in case of addressing a numerical attribute.
       return !entity.startsWith('binary_sensor.');
     }
     // processing a possible `static_value` entry
@@ -445,7 +446,8 @@ class MiniGraphCard extends LitElement {
       // "tooltip" - a selected point/bar
       const { entity: tooltipEntityIndex, value: tooltipValue } = this.tooltip;
       const isTooltip = isPrimary && tooltipEntityIndex !== undefined;
-      // either a state/attr/static_value for a selected point/bar - or a "native" state/attr/static_value
+      // either a state/attr/static_value for a selected point/bar
+      // - or a "native" state/attr/static_value
       const value = isTooltip ? tooltipValue : state;
       const entityIndex = isTooltip ? tooltipEntityIndex : index;
       const entityConfig = this.config.entities[entityIndex];
@@ -871,7 +873,13 @@ class MiniGraphCard extends LitElement {
   handlePopup(e, entity) {
     if (entity) {
       e.stopPropagation();
-      handleClick(this, this._hass, this.config, this.config.tap_action, entity.entity_id || entity);
+      handleClick(
+        this,
+        this._hass,
+        this.config,
+        this.config.tap_action,
+        entity.entity_id || entity,
+      );
     }
   }
 
@@ -1487,7 +1495,9 @@ class MiniGraphCard extends LitElement {
       if (this.config.state_map.length > 0 || this.config.entities[index].attribute) {
         newStateHistory[0].forEach((item) => {
           if (this.config.entities[index].attribute) {
+            // eslint-disable-next-line no-param-reassign
             item.state = this.getObjectAttr(item.attributes, this.config.entities[index].attribute);
+            // eslint-disable-next-line no-param-reassign
             delete item.attributes;
           }
           if (this.config.state_map.length > 0)

--- a/src/main.js
+++ b/src/main.js
@@ -872,8 +872,8 @@ class MiniGraphCard extends LitElement {
   }
 
   handlePopup(e, entity) {
+    e.stopPropagation();
     if (entity) {
-      e.stopPropagation();
       handleClick(
         this,
         this._hass,

--- a/src/main.js
+++ b/src/main.js
@@ -297,12 +297,9 @@ class MiniGraphCard extends LitElement {
     return html`
       <hui-warning>
         <div>mini-graph-card</div>
-        ${this.config.entities.map(
-          (_, index) => (!this.entity[index] && !this.isStaticValue(index)
-            ? html`<div>
-                Entity not available: ${this.config.entities[index].entity}
-              </div>`
-            : html``))}
+        ${this.config.entities.map((_, index) => (!this.entity[index] && !this.isStaticValue(index)
+          ? html`<div>Entity not available: ${this.config.entities[index].entity}</div>`
+          : html``))}
       </hui-warning>
     `;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -880,7 +880,7 @@ class MiniGraphCard extends LitElement {
         this._hass,
         this.config,
         this.config.tap_action,
-        entity.entity_id || entity,
+        entity && entity.entity_id || entity,
       );
     }
   }


### PR DESCRIPTION
A static horizontal line is drawn for a user-defined static value.
Can be used in various applications like drawing a threshold line or a zeroth X-axis.

Also, might be a useful addition for http://github.com/kalkih/mini-graph-card/pull/1205.

Examples:

Threshold line:

<img width="485" height="257" alt="image" src="https://github.com/user-attachments/assets/f89da33d-8ef3-449d-b8f7-685f7448da6d" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
  - static_value: 50
    name: Threshold
    unit: "%"
    show_legend_state: true
    show_state: false
    show_points: false
    show_fill: false
    line_width: 1
    line_style: 4,7
    color: red
lower_bound: ~0
show:
  labels: true
```

Zeroth X-axis:

<img width="480" height="219" alt="image" src="https://github.com/user-attachments/assets/e7acd525-d65c-4b40-8d24-11a52be15fca" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.temperature
  - static_value: 0
    show_state: false
    show_points: false
    show_fill: false
    show_legend: false
    line_width: 1
    color: grey
show:
  labels: true
```

Possible future improvements:
1. Add a new per-entry option (can be called `show_static_value_inline` or simpler/clearer) to show a value of `static_value` close to a corresponding static_line.
Default – value not shown, `left` - shown on a left side, `right` - on a right side.
Valid for `static_value` entries only.
2. Add a new option (per-entry? card-wide?) to prevent:
-- hiding other graphs when a static line is selected (not sure if it is useful);
-- hiding static lines when a graph is selected (could be useful to see a selected point’s value along with static lines) (done in https://github.com/kalkih/mini-graph-card/pull/1381).