### PR TITLE
fix: add isNumeric() helper function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,10 @@ import {
   ONE_HOUR,
   DEFAULT_MARGIN,
 } from './const';
-import { getFactor } from './others';
+import {
+  getFactor,
+  isNumeric,
+} from './others';
 import {
   getMin, getAvg, getMax,
   getMilli,
@@ -138,8 +141,7 @@ class MiniGraphCard extends LitElement {
       .filter(entityConfig => entityConfig.show_graph !== false)
       .map((entityConfig) => {
         const value = entityConfig.line_width;
-        return (typeof value === 'number'
-          && !Number.isNaN(value))
+        return isNumeric(value)
           ? value : this.config.line_width;
       });
     return ({
@@ -385,7 +387,7 @@ class MiniGraphCard extends LitElement {
    */
   isStaticValue(index) {
     const entity = this.config.entities[index];
-    return typeof entity.static_value === 'number' && !Number.isNaN(entity.static_value);
+    return isNumeric(entity.static_value);
   }
 
   /**

--- a/src/others.js
+++ b/src/others.js
@@ -66,7 +66,7 @@ const getFactor = (config, index = undefined) => {
   return 1;
 };
 
-const isNumeric = (value) => typeof value === 'number' && !Number.isNaN(value);
+const isNumeric = value => typeof value === 'number' && !Number.isNaN(value);
 
 export {
   getFactor,

--- a/src/others.js
+++ b/src/others.js
@@ -66,6 +66,9 @@ const getFactor = (config, index = undefined) => {
   return 1;
 };
 
+const isNumeric = (value) => typeof value === 'number' && !Number.isNaN(value);
+
 export {
   getFactor,
+  isNumeric,
 };


### PR DESCRIPTION
The added `isNumeric()` function checks if an option keeps a numeric value.