### PR TITLE
fix: Add cached arrays

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1014,29 +1014,33 @@ class MiniGraphCard extends LitElement {
 
   get visibleEntities() {
     if (!this._visibleEntitiesCache) {
-      this._visibleEntitiesCache = this.config.entities.filter(entity => entity.show_graph !== false);
+      this._visibleEntitiesCache =
+        this.config.entities.filter(entity => entity.show_graph !== false);
     }
     return this._visibleEntitiesCache;
   }
 
   get primaryYaxisEntities() {
     if (!this._primaryYaxisEntitiesCache) {
-      this._primaryYaxisEntitiesCache = this.visibleEntities.filter(entity => entity.y_axis === undefined
-        || entity.y_axis === 'primary');
+      this._primaryYaxisEntitiesCache =
+        this.visibleEntities.filter(entity => entity.y_axis === undefined
+          || entity.y_axis === 'primary');
     }
     return this._primaryYaxisEntitiesCache;
   }
 
   get secondaryYaxisEntities() {
     if (!this._secondaryYaxisEntitiesCache) {
-      this._secondaryYaxisEntitiesCache = this.visibleEntities.filter(entity => entity.y_axis === 'secondary');
+      this._secondaryYaxisEntitiesCache =
+        this.visibleEntities.filter(entity => entity.y_axis === 'secondary');
     }
     return this._secondaryYaxisEntitiesCache;
   }
 
   get visibleLegends() {
     if (!this._visibleLegendsCache) {
-      this._visibleLegendsCache = this.visibleEntities.filter(entity => entity.show_legend !== false);
+      this._visibleLegendsCache =
+        this.visibleEntities.filter(entity => entity.show_legend !== false);
     }
     return this._visibleLegendsCache;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1014,33 +1014,32 @@ class MiniGraphCard extends LitElement {
 
   get visibleEntities() {
     if (!this._visibleEntitiesCache) {
-      this._visibleEntitiesCache =
-        this.config.entities.filter(entity => entity.show_graph !== false);
+      this._visibleEntitiesCache = this.config.entities
+        .filter(entity => entity.show_graph !== false);
     }
     return this._visibleEntitiesCache;
   }
 
   get primaryYaxisEntities() {
     if (!this._primaryYaxisEntitiesCache) {
-      this._primaryYaxisEntitiesCache =
-        this.visibleEntities.filter(entity => entity.y_axis === undefined
-          || entity.y_axis === 'primary');
+      this._primaryYaxisEntitiesCache = this.visibleEntities
+        .filter(entity => entity.y_axis === undefined || entity.y_axis === 'primary');
     }
     return this._primaryYaxisEntitiesCache;
   }
 
   get secondaryYaxisEntities() {
     if (!this._secondaryYaxisEntitiesCache) {
-      this._secondaryYaxisEntitiesCache =
-        this.visibleEntities.filter(entity => entity.y_axis === 'secondary');
+      this._secondaryYaxisEntitiesCache = this.visibleEntities
+        .filter(entity => entity.y_axis === 'secondary');
     }
     return this._secondaryYaxisEntitiesCache;
   }
 
   get visibleLegends() {
     if (!this._visibleLegendsCache) {
-      this._visibleLegendsCache =
-        this.visibleEntities.filter(entity => entity.show_legend !== false);
+      this._visibleLegendsCache = this.visibleEntities
+        .filter(entity => entity.show_legend !== false);
     }
     return this._visibleLegendsCache;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,6 @@ class MiniGraphCard extends LitElement {
 
     // initailize memoized arrays
     this._visibleEntitiesCache = null;
-    this._visibleBarEntitiesCache = null;
     this._primaryYaxisEntitiesCache = null;
     this._secondaryYaxisEntitiesCache = null;
     this._visibleLegendsCache = null;
@@ -1018,15 +1017,6 @@ class MiniGraphCard extends LitElement {
       this._visibleEntitiesCache = this.config.entities.filter(entity => entity.show_graph !== false);
     }
     return this._visibleEntitiesCache;
-  }
-
-  get visibleBarEntities() {
-    if (!this._visibleBarEntitiesCache) {
-      this._visibleBarEntitiesCache = this.config.show.graph === 'bar'
-        ? this.visibleEntities
-        : this.visibleEntities.filter(entity => entity.graph === 'bar');
-    }
-    return this._visibleBarEntitiesCache;
   }
 
   get primaryYaxisEntities() {

--- a/src/main.js
+++ b/src/main.js
@@ -85,6 +85,14 @@ class MiniGraphCard extends LitElement {
     this._hass = hass;
     let updated = false;
     const queue = [];
+
+    // initailize memoized arrays
+    this._visibleEntitiesCache = null;
+    this._visibleBarEntitiesCache = null;
+    this._primaryYaxisEntitiesCache = null;
+    this._secondaryYaxisEntitiesCache = null;
+    this._visibleLegendsCache = null;
+
     this.config.entities.forEach((entity, index) => {
       this.config.entities[index].index = index; // Required for filtered views
       // entityState stands for "stateObj"
@@ -1006,20 +1014,41 @@ class MiniGraphCard extends LitElement {
   }
 
   get visibleEntities() {
-    return this.config.entities.filter(entity => entity.show_graph !== false);
+    if (!this._visibleEntitiesCache) {
+      this._visibleEntitiesCache = this.config.entities.filter(entity => entity.show_graph !== false);
+    }
+    return this._visibleEntitiesCache;
+  }
+
+  get visibleBarEntities() {
+    if (!this._visibleBarEntitiesCache) {
+      this._visibleBarEntitiesCache = this.config.show.graph === 'bar'
+        ? this.visibleEntities
+        : this.visibleEntities.filter(entity => entity.graph === 'bar');
+    }
+    return this._visibleBarEntitiesCache;
   }
 
   get primaryYaxisEntities() {
-    return this.visibleEntities.filter(entity => entity.y_axis === undefined
-      || entity.y_axis === 'primary');
+    if (!this._primaryYaxisEntitiesCache) {
+      this._primaryYaxisEntitiesCache = this.visibleEntities.filter(entity => entity.y_axis === undefined
+        || entity.y_axis === 'primary');
+    }
+    return this._primaryYaxisEntitiesCache;
   }
 
   get secondaryYaxisEntities() {
-    return this.visibleEntities.filter(entity => entity.y_axis === 'secondary');
+    if (!this._secondaryYaxisEntitiesCache) {
+      this._secondaryYaxisEntitiesCache = this.visibleEntities.filter(entity => entity.y_axis === 'secondary');
+    }
+    return this._secondaryYaxisEntitiesCache;
   }
 
   get visibleLegends() {
-    return this.visibleEntities.filter(entity => entity.show_legend !== false);
+    if (!this._visibleLegendsCache) {
+      this._visibleLegendsCache = this.visibleEntities.filter(entity => entity.show_legend !== false);
+    }
+    return this._visibleLegendsCache;
   }
 
   get primaryYaxisSeries() {


### PR DESCRIPTION
This PR is for improving a performance.

These properties are recalculated on every call:
```
visibleEntities
primaryYaxisEntities
secondaryYaxisEntities
visibleLegends
primaryYaxisSeries
secondaryYaxisSeries
```
To calculate `visibleEntities`, a `filter()` function is called.
To calculate every other property, a `filter()` function is called 2 times.

In this PR, cached values are used for these properties:
```
visibleEntities
primaryYaxisEntities
secondaryYaxisEntities
visibleLegends
```
For other 2 properties we probably cannot use cached values since we use data from `Graph[i]` object.

Update 24.07.26: there are related fixes in https://github.com/kalkih/mini-graph-card/pull/1407 & https://github.com/kalkih/mini-graph-card/pull/1408.