### PR TITLE
fix: Datetime functions fixes & optimizations (#2)

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -170,10 +170,6 @@ export default (config) => {
     conf.color_thresholds_transition,
   );
 
-  // parse a possibly defined "datetime_format" option;
-  // fallback to "day_weekday" if undefined
-  conf.datetimeFormatParsed = parseDateTimeFormat(conf.datetime_format);
-
   // override points per hour to mach group_by function
   switch (conf.group_by) {
     case 'date':

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -1,4 +1,3 @@
-import { parseDateTimeFormat } from './locale';
 import { log } from './utils';
 import {
   URL_DOCS,

--- a/src/locale.js
+++ b/src/locale.js
@@ -129,11 +129,11 @@ const resolveTimeZone = (option, serverTimeZone) => {
 /**
  * Get date formatting options
  * @param {object} config Card config
- * @param {object} datetimeFormatParsed Parsed datetime format
+ * @param {object} datetimeFormatFromCfgParsed Parsed datetime format taken from config
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {Intl.DateTimeFormatOptions} Date format
  */
-const getDateFormat = (config, datetimeFormatParsed, hass) => {
+const getDateFormat = (config, datetimeFormatFromCfgParsed, hass) => {
   const { hours_to_show, datetime_format } = config;
 
   if (hours_to_show === undefined || hours_to_show <= 24) {
@@ -156,18 +156,18 @@ const getDateFormat = (config, datetimeFormatParsed, hass) => {
   } else {
     // use formatting settings from a card config
     // eslint-disable-next-line no-lonely-if
-    if (datetimeFormatParsed && datetimeFormatParsed.day_weekday) {
+    if (datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.day_weekday) {
       dateOptions = {
         day: 'numeric',
         weekday: 'short',
       };
     } else {
       dateOptions = {
-        year: datetimeFormatParsed && datetimeFormatParsed.year_2digit
+        year: datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.year_2digit
           ? '2-digit' : 'numeric',
-        month: datetimeFormatParsed && datetimeFormatParsed.month_2digit
+        month: datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.month_2digit
           ? '2-digit' : 'numeric',
-        day: datetimeFormatParsed && datetimeFormatParsed.day_2digit
+        day: datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.day_2digit
           ? '2-digit' : 'numeric',
       };
     }
@@ -180,11 +180,11 @@ const getDateFormat = (config, datetimeFormatParsed, hass) => {
 /**
  * Get time formatting options
  * @param {object} config Card config
- * @param {object} datetimeFormatParsed Parsed datetime format
+ * @param {object} datetimeFormatFromCfgParsed Parsed datetime format taken from config
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {Intl.DateTimeFormatOptions} Time formatting options
  */
-const getTimeFormat = (config, datetimeFormatParsed, hass) => {
+const getTimeFormat = (config, datetimeFormatFromCfgParsed, hass) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
 
   const serverTimeZone = hass.config.time_zone; // Server time zone
@@ -204,13 +204,13 @@ const getTimeFormat = (config, datetimeFormatParsed, hass) => {
   } else {
     // use formatting settings from a card config
     // eslint-disable-next-line no-lonely-if
-    if (datetimeFormatParsed && datetimeFormatParsed.day_weekday) {
+    if (datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.day_weekday) {
       hourOption = {
         hour: valueUseAmPm ? 'numeric' : '2-digit',
       };
     } else {
       hourOption = {
-        hour: datetimeFormatParsed && datetimeFormatParsed.hour_2digit
+        hour: datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.hour_2digit
           ? '2-digit' : 'numeric',
       };
     }
@@ -225,14 +225,13 @@ const getTimeFormat = (config, datetimeFormatParsed, hass) => {
 };
 
 /**
- * Returns formatting options to represent a date & time value
+ * Returns formatting options to represent a date & time value from config
  * @param {string} dateTimeFormat Card config option to represent a date & time value
  * @returns {object} Formatting options
  */
-const parseDateTimeFormat = (dateTimeFormat) => {
+const parseDateTimeFormatFromCfg = (dateTimeFormat) => {
   if (!dateTimeFormat) {
-    // fallback to a default "legacy" format
-    return { day_weekday: true };
+    return undefined;
   }
 
   const regex = /^(M{1,2}|D{1,2}|Y{2,4})(\/|\.|-)(M{1,2}|D{1,2})(\/|\.|-)(M{1,2}|D{1,2}|Y{2,4}) H{1,2}:mm$/;
@@ -358,14 +357,16 @@ const composeTimeString = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
- * @param {object} datetimeFormatParsed Parsed datetime format
+ * @param {object} datetimeFormatFromCfgParsed Parsed datetime format taken from config
+ * @param {Intl.DateTimeFormatOptions} datetimeFormatDateOptions Date format options
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted date string
  */
 const formatDate = (
   dateObj,
   config,
-  datetimeFormatParsed,
+  datetimeFormatFromCfgParsed,
+  datetimeFormatDateOptions,
   hass,
 ) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
@@ -379,7 +380,7 @@ const formatDate = (
 
   if (!datetime_format) {
     // follow global HA Frontend settings
-    formatter = new Intl.DateTimeFormat(localeDate, config.date_format);
+    formatter = new Intl.DateTimeFormat(localeDate, datetimeFormatDateOptions);
     if (localeOptions.date_format === DateFormat.language
         || localeOptions.date_format === DateFormat.system) {
       // use default auto-generated presentation
@@ -398,20 +399,20 @@ const formatDate = (
   }
 
   // use formatting settings from a card config
-  if ((datetimeFormatParsed && datetimeFormatParsed.day_weekday)
-    || !datetimeFormatParsed) {
-    formatter = new Intl.DateTimeFormat(localeDate, config.date_format);
+  if ((datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.day_weekday)
+    || !datetimeFormatFromCfgParsed) {
+    formatter = new Intl.DateTimeFormat(localeDate, datetimeFormatDateOptions);
     formatted = formatter.format(dateObj);
     return formatted;
   }
 
-  formatter = new Intl.DateTimeFormat(undefined, config.date_format);
+  formatter = new Intl.DateTimeFormat(undefined, datetimeFormatDateOptions);
   parts = formatter.formatToParts(dateObj);
   // re-compose a string with a required order
   composed = composeDateString(
     parts,
-    datetimeFormatParsed.order,
-    datetimeFormatParsed.date_literal,
+    datetimeFormatFromCfgParsed.order,
+    datetimeFormatFromCfgParsed.date_literal,
   );
   return composed;
 };
@@ -421,14 +422,16 @@ const formatDate = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
- * @param {object} datetimeFormatParsed Parsed datetime format
+ * @param {object} datetimeFormatFromCfgParsed Parsed datetime format taken from config
+ * @param {Intl.DateTimeFormatOptions} datetimeFormatTimeOptions Time format options
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted time string
  */
 const formatTime = (
   dateObj,
   config,
-  datetimeFormatParsed,
+  datetimeFormatFromCfgParsed,
+  datetimeFormatTimeOptions,
   hass,
 ) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
@@ -440,26 +443,25 @@ const formatTime = (
 
   if (!datetime_format) {
     // follow global HA Frontend settings
-    formatter = new Intl.DateTimeFormat(localeTime, config.time_format);
+    formatter = new Intl.DateTimeFormat(localeTime, datetimeFormatTimeOptions);
     formatted = formatter.format(dateObj);
     return formatted;
   }
-
 
   // use formatting settings from a card config
-  if ((datetimeFormatParsed && datetimeFormatParsed.day_weekday)
-    || !datetimeFormatParsed) {
-    formatter = new Intl.DateTimeFormat(localeTime, config.time_format);
+  if ((datetimeFormatFromCfgParsed && datetimeFormatFromCfgParsed.day_weekday)
+    || !datetimeFormatFromCfgParsed) {
+    formatter = new Intl.DateTimeFormat(localeTime, datetimeFormatTimeOptions);
     formatted = formatter.format(dateObj);
     return formatted;
   }
 
-  formatter = new Intl.DateTimeFormat(undefined, config.time_format);
+  formatter = new Intl.DateTimeFormat(undefined, datetimeFormatTimeOptions);
   const parts = formatter.formatToParts(dateObj);
   // re-compose a string with a possibly needed fix for "hour" value
   const composed = composeTimeString(
     parts,
-    datetimeFormatParsed.hour_2digit,
+    datetimeFormatFromCfgParsed.hour_2digit,
   );
   return composed;
 };
@@ -469,20 +471,36 @@ const formatTime = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
- * @param {object} datetimeFormatParsed Parsed datetime format
+ * @param {object} datetimeFormatFromCfgParsed Parsed datetime format taken from config
+ * @param {Intl.DateTimeFormatOptions} datetimeFormatDateOptions Date format options
+ * @param {Intl.DateTimeFormatOptions} datetimeFormatTimeOptions Time format options
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted string
  */
 const formatDateTime = (
   dateObj,
   config,
-  datetimeFormatParsed,
+  datetimeFormatFromCfgParsed,
+  datetimeFormatDateOptions,
+  datetimeFormatTimeOptions,
   hass,
 ) => {
-  let timeString = formatTime(dateObj, config, datetimeFormatParsed, hass);
+  let timeString = formatTime(
+    dateObj,
+    config,
+    datetimeFormatFromCfgParsed,
+    datetimeFormatTimeOptions,
+    hass,
+  );
   const { hours_to_show } = config;
   if (hours_to_show > 24) {
-    const dateString = formatDate(dateObj, config, datetimeFormatParsed, hass);
+    const dateString = formatDate(
+      dateObj,
+      config,
+      datetimeFormatFromCfgParsed,
+      datetimeFormatDateOptions,
+      hass,
+    );
     // the ", " separator between date & time parts is hard-coded
     // (same as currently used in HA Frontend)
     timeString = `${dateString}, ${timeString}`;
@@ -651,7 +669,7 @@ const blankBeforePercent = (localeOptions) => {
 
 export {
   formatNumber,
-  parseDateTimeFormat,
+  parseDateTimeFormatFromCfg,
   getDateFormat, getTimeFormat,
   formatDateTime,
   TimeZone, TimeFormat, DateFormat, // used in tests

--- a/src/locale.js
+++ b/src/locale.js
@@ -129,11 +129,12 @@ const resolveTimeZone = (option, serverTimeZone) => {
 /**
  * Get date formatting options
  * @param {object} config Card config
+ * @param {object} datetimeFormatParsed Parsed datetime format
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {Intl.DateTimeFormatOptions} Date format
  */
-const getDateFormat = (config, hass) => {
-  const { hours_to_show, datetime_format, datetimeFormatParsed } = config;
+const getDateFormat = (config, datetimeFormatParsed, hass) => {
+  const { hours_to_show, datetime_format } = config;
 
   if (hours_to_show === undefined || hours_to_show <= 24) {
     return {};
@@ -179,10 +180,11 @@ const getDateFormat = (config, hass) => {
 /**
  * Get time formatting options
  * @param {object} config Card config
+ * @param {object} datetimeFormatParsed Parsed datetime format
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {Intl.DateTimeFormatOptions} Time formatting options
  */
-const getTimeFormat = (config, hass) => {
+const getTimeFormat = (config, datetimeFormatParsed, hass) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
 
   const serverTimeZone = hass.config.time_zone; // Server time zone
@@ -193,7 +195,7 @@ const getTimeFormat = (config, hass) => {
   const hourCycle = valueUseAmPm ? 'h12' : 'h23'; // accounting possibly defined "hour12"
 
   let hourOption;
-  const { datetime_format, datetimeFormatParsed } = config; // user-defined datetime format
+  const { datetime_format } = config; // user-defined datetime format
   if (!datetime_format) {
     // follow global HA Frontend settings
     hourOption = {
@@ -356,12 +358,14 @@ const composeTimeString = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
+ * @param {object} datetimeFormatParsed Parsed datetime format
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted date string
  */
 const formatDate = (
   dateObj,
   config,
+  datetimeFormatParsed,
   hass,
 ) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
@@ -371,7 +375,7 @@ const formatDate = (
   let formatted;
   let composed;
   let parts;
-  const { datetime_format, datetimeFormatParsed } = config; // user-defined datetime format
+  const { datetime_format } = config; // user-defined datetime format
 
   if (!datetime_format) {
     // follow global HA Frontend settings
@@ -417,12 +421,14 @@ const formatDate = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
+ * @param {object} datetimeFormatParsed Parsed datetime format
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted time string
  */
 const formatTime = (
   dateObj,
   config,
+  datetimeFormatParsed,
   hass,
 ) => {
   const localeOptions = hass.locale; // FrontendLocaleData object
@@ -430,7 +436,7 @@ const formatTime = (
     ? undefined : localeOptions.language;
   let formatter;
   let formatted;
-  const { datetime_format, datetimeFormatParsed } = config; // user-defined datetime format
+  const { datetime_format } = config; // user-defined datetime format
 
   if (!datetime_format) {
     // follow global HA Frontend settings
@@ -463,18 +469,20 @@ const formatTime = (
  * time zone & formatting options
  * @param {Date} dateObj "Date" object representing a date & time value
  * @param {object} config Card config
+ * @param {object} datetimeFormatParsed Parsed datetime format
  * @param {HomeAssistant} hass HomeAssistant object
  * @returns {string} Formatted string
  */
 const formatDateTime = (
   dateObj,
   config,
+  datetimeFormatParsed,
   hass,
 ) => {
-  let timeString = formatTime(dateObj, config, hass);
+  let timeString = formatTime(dateObj, config, datetimeFormatParsed, hass);
   const { hours_to_show } = config;
   if (hours_to_show > 24) {
-    const dateString = formatDate(dateObj, config, hass);
+    const dateString = formatDate(dateObj, config, datetimeFormatParsed, hass);
     // the ", " separator between date & time parts is hard-coded
     // (same as currently used in HA Frontend)
     timeString = `${dateString}, ${timeString}`;

--- a/src/main.js
+++ b/src/main.js
@@ -226,7 +226,7 @@ class MiniGraphCard extends LitElement {
     if (!this._datetimeFormatFromCfgParsedCache) {
       // parse a possibly defined "datetime_format" option from config
       this._datetimeFormatFromCfgParsedCache = parseDateTimeFormatFromCfg(
-        this.config.datetime_format
+        this.config.datetime_format,
       );
     }
     return this._datetimeFormatFromCfgParsedCache;

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
   blankBeforePercent,
   formatNumber,
   formatDateTime,
+  parseDateTimeFormat,
   getDateFormat, getTimeFormat,
 } from './locale';
 import './initialize';
@@ -86,7 +87,8 @@ class MiniGraphCard extends LitElement {
     let updated = false;
     const queue = [];
 
-    // initailize memoized arrays
+    // initailize memoized data
+    this._datetimeFormatParsedCache = null;
     this._visibleEntitiesCache = null;
     this._primaryYaxisEntitiesCache = null;
     this._secondaryYaxisEntitiesCache = null;
@@ -218,6 +220,15 @@ class MiniGraphCard extends LitElement {
     }
     // processing a possible `static_value` entry
     return false;
+  }
+
+  get datetimeFormatParsed() {
+    if (!this._datetimeFormatParsedCache) {
+      // parse a possibly defined "datetime_format" option;
+      // fallback to "day_weekday" if undefined
+      this._datetimeFormatParsedCache = parseDateTimeFormat(this.config.datetime_format);
+    }
+    return this._datetimeFormatParsedCache;
   }
 
   /**
@@ -967,9 +978,9 @@ class MiniGraphCard extends LitElement {
     const now = this.getEndDate();
 
     now.setMilliseconds(now.getMilliseconds() - oneMinute - interval * count);
-    const end = formatDateTime(now, this.config, this._hass);
+    const end = formatDateTime(now, this.config, this.datetimeFormatParsed, this._hass);
     now.setMilliseconds(now.getMilliseconds() + oneMinute - interval);
-    const start = formatDateTime(now, this.config, this._hass);
+    const start = formatDateTime(now, this.config, this.datetimeFormatParsed, this._hass);
 
     this.tooltip = {
       value,
@@ -1038,7 +1049,9 @@ class MiniGraphCard extends LitElement {
               ${this.computeStateWithUom(entry.state, 0, hideUnit)}
             </span>
             <span class="info__item__time">
-              ${entry.type !== 'avg' ? formatDateTime(new Date(entry.last_changed), this.config, this._hass) : ''}
+              ${entry.type !== 'avg' ? formatDateTime(
+                new Date(entry.last_changed), this.config, this.datetimeFormatParsed, this._hass
+              ) : ''}
             </span>
           </div>
         `)}

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ import {
   blankBeforePercent,
   formatNumber,
   formatDateTime,
-  parseDateTimeFormat,
+  parseDateTimeFormatFromCfg,
   getDateFormat, getTimeFormat,
 } from './locale';
 import './initialize';
@@ -87,8 +87,8 @@ class MiniGraphCard extends LitElement {
     let updated = false;
     const queue = [];
 
-    // initailize memoized data
-    this._datetimeFormatParsedCache = null;
+    // initialize memoized data
+    this._datetimeFormatFromCfgParsedCache = null;
     this._visibleEntitiesCache = null;
     this._primaryYaxisEntitiesCache = null;
     this._secondaryYaxisEntitiesCache = null;
@@ -222,13 +222,12 @@ class MiniGraphCard extends LitElement {
     return false;
   }
 
-  get datetimeFormatParsed() {
-    if (!this._datetimeFormatParsedCache) {
-      // parse a possibly defined "datetime_format" option;
-      // fallback to "day_weekday" if undefined
-      this._datetimeFormatParsedCache = parseDateTimeFormat(this.config.datetime_format);
+  get datetimeFormatFromCfgParsed() {
+    if (!this._datetimeFormatFromCfgParsedCache) {
+      // parse a possibly defined "datetime_format" option from config
+      this._datetimeFormatFromCfgParsedCache = parseDateTimeFormatFromCfg(this.config.datetime_format);
     }
-    return this._datetimeFormatParsedCache;
+    return this._datetimeFormatFromCfgParsedCache;
   }
 
   /**
@@ -237,10 +236,18 @@ class MiniGraphCard extends LitElement {
   */
   updateFormatFromLocale(forced) {
     if (this.updateDateTimeFormat || forced) {
-      this.config.date_format = getDateFormat(this.config, this._hass);
+      this.datetimeFormatDateOptions = getDateFormat(
+        this.config,
+        this.datetimeFormatFromCfgParsed,
+        this._hass,
+      );
     }
     if (this.updateHour24 || this.updateDateTimeFormat || forced) {
-      this.config.time_format = getTimeFormat(this.config, this._hass);
+      this.datetimeFormatTimeOptions = getTimeFormat(
+        this.config,
+        this.datetimeFormatFromCfgParsed,
+        this._hass,
+      );
     }
   }
 
@@ -978,9 +985,23 @@ class MiniGraphCard extends LitElement {
     const now = this.getEndDate();
 
     now.setMilliseconds(now.getMilliseconds() - oneMinute - interval * count);
-    const end = formatDateTime(now, this.config, this.datetimeFormatParsed, this._hass);
+    const end = formatDateTime(
+      now,
+      this.config,
+      this.datetimeFormatFromCfgParsed,
+      this.datetimeFormatDateOptions,
+      this.datetimeFormatTimeOptions,
+      this._hass,
+    );
     now.setMilliseconds(now.getMilliseconds() + oneMinute - interval);
-    const start = formatDateTime(now, this.config, this.datetimeFormatParsed, this._hass);
+    const start = formatDateTime(
+      now,
+      this.config,
+      this.datetimeFormatFromCfgParsed,
+      this.datetimeFormatDateOptions,
+      this.datetimeFormatTimeOptions,
+      this._hass,
+    );
 
     this.tooltip = {
       value,
@@ -1050,7 +1071,12 @@ class MiniGraphCard extends LitElement {
             </span>
             <span class="info__item__time">
               ${entry.type !== 'avg' ? formatDateTime(
-                new Date(entry.last_changed), this.config, this.datetimeFormatParsed, this._hass
+                new Date(entry.last_changed),
+                this.config,
+                this.datetimeFormatFromCfgParsed,
+                this.datetimeFormatDateOptions,
+                this.datetimeFormatTimeOptions,
+                this._hass,
               ) : ''}
             </span>
           </div>

--- a/src/main.js
+++ b/src/main.js
@@ -225,7 +225,9 @@ class MiniGraphCard extends LitElement {
   get datetimeFormatFromCfgParsed() {
     if (!this._datetimeFormatFromCfgParsedCache) {
       // parse a possibly defined "datetime_format" option from config
-      this._datetimeFormatFromCfgParsedCache = parseDateTimeFormatFromCfg(this.config.datetime_format);
+      this._datetimeFormatFromCfgParsedCache = parseDateTimeFormatFromCfg(
+        this.config.datetime_format
+      );
     }
     return this._datetimeFormatFromCfgParsedCache;
   }
@@ -1061,6 +1063,7 @@ class MiniGraphCard extends LitElement {
     } = this.config.show;
     const location = (extrema === 'below' || average === 'below') ? 'below' : 'above';
     // index "0" is passed into computeStateWithUom() since "info" is shown for the 1st entry
+    /* eslint-disable indent */
     return this.abs.length > 0 ? html`
       <div class="info flex" loc=${location}>
         ${this.abs.map(entry => html`
@@ -1070,19 +1073,22 @@ class MiniGraphCard extends LitElement {
               ${this.computeStateWithUom(entry.state, 0, hideUnit)}
             </span>
             <span class="info__item__time">
-              ${entry.type !== 'avg' ? formatDateTime(
-                new Date(entry.last_changed),
-                this.config,
-                this.datetimeFormatFromCfgParsed,
-                this.datetimeFormatDateOptions,
-                this.datetimeFormatTimeOptions,
-                this._hass,
-              ) : ''}
+              ${entry.type !== 'avg'
+                ? formatDateTime(
+                    new Date(entry.last_changed),
+                    this.config,
+                    this.datetimeFormatFromCfgParsed,
+                    this.datetimeFormatDateOptions,
+                    this.datetimeFormatTimeOptions,
+                    this._hass,
+                  )
+                : ''}
             </span>
           </div>
         `)}
       </div>
     ` : html``;
+    /* eslint-enable indent */
   }
 
   handlePopup(e, entity) {

--- a/tests/formatTime.test.ts.dis
+++ b/tests/formatTime.test.ts.dis
@@ -20,7 +20,7 @@ import {
   TimeFormat,
   DateFormat,
   TimeZone,
-} from '../src/locale';
+} from '../locale';
 
 // Set UTC time if your vitest is configired for UTC or has a default config;
 // also, set UTC for HASS_TIME_ZONE
@@ -104,7 +104,6 @@ interface ConfigType {
   hour24?: boolean;
   time_format?: Intl.DateTimeFormatOptions;
   date_format?: Intl.DateTimeFormatOptions;
-  datetimeFormatParsed: any;
 };
 
 const getConfig = (
@@ -126,14 +125,14 @@ const getConfig = (
     config = { ...config, hour24 };
   }
 
-  config.datetimeFormatParsed = parseDateTimeFormat(datetime_format!);
-  config.date_format = getDateFormat(config, hass);
-  config.time_format = getTimeFormat(config, hass);
+  const datetimeFormatParsed = parseDateTimeFormat(datetime_format!);
+  config.date_format = getDateFormat(config, datetimeFormatParsed, hass);
+  config.time_format = getTimeFormat(config, datetimeFormatParsed, hass);
 
-  return config;
+  return { config, datetimeFormatParsed };
 };
 
-// Tests do not bother a bout a difference in "normal vs NNBSP" whitespaces & "AM vs am",
+// Tests do not bother about a difference in "normal vs NNBSP" whitespaces & "AM vs am",
 // it's a complicated & confusing logic in Intl
 const standardizeAmPm = (result: string) => result.replace('\u202f', ' ').replace('am', 'AM');
 
@@ -204,12 +203,12 @@ describe("formatDateTime", () => {
                   date_format, time_format, time_zone, language, hour24, hours_to_show
                 ), () => {
                   patternsOK.forEach((pattern) => {
-                    const config = getConfig(hass, pattern.pattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value,
                     );
                   });
@@ -227,12 +226,12 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('HH', 'H');
-                    const config = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value.replace('04:05', '4:05'),
                     );
                   });
@@ -246,12 +245,12 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('YYYY', 'YY');
-                    const config = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value.replace('2023', '23'),
                     );
                   });
@@ -265,12 +264,12 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('MM', 'M');
-                    const config = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value.replace('03', '3'),
                     );
                   });
@@ -284,12 +283,12 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('DD', 'D');
-                    const config = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value.replace('01', '1')
                     );
                   });
@@ -306,7 +305,7 @@ describe("formatDateTime", () => {
                   date_format, time_format, time_zone, language, hour24, hours_to_show
                 ), () => {
                   patternsFaulty.forEach((pattern) => {
-                    const config = getConfig(hass, pattern.pattern, hours_to_show, hour24);
+                    const { config, datetimeFormatParsed } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
                     const weekdayLocalized = WEEKDAYS[language];
                     const order = language !== 'en';
                     let valueLocalized = pattern.value(weekdayLocalized, order);
@@ -317,7 +316,7 @@ describe("formatDateTime", () => {
                       valueLocalized, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, hass)),
+                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
                       value,
                     );
                   });
@@ -357,8 +356,8 @@ describe("formatDateTime", () => {
               hour24,
               hours_to_show,
             ), () => {
-              const config = getConfig(hass, undefined, hours_to_show, hour24);
-              const result = formatDateTime(dateObj, config, hass);
+              const { config, datetimeFormatParsed } = getConfig(hass, undefined, hours_to_show, hour24);
+              const result = formatDateTime(dateObj, config, datetimeFormatParsed, hass);
               let newValue = pattern.value;
               if (
                 (hour24 === undefined

--- a/tests/formatTime.test.ts.dis
+++ b/tests/formatTime.test.ts.dis
@@ -15,7 +15,7 @@ import { assert, describe, it } from 'vitest';
 import {
   getDateFormat,
   getTimeFormat,
-  parseDateTimeFormat,
+  parseDateTimeFormatFromCfg,
   formatDateTime,
   TimeFormat,
   DateFormat,
@@ -125,11 +125,11 @@ const getConfig = (
     config = { ...config, hour24 };
   }
 
-  const datetimeFormatParsed = parseDateTimeFormat(datetime_format!);
-  config.date_format = getDateFormat(config, datetimeFormatParsed, hass);
-  config.time_format = getTimeFormat(config, datetimeFormatParsed, hass);
+  const datetimeFormatFromCfgParsed = parseDateTimeFormatFromCfg(datetime_format!);
+  const datetimeFormatDateOptions = getDateFormat(config, datetimeFormatFromCfgParsed, hass);
+  const datetimeFormatTimeOptions = getTimeFormat(config, datetimeFormatFromCfgParsed, hass);
 
-  return { config, datetimeFormatParsed };
+  return { config, datetimeFormatFromCfgParsed, datetimeFormatDateOptions, datetimeFormatTimeOptions };
 };
 
 // Tests do not bother about a difference in "normal vs NNBSP" whitespaces & "AM vs am",
@@ -203,12 +203,24 @@ describe("formatDateTime", () => {
                   date_format, time_format, time_zone, language, hour24, hours_to_show
                 ), () => {
                   patternsOK.forEach((pattern) => {
-                    const { config, datetimeFormatParsed } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value,
                     );
                   });
@@ -226,12 +238,24 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('HH', 'H');
-                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value.replace('04:05', '4:05'),
                     );
                   });
@@ -245,12 +269,24 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('YYYY', 'YY');
-                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value.replace('2023', '23'),
                     );
                   });
@@ -264,12 +300,24 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('MM', 'M');
-                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value.replace('03', '3'),
                     );
                   });
@@ -283,12 +331,24 @@ describe("formatDateTime", () => {
                 ), () => {
                   patternsOK.forEach((pattern) => {
                     const newPattern = pattern.pattern.replace('DD', 'D');
-                    const { config, datetimeFormatParsed } = getConfig(hass, newPattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, newPattern, hours_to_show, hour24);
                     const value = getExpectedValue(
                       pattern.value, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value.replace('01', '1')
                     );
                   });
@@ -305,7 +365,12 @@ describe("formatDateTime", () => {
                   date_format, time_format, time_zone, language, hour24, hours_to_show
                 ), () => {
                   patternsFaulty.forEach((pattern) => {
-                    const { config, datetimeFormatParsed } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
+                    const {
+                      config,
+                      datetimeFormatFromCfgParsed,
+                      datetimeFormatDateOptions,
+                      datetimeFormatTimeOptions,
+                    } = getConfig(hass, pattern.pattern, hours_to_show, hour24);
                     const weekdayLocalized = WEEKDAYS[language];
                     const order = language !== 'en';
                     let valueLocalized = pattern.value(weekdayLocalized, order);
@@ -316,7 +381,14 @@ describe("formatDateTime", () => {
                       valueLocalized, hours_to_show, hour24, language, time_format
                     );
                     assert.strictEqual(
-                      standardizeAmPm(formatDateTime(dateObj, config, datetimeFormatParsed, hass)),
+                      standardizeAmPm(formatDateTime(
+                        dateObj,
+                        config,
+                        datetimeFormatFromCfgParsed,
+                        datetimeFormatDateOptions,
+                        datetimeFormatTimeOptions,
+                        hass,
+                      )),
                       value,
                     );
                   });
@@ -356,8 +428,20 @@ describe("formatDateTime", () => {
               hour24,
               hours_to_show,
             ), () => {
-              const { config, datetimeFormatParsed } = getConfig(hass, undefined, hours_to_show, hour24);
-              const result = formatDateTime(dateObj, config, datetimeFormatParsed, hass);
+              const {
+                config,
+                datetimeFormatFromCfgParsed,
+                datetimeFormatDateOptions,
+                datetimeFormatTimeOptions,
+              } = getConfig(hass, undefined, hours_to_show, hour24);
+              const result = formatDateTime(
+                dateObj,
+                config,
+                datetimeFormatFromCfgParsed,
+                datetimeFormatDateOptions,
+                datetimeFormatTimeOptions,
+                hass,
+              );
               let newValue = pattern.value;
               if (
                 (hour24 === undefined


### PR DESCRIPTION
More fixes & optimizations for datetime functions:
`date_format`, `time_format` & `datetimeFormatParsed` - moved out a `config` object to prevent possible glitches due to wrong user's actions.