### PR TITLE
fix: Static value label with unit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -670,7 +670,7 @@ class MiniGraphCard extends LitElement {
               left: ${isLeft ? `${offset}%` : `calc(100% - ${offset}%)`};
             "
           >
-            ${this.computeState(staticValue, index)}
+            ${this.computeStateWithUnit(staticValue, index)}
           </span>`;
         })}
       </div>


### PR DESCRIPTION
Fix for https://github.com/kalkih/mini-graph-card/pull/1391:
Somehow (I forgot or messed up) a minor (but important) change did not make it to PR, although that change was accounted locally in my dev setup (from where I took screenshots).
In the code from https://github.com/kalkih/mini-graph-card/pull/1391, UoM was not displayed in a static value label.
Fixed.