### PR TITLE
feat: Static value label

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -7,6 +7,7 @@ import {
   MAX_BARS,
   DEFAULT_COLORS,
   DEFAULT_SHOW,
+  DEFAULT_GRAPH_HEIGHT,
   DEFAULT_MARGIN,
 } from './const';
 
@@ -120,7 +121,7 @@ export default (config) => {
     animate: false,
     font_size: FONT_SIZE,
     font_size_header: FONT_SIZE_HEADER,
-    height: 100,
+    height: DEFAULT_GRAPH_HEIGHT,
     hours_to_show: 24,
     points_per_hour: 0.5,
     aggregate_func: 'avg',

--- a/src/const.js
+++ b/src/const.js
@@ -2,7 +2,9 @@ const URL_DOCS = 'https://github.com/kalkih/mini-graph-card/blob/master/README.m
 const FONT_SIZE = 14;
 const FONT_SIZE_HEADER = 14;
 const MAX_BARS = 96;
+const DEFAULT_GRAPH_HEIGHT = 100;
 const DEFAULT_MARGIN = 5;
+const DEFAULT_STATIC_VALUE_LABEL_OFFSET = 20; // in %
 const ICONS = {
   humidity: 'hass:water-percent',
   illuminance: 'hass:brightness-5',
@@ -56,7 +58,9 @@ export {
   FONT_SIZE,
   FONT_SIZE_HEADER,
   MAX_BARS,
+  DEFAULT_GRAPH_HEIGHT,
   DEFAULT_MARGIN,
+  DEFAULT_STATIC_VALUE_LABEL_OFFSET,
   ICONS,
   DEFAULT_COLORS,
   UPDATE_PROPS,

--- a/src/main.js
+++ b/src/main.js
@@ -638,7 +638,7 @@ class MiniGraphCard extends LitElement {
       >
         ${this.config.entities.map((_, index) => {
           if (!this.isStaticValue(index)
-              || this.config.entities[index].show_static_value_label === false) {
+            || this.config.entities[index].show_static_value_label === false) {
             return;
           }
           const staticValue = this.config.entities[index].static_value;

--- a/src/main.js
+++ b/src/main.js
@@ -632,7 +632,10 @@ class MiniGraphCard extends LitElement {
     const isLeft = this.config.show.static_value_labels === 'left';
 
     return html`
-      <div class="graph__static_value_labels" loc="${this.config.show.static_value_labels}">
+      <div
+        class="graph__static_value_labels"
+        loc="${this.config.show.static_value_labels}"
+      >
         ${this.config.entities.map((_, index) => {
           if (!this.isStaticValue(index)
               || this.config.entities[index].show_static_value_label === false) {

--- a/src/main.js
+++ b/src/main.js
@@ -525,6 +525,7 @@ class MiniGraphCard extends LitElement {
       ))
     || this.config.show.loading_indicator === false;
 
+    /* eslint-disable indent */
     return this.config.show.graph
       ? html`
           <div class="graph">
@@ -543,6 +544,7 @@ class MiniGraphCard extends LitElement {
               : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`}
           </div>`
       : html``;
+    /* eslint-enable indent */
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -631,6 +631,7 @@ class MiniGraphCard extends LitElement {
 
     const isLeft = this.config.show.static_value_labels === 'left';
 
+    /* eslint-disable indent */
     return html`
       <div
         class="graph__static_value_labels"
@@ -672,6 +673,7 @@ class MiniGraphCard extends LitElement {
         })}
       </div>
     `;
+    /* eslint-enable indent */
   }
 
   renderSvgFill(fill, i) {

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,9 @@ import {
   UPDATE_PROPS,
   X, Y, V,
   ONE_HOUR,
+  DEFAULT_GRAPH_HEIGHT,
   DEFAULT_MARGIN,
+  DEFAULT_STATIC_VALUE_LABEL_OFFSET,
 } from './const';
 import {
   getFactor,
@@ -62,6 +64,7 @@ class MiniGraphCard extends LitElement {
     this.stateChanged = false;
     this.initial = true;
     this._md5Config = undefined;
+    this.staticValueLabelOffset = undefined; // offset (x) for labels for static lines
 
     // update datetime settings periodically
     this.updateHour24 = true;
@@ -154,6 +157,9 @@ class MiniGraphCard extends LitElement {
     this.config = buildConfig(config);
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
+
+    // set offset (x) for labels for static lines
+    this.prepareStaticValueLabelOffset();
 
     // update datetime settings periodically
     this.updateHour24 = config.hour24 === undefined;
@@ -256,6 +262,8 @@ class MiniGraphCard extends LitElement {
   }
 
   updated(changedProperties) {
+    super.updated(changedProperties);
+
     if (this.config.animate && changedProperties.has('line')) {
       if (this.length.length < this.entity.length) {
         this.shadowRoot.querySelectorAll('svg path.line').forEach((ele) => {
@@ -502,26 +510,38 @@ class MiniGraphCard extends LitElement {
     `;
   }
 
+  /**
+  * Renders a Graph element (along with a legend)
+  * @returns {TemplateResult} Lit template result
+  */
   renderGraph() {
-    const ready = ((this.entity[0] || this.isStaticValue(0))
+    const hasInitialData = this.entity
+      && (this.entity[0] || this.isStaticValue(0));
+    const ready = (hasInitialData
       && !this.Graph.some(
         (element, index) => element._history === undefined
           && this.config.entities[index].show_graph !== false,
       ))
     || this.config.show.loading_indicator === false;
-    return this.config.show.graph ? html`
-      <div class="graph">
-        ${ready ? html`
-            <div class="graph__container">
-              ${this.renderLabels()}
-              ${this.renderLabelsSecondary()}
-              <div class="graph__container__svg">
-                ${this.renderSvg()}
-              </div>
-            </div>
-            ${this.renderLegend()}
-        ` : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`}
-      </div>` : '';
+
+    return this.config.show.graph
+      ? html`
+          <div class="graph">
+            ${ready
+              ? html`
+                  <div class="graph__container">
+                    ${this.renderLabels()}
+                    ${this.renderLabelsSecondary()}
+                    <div class="graph__container__svg">
+                      ${this.renderSvg()}
+                      ${this.renderStaticLabels()}
+                    </div>
+                  </div>
+                  ${this.renderLegend()}
+                `
+              : html`<ha-spinner aria-label="Loading" size="small"></ha-spinner>`}
+          </div>`
+      : html``;
   }
 
   /**
@@ -578,6 +598,76 @@ class MiniGraphCard extends LitElement {
       <svg width='10' height='10'>
         <rect width='10' height='10' fill=${this.computeColor(state, index)} />
       </svg>
+    `;
+  }
+
+  prepareStaticValueLabelOffset() {
+    const { static_value_label_offset: offset } = this.config;
+    this.staticValueLabelOffset = DEFAULT_STATIC_VALUE_LABEL_OFFSET;
+
+    if (offset === undefined || offset === null) return;
+    if (isNumeric(offset)) {
+      this.staticValueLabelOffset = Number(offset);
+    } else {
+      log('value of static_value_label_offset is incorrect, a default value is used');
+    }
+  }
+
+  /**
+  * Renders static lines' labels
+  * @returns {TemplateResult} Lit template result
+  */
+  renderStaticLabels() {
+    if (!this.config.show.static_value_labels) {
+      return html``;
+    }
+
+    const graphHeight = this.config.height !== undefined
+      ? this.config.height : DEFAULT_GRAPH_HEIGHT;
+    if (!isNumeric(graphHeight) || graphHeight <= 0) {
+      return html``;
+    }
+
+    const isLeft = this.config.show.static_value_labels === 'left';
+
+    return html`
+      <div class="graph__static_value_labels" loc="${this.config.show.static_value_labels}">
+        ${this.config.entities.map((_, index) => {
+          if (!this.isStaticValue(index) || this.config.entities[index].show_static_value_label === false) {
+            return;
+          }
+          const staticValue = this.config.entities[index].static_value;
+          // get Y coord in SVG space
+          const [staticLineCoord] = this.Graph[index]._calcY([[0, 0, staticValue]]);
+          const [, topSVG] = staticLineCoord; // top in SVG coords
+
+          const topPercent = (topSVG / graphHeight) * 100; // top in %
+          if (!isNumeric(topPercent)) {
+            return;
+          }
+
+          const offset = this.staticValueLabelOffset; // offset in %
+
+          const color = this.config.entities[index].state_adaptive_color
+            ? this.computeColor(staticValue, index)
+            : 'var(--primary-text-color)';
+
+          return html`
+            <span
+              id="static-label-${index}"
+              ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
+                && !this.isShowStaticInactive(index)}
+              style="
+                color: ${color};
+                top: ${topPercent}%;
+                left: ${isLeft ? `${offset}%` : `calc(100% - ${offset}%)`};
+              "
+            >
+              ${this.computeState(staticValue, index)}
+            </span>
+          `;
+        })}
+      </div>
     `;
   }
 
@@ -768,7 +858,7 @@ class MiniGraphCard extends LitElement {
   }
 
   /** Returns all rendered SVG parts (fill, line, bars, points)
-  * @returns {any} SVG
+  * @returns {any} SVG element
   */
   renderSvg() {
     const { height, show } = this.config;

--- a/src/main.js
+++ b/src/main.js
@@ -634,7 +634,8 @@ class MiniGraphCard extends LitElement {
     return html`
       <div class="graph__static_value_labels" loc="${this.config.show.static_value_labels}">
         ${this.config.entities.map((_, index) => {
-          if (!this.isStaticValue(index) || this.config.entities[index].show_static_value_label === false) {
+          if (!this.isStaticValue(index)
+              || this.config.entities[index].show_static_value_label === false) {
             return;
           }
           const staticValue = this.config.entities[index].static_value;
@@ -653,20 +654,18 @@ class MiniGraphCard extends LitElement {
             ? this.computeColor(staticValue, index)
             : 'var(--primary-text-color)';
 
-          return html`
-            <span
-              id="static-label-${index}"
-              ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
-                && !this.isShowStaticInactive(index)}
-              style="
-                color: ${color};
-                top: ${topPercent}%;
-                left: ${isLeft ? `${offset}%` : `calc(100% - ${offset}%)`};
-              "
-            >
-              ${this.computeState(staticValue, index)}
-            </span>
-          `;
+          return html`<span
+            id="static-label-${index}"
+            ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
+              && !this.isShowStaticInactive(index)}
+            style="
+              color: ${color};
+              top: ${topPercent}%;
+              left: ${isLeft ? `${offset}%` : `calc(100% - ${offset}%)`};
+            "
+          >
+            ${this.computeState(staticValue, index)}
+          </span>`;
         })}
       </div>
     `;

--- a/src/others.js
+++ b/src/others.js
@@ -7,7 +7,7 @@
 
 import { log } from './utils';
 
-const isNumeric = value => typeof value === 'number' && !Number.isNaN(value);
+const isNumeric = value => typeof value === 'number' && Number.isFinite(value);
 
 /**
   * Return a multiplying factor (exponental or scale) based on a "value_factor" option

--- a/src/style.js
+++ b/src/style.js
@@ -23,11 +23,7 @@ const style = css`
     order: 10;
   }
   ha-card[points] .line--points,
-  ha-card[labels] .graph__labels.--primary {
-    opacity: 0;
-    transition: opacity .25s;
-    animation: none;
-  }
+  ha-card[labels] .graph__labels.--primary,
   ha-card[labels-secondary] .graph__labels.--secondary {
     opacity: 0;
     transition: opacity .25s;
@@ -245,13 +241,19 @@ const style = css`
     width: 100%;
   }
   .graph__container {
-    display: flex;
-    flex-direction: row;
-    position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+    align-items: stretch;
   }
   .graph__container__svg {
     cursor: default;
-    flex: 1;
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+    grid-column: 1;
+    grid-row: 1;
   }
   svg {
     overflow: hidden;
@@ -278,7 +280,8 @@ const style = css`
     animation: none !important;
     transition: all .15s !important;
   }
-  .line--points[tooltip] .line--point[inactive] {
+  .line--points[tooltip] .line--point[inactive],
+  .graph__static_value_labels > span[inactive] {
     opacity: 0;
   }
   .line--point {
@@ -319,30 +322,47 @@ const style = css`
   .line[anim="true"][init] {
     animation: dash 1s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;
   }
-  .graph__labels.--secondary {
-    right: 0;
-    margin-right: 0px;
-    align-items: flex-end;
-  }
   .graph__labels {
-    align-items: flex-start;
+    display: flex;
     flex-direction: column;
-    font-size: calc(.15em + 8.5px);
-    font-weight: 400;
     justify-content: space-between;
-    margin-right: 10px;
+    align-items: flex-start;
+    font-size: calc(.15em + 8.5px);
     padding: .6em;
-    position: absolute;
     pointer-events: none;
-    top: 0; bottom: 0;
     opacity: .75;
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .graph__labels.--secondary {
+    align-items: flex-end;
+    grid-column: 1;
+    grid-row: 1;
   }
   .graph__labels > span {
     cursor: pointer;
+  }
+  .graph__static_value_labels {
+    font-size: calc(.15em + 8.5px);
+    position: absolute;
+    pointer-events: none;
+    top: 0; bottom: 0;
+    left: 0; right: 0;
+  }
+  .graph__labels > span,
+  .graph__static_value_labels > span {
     background: var(--primary-background-color, white);
     border-radius: 1em;
     padding: .2em .6em;
     box-shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.24);
+    white-space: nowrap;
+    font-weight: 400;
+    user-select: none;
+  }
+  .graph__static_value_labels > span {
+    opacity: 0.75;
+    position: absolute;
+    transform: translate(-50%, -50%);
   }
   .graph__legend {
     display: flex;


### PR DESCRIPTION
Display a value for a static line.

By default, a value is shown on a left side with a 20% horizontal offset - see example on the left.
Example on the right - a label shown on a right side with a customized 5% offset:

<img width="1004" height="321" alt="image" src="https://github.com/user-attachments/assets/67d87c66-fe59-4d23-a0da-8e1d29ffb856" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
  - static_value: 50
    unit: "%"
    show_fill: false
    show_points: false
    color: red
    line_width: 1
    state_adaptive_color: true
hours_to_show: 6
points_per_hour: 12
height: 200
show:
  icon: false
  legend: false
  state: true
  static_value_labels: left
```
```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
  - static_value: 50
    unit: "%"
    show_fill: false
    show_points: false
    color: red
    line_width: 1
    state_adaptive_color: true
hours_to_show: 6
points_per_hour: 12
height: 200
static_value_label_offset: 5
show:
  icon: false
  legend: false
  state: true
  static_value_labels: right
```

Example for a language (German) where a whitespace is put before a "%" sign:

<img width="1005" height="318" alt="image" src="https://github.com/user-attachments/assets/8a92e51b-369b-4d78-8046-6bc31747b88f" />


Update: https://github.com/kalkih/mini-graph-card/pull/1394