### PR TITLE
fix: computeColor() for color_thresholds

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -86,7 +86,8 @@ const interpolateStops = (stops) => {
 };
 
 /**
- * Process color_thresholds array: first reverse it, then either return it "as is" (if type = smooth)
+ * Process color_thresholds array: first reverse it,
+ * then either return it "as is" (if type = smooth)
  * or augment it with additional stops to prevent an unneeded color transition (if type = hard)
  * @param {Array<{ color: string, value: number }>} stops Initial color_thresholds array
  * @param {string} type Type of color thresholds transition

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -85,6 +85,13 @@ const interpolateStops = (stops) => {
   });
 };
 
+/**
+ * Process color_thresholds array: first reverse it, then either return it "as is" (if type = smooth)
+ * or augment it with additional stops to prevent an unneeded color transition (if type = hard)
+ * @param {Array<{ color: string, value: number }>} stops Initial color_thresholds array
+ * @param {string} type Type of color thresholds transition
+ * @returns {Array<{ color: string, value: number }>} Processed color_thresholds array
+ */
 const computeThresholds = (stops, type) => {
   const valuedStops = interpolateStops(stops);
   valuedStops.sort((a, b) => b.value - a.value);

--- a/src/main.js
+++ b/src/main.js
@@ -949,10 +949,10 @@ class MiniGraphCard extends LitElement {
 
     let intColor;
     if (color_thresholds.length > 0) {
-      const { color } = color_thresholds.find(ele => ele.value < state)
-        || color_thresholds.slice(-1)[0];
+      const { color } = color_thresholds.find(ele => ele.value <= state)
+        || color_thresholds.at(-1);
       intColor = color;
-      const indexThreshold = color_thresholds.findIndex(ele => ele.value < state);
+      const indexThreshold = color_thresholds.findIndex(ele => ele.value <= state);
       const c1 = color_thresholds[indexThreshold];
       const c2 = color_thresholds[indexThreshold - 1];
       if (c2) {


### PR DESCRIPTION
Currently, in `computeColor()` when calculating a nearest stop point, a "state = stop point" case was not accounted.
As a result, a previous stop point (and thus a wrong color) was selected with a 0 value of a `factor` variable; although then this 0 value was accounted in `interpolateRgb()` and a valid color was selected anyway. But this imperfection should not be here anyway.

Additionally - add a description for `computeThresholds()`.