### PR TITLE
fix: typo in renderStaticLabels

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -670,7 +670,7 @@ class MiniGraphCard extends LitElement {
               left: ${isLeft ? `${offset}%` : `calc(100% - ${offset}%)`};
             "
           >
-            ${this.computeStateWithUnit(staticValue, index)}
+            ${this.computeStateWithUom(staticValue, index)}
           </span>`;
         })}
       </div>


### PR DESCRIPTION
Fixed a typo from https://github.com/kalkih/mini-graph-card/pull/1394 (((