### PR TITLE
feat: Add disabling hiding of static lines when another line is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | show_fill | boolean |         | Set to false to hide the fill.
 | show_points | boolean |         | Set to false to hide the points (see a note below).
 | show_legend | boolean |         | Set to false to turn hide from the legend.
+| show_static_inactive | boolean |         | Set to true to disable hiding the line when a point of a line of another entity selected; meaningful for a [static line](#static-lines) only.
 | state_adaptive_color | boolean |         | Make the color of the state adapt to the entity/static value color.
 | y_axis | string |         | If 'secondary', displays using the secondary Y-axis on the right.
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
@@ -627,6 +628,33 @@ show:
   labels: true
 ```
 
+Example with a static line which is not hidden when a point of a line of another entity selected:
+
+<img width="481" height="353" alt="изображение" src="https://github.com/user-attachments/assets/bc11d3c1-c557-46e0-afe9-b7d2e17b35be" />
+
+```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.system_monitor_processor_use
+    line_width: 4
+  - static_value: 50
+    name: Threshold
+    unit: "%"
+    show_legend_state: true
+    show_state: false
+    show_points: false
+    line_width: 1
+    line_style: 4,7
+    color: red
+    show_static_inactive: true
+lower_bound: ~0
+points_per_hour: 60
+hours_to_show: 3
+height: 200
+show:
+  labels: true
+  fill: false
+```
 
 #### Grouping by date
 

--- a/src/main.js
+++ b/src/main.js
@@ -191,7 +191,7 @@ class MiniGraphCard extends LitElement {
   /**
    * Check if smoothing can be defaulted to `true` for an entity
    * @param {number} index Index of an entry in config.entities
-   * @returns True if smoothing is applicable for an entity, false - otherwise
+   * @returns {boolean} True if smoothing is applicable for an entity, false - otherwise
    */
   getDefaultSmoothing(index) {
     const { entity } = this.config.entities[index];
@@ -383,11 +383,21 @@ class MiniGraphCard extends LitElement {
   /**
    * Check if an entity config contains a valid `static_value` option
    * @param {number} index Index of an entry in config.entities
-   * @returns True if a valid `static_value` option defined, false - otherwise
+   * @returns {boolean} True if a valid `static_value` option defined, false - otherwise
    */
   isStaticValue(index) {
     const entity = this.config.entities[index];
     return isNumeric(entity.static_value);
+  }
+
+  /**
+  * Check if an entry represents a static_value with `show_static_inactive: true`
+  * @param {number} index Index of an entry in config.entities
+  * @returns {boolean} True if an entry represents a static value with `show_static_inactive: true`,
+  * false - otherwise
+  */
+  isShowStaticInactive(index) {
+    return this.isStaticValue(index) && this.config.entities[index].show_static_inactive;
   }
 
   /**
@@ -650,7 +660,7 @@ class MiniGraphCard extends LitElement {
     return svg`
       <g class='line--points'
         ?tooltip=${this.tooltip.entity === i}
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
         ?init=${this.length[i]}
         anim=${this.config.animate && this.config.show.points !== 'hover'}
         style="animation-delay: ${this.config.animate ? `${i * 0.5 + 0.5}s` : '0s'}"
@@ -685,7 +695,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, i);
     return svg`
       <rect class='line--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
         id=${`rect-${this.id}-${i}`}
         fill=${fill} height="100%" width="100%"
         mask=${`url(#line-${this.id}-${i})`}
@@ -702,7 +712,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, i);
     return svg`
       <rect class='fill--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
         id=${`fill-rect-${this.id}-${i}`}
         fill=${svgFill} height="100%" width="100%"
         mask=${`url(#fill-${this.id}-${i})`}


### PR DESCRIPTION
Consider a card with a few entities (for example, two entities) with linear graphs with shown points.
Currently, if a point of a line of entity_1 is selected, a whole line for entity_2 is hidden.
This may be not useful for static lines (when a `static_value` is defined).
This PR introduces a new option `show_static_inactive` (true/false).
The option is only accounted for static lines; if `true` - the static line is not hidden when a point of a line of another entity is selected:

<img width="481" height="353" alt="изображение" src="https://github.com/user-attachments/assets/b63c8696-3024-4e5a-9627-4fc0aa1738dd" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
    line_width: 4
  - static_value: 50
    name: Threshold
    unit: "%"
    show_legend_state: true
    show_state: false
    show_points: false
    line_width: 1
    line_style: 4,7
    color: red
    show_static_inactive: true
lower_bound: ~0
points_per_hour: 60
hours_to_show: 3
height: 200
show:
  labels: true
  fill: false
```