### PR TITLE
fix: Blank before a percent

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -3,6 +3,7 @@ const FONT_SIZE = 14;
 const FONT_SIZE_HEADER = 14;
 const MAX_BARS = 96;
 const DEFAULT_MARGIN = 5;
+const NBSP = '\u00A0';
 const ICONS = {
   humidity: 'hass:water-percent',
   illuminance: 'hass:brightness-5',
@@ -57,6 +58,7 @@ export {
   FONT_SIZE_HEADER,
   MAX_BARS,
   DEFAULT_MARGIN,
+  NBSP,
   ICONS,
   DEFAULT_COLORS,
   UPDATE_PROPS,

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,4 +1,5 @@
 import { log } from './utils';
+import { NBSP } from './const';
 
 /**
  * HA Frontend time format settings
@@ -631,7 +632,7 @@ const blankBeforePercent = (localeOptions) => {
     }).formatToParts(1);
 
     const hasSpace = parts.some(part => part.type === 'literal' && /\s/.test(part.value));
-    const result = hasSpace ? '\u00A0' : '';
+    const result = hasSpace ? NBSP : '';
 
     blankPercentCache.set(language, result);
     return result;

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import {
   X, Y, V,
   ONE_HOUR,
   DEFAULT_MARGIN,
+  NBSP,
 } from './const';
 import {
   getFactor,
@@ -1224,7 +1225,7 @@ class MiniGraphCard extends LitElement {
               || stateObj.attributes.unit_of_measurement;
             const delimiter = unit
               ? unit === '%' && blankBeforePercent(this._hass.locale) === ''
-                ? '' : ' '
+                ? '' : NBSP
               : '';
             return {
               directOrder: true,
@@ -1286,7 +1287,7 @@ class MiniGraphCard extends LitElement {
       && !nativeDelimiter
       && (this.config.unit || this.config.entities[index].unit)
       && (unit !== '%'
-        || blankBeforePercent(this._hass.locale) === ' ')) {
+        || blankBeforePercent(this._hass.locale) === NBSP)) {
       // add a delimiter for a user-defined unit (except for "%" for some locales)
       delimiter = ' ';
     } else {

--- a/src/main.js
+++ b/src/main.js
@@ -1259,7 +1259,7 @@ class MiniGraphCard extends LitElement {
       }
     } else {
       // processing entity, object attribute
-      return { directOrder: true, delimiter: ' ' };
+      return { directOrder: true, delimiter: NBSP };
     }
   }
 
@@ -1289,7 +1289,7 @@ class MiniGraphCard extends LitElement {
       && (unit !== '%'
         || blankBeforePercent(this._hass.locale) === NBSP)) {
       // add a delimiter for a user-defined unit (except for "%" for some locales)
-      delimiter = ' ';
+      delimiter = NBSP;
     } else {
       delimiter = nativeDelimiter;
     }


### PR DESCRIPTION
following https://github.com/kalkih/mini-graph-card/pull/1386:
although in `blankBeforePercent()` a no-break-space (nbsp) is used, in `computeStateOrder()` & `computeStateWithUom()` an ordinary whitespace is still used by a mistake.