### PR TITLE
fix: Labels order

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -532,12 +532,12 @@ class MiniGraphCard extends LitElement {
             ${ready
               ? html`
                   <div class="graph__container">
-                    ${this.renderLabels()}
-                    ${this.renderLabelsSecondary()}
                     <div class="graph__container__svg">
                       ${this.renderSvg()}
                       ${this.renderStaticLabels()}
                     </div>
+                    ${this.renderLabels()}
+                    ${this.renderLabelsSecondary()}
                   </div>
                   ${this.renderLegend()}
                 `

--- a/src/style.js
+++ b/src/style.js
@@ -333,6 +333,7 @@ const style = css`
     opacity: .75;
     grid-column: 1;
     grid-row: 1;
+    position: relative;
   }
   .graph__labels.--secondary {
     align-items: flex-end;


### PR DESCRIPTION
https://github.com/kalkih/mini-graph-card/pull/1391 brought a glitch:
y-axis labels are shown below a graph:
<img width="117" height="209" alt="image" src="https://github.com/user-attachments/assets/889b0eb2-9159-4e22-a9ae-0f7b13a32157" />

After the fix:
<img width="65" height="216" alt="image" src="https://github.com/user-attachments/assets/7d936522-05bd-49c9-a3ed-ecc874c4286d" />
