### PR TITLE
fix: Line color interpolation of stop values when there are values in a middle

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -19,7 +19,7 @@ import {
  * @returns {number}
  */
 const findFirstValuedIndex = (stops, startIndex) => {
-  for (let i = startIndex, l = stops.length; i < l; i += 1) {
+  for (let i = startIndex; i < stops.length; i += 1) {
     if (stops[i].value != null) {
       return i;
     }
@@ -66,10 +66,7 @@ const interpolateStops = (stops) => {
       return { ...stop };
     }
 
-    if (rightValuedIndex == null) {
-      rightValuedIndex = findFirstValuedIndex(stops, stopIndex);
-    } else if (stopIndex > rightValuedIndex) {
-      leftValuedIndex = rightValuedIndex;
+    if (rightValuedIndex == null || stopIndex > rightValuedIndex) {
       rightValuedIndex = findFirstValuedIndex(stops, stopIndex);
     }
 
@@ -83,7 +80,7 @@ const interpolateStops = (stops) => {
     const m = (rightValue - leftValue) / (rightValuedIndex - leftValuedIndex);
     return {
       color: typeof stop === 'string' ? stop : stop.color,
-      value: m * stopIndex + leftValue,
+      value: m * (stopIndex - leftValuedIndex) + leftValue,
     };
   });
 };
@@ -96,7 +93,7 @@ const computeThresholds = (stops, type) => {
     return valuedStops;
   } else {
     const rect = [].concat(...valuedStops.map((stop, i) => ([stop, {
-      value: stop.value - 0.0001,
+      value: stop.value * 0.9999,
       color: valuedStops[i + 1] ? valuedStops[i + 1].color : stop.color,
     }])));
     return rect;


### PR DESCRIPTION
Line color interpolation of stop values allows to NOT set values for all colors - absent values are interpolated.
Consider this example for `color_thresholds` - values are only defined in the beginning & in the end of an array (there is only ONE gap):
```
color_thresholds:
  - value: 0
    color: "#ff0000"
  - color: "#ffff00"
  - color: "#00ff00"
  - value: 4
    color: "#0000ff"
```
which is interpolated to
```
color_thresholds:
  - value: 0
    color: "#ff0000"
  - value: 1.333333
    color: "#ffff00"
  - value: 2.666667
    color: "#00ff00"
  - value: 4
    color: "#0000ff"
```
But another example - when values are defined somewhere in the middle (i.e. there are multiple gaps) - will not work:
```
color_thresholds:
  - value: 0
    color: "#ff0000"
  - color: "#ffff00"
  - color: "#f0ff00"
    value: 2
  - color: "#00ff00"
  - color: "#00ff0f"
  - value: 4
    color: "#0000ff"
```

For instance, a card with these `color_thresholds`:
```
    color_thresholds:
      - color: red
        value: 1
      - color: orange
      - color: yellow
        value: 4
      - color: green
      - color: lightblue
      - color: blue
        value: 10
      - color: violet
      - color: brown
        value: 12
```
is interpreted as
<img width="899" height="343" alt="изображение" src="https://github.com/user-attachments/assets/a2a3b891-4348-4c6e-a195-24653a832d97" />

This PR fixes it.
After the fix:
<img width="894" height="333" alt="изображение" src="https://github.com/user-attachments/assets/a4523f06-d241-4cee-a236-445055914c14" />




Additional fix: in `computeThresholds()`, there could be an error in case of small values of an entity state/attribute.