### PR TITLE
feat: Hide inactive bars

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -798,6 +798,12 @@ class MiniGraphCard extends LitElement {
       />`;
   }
 
+  /**
+  * Renders bars for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param bars Array of bars for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgFillRect(fill, i) {
     if (!fill) return;
     const state = this.entity[i] !== undefined
@@ -833,7 +839,13 @@ class MiniGraphCard extends LitElement {
           ${animation}
         </rect>`;
     });
-    return svg`<g class='bars' ?anim=${this.config.animate}>${items}</g>`;
+    return svg`
+      <g
+        class='bars'
+        ?anim=${this.config.animate}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
+          && !this.isShowStaticInactive(index)}
+      >${items}</g>`;
   }
 
   /** Returns a rendered SVG part (fill, line, bars, points)

--- a/src/style.js
+++ b/src/style.js
@@ -275,7 +275,8 @@ const style = css`
   }
   .line--points[inactive],
   .line--rect[inactive],
-  .fill--rect[inactive] {
+  .fill--rect[inactive],
+  .bars[inactive] {
     opacity: 0 !important;
     animation: none !important;
     transition: all .15s !important;


### PR DESCRIPTION
When a legend entry is selected for some entity, all graphs for other entities are hidden (become "inactive"):

<img width="448" height="324" alt="b-1" src="https://github.com/user-attachments/assets/c547f9c0-47d4-44ce-b395-2996e1dede1d" />

This does not happen for bars - bars for all entities stay displayed:

<img width="448" height="324" alt="b0" src="https://github.com/user-attachments/assets/faaba5c5-7e70-4a62-bc59-61c737fb5c2e" />

This PR makes other entities' bars hidden:

<img width="448" height="324" alt="bars2" src="https://github.com/user-attachments/assets/2d613acd-d77e-40b6-8ed9-4edc1f47003c" />

Especially useful for "overlapping bars" graphs (proposed in https://github.com/kalkih/mini-graph-card/pull/1376):

<img width="448" height="324" alt="bar3" src="https://github.com/user-attachments/assets/5fea3e8a-211c-4afe-8dd5-7728a455650e" />

