### PR TITLE
fix: incorrect formula in getFill()

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -192,7 +192,7 @@ export default class Graph {
     const height = this.height + this.margin[Y] * 4;
     let fill = path;
     // note that currently this.margin[X] = 0 when fill is defined
-    fill += ` L ${this.width - this.margin[X]}, ${height}`;
+    fill += ` L ${this.width + this.margin[X]}, ${height}`;
     fill += ` L ${this.coords[0][X]}, ${height} z`;
     return fill;
   }

--- a/src/graph.js
+++ b/src/graph.js
@@ -191,7 +191,8 @@ export default class Graph {
   getFill(path) {
     const height = this.height + this.margin[Y] * 4;
     let fill = path;
-    fill += ` L ${this.width - this.margin[X] * 2}, ${height}`;
+    // note that currently this.margin[X] = 0 when fill is defined
+    fill += ` L ${this.width - this.margin[X]}, ${height}`;
     fill += ` L ${this.coords[0][X]}, ${height} z`;
     return fill;
   }


### PR DESCRIPTION
In `getFill()`, a path for a fill is defined as
```
fill += ` L ${this.width - this.margin[X] * 2}, ${height}`;  
```
But it should be in fact
```
fill += ` L ${this.width + this.margin[X]}, ${height}`;  
```
<img width="1149" height="625" alt="изображение" src="https://github.com/user-attachments/assets/3d0145f8-6da6-4227-ba72-243816459d96" />

Note that in case of `fill: true` margin[X] is currently 0.
That is why that incorrectness is not visible.