### PR TITLE
fix: Graph constructor - pass a dictionary

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -5,7 +5,17 @@ import {
 } from './const';
 
 export default class Graph {
-  constructor(width, height, margin, hours = 24, points = 1, aggregateFuncName = 'avg', groupBy = 'interval', smoothing = true, logarithmic = false) {
+  constructor({
+    width,
+    height,
+    margin,
+    hours = 24,
+    points = 1,
+    aggregateFuncName = 'avg',
+    groupBy = 'interval',
+    smoothing = true,
+    logarithmic = false,
+  }) {
     const aggregateFuncMap = {
       avg: this._average,
       median: this._median,

--- a/src/main.js
+++ b/src/main.js
@@ -183,7 +183,7 @@ class MiniGraphCard extends LitElement {
         (entity, index) => new Graph({
           width: 500,
           height: this.config.height,
-          margin: margin,
+          margin,
           hours: this.config.hours_to_show,
           points: this.config.points_per_hour,
           aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
@@ -198,7 +198,7 @@ class MiniGraphCard extends LitElement {
             this.config.logarithmic,
             false,
           ),
-        }),          
+        }),
       );
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -180,21 +180,25 @@ class MiniGraphCard extends LitElement {
           ? [0, max_line_width]
           : [min_line_width, max_line_width];
       this.Graph = this.config.entities.map(
-        (entity, index) => new Graph(
-          500,
-          this.config.height,
-          margin,
-          this.config.hours_to_show,
-          this.config.points_per_hour,
-          entity.aggregate_func || this.config.aggregate_func,
-          this.config.group_by,
-          getFirstDefinedItem(
+        (entity, index) => new Graph({
+          width: 500,
+          height: this.config.height,
+          margin: margin,
+          hours: this.config.hours_to_show,
+          points: this.config.points_per_hour,
+          aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
+          groupBy: this.config.group_by,
+          smoothing: getFirstDefinedItem(
             entity.smoothing,
             this.config.smoothing,
             this.getDefaultSmoothing(index),
           ),
-          this.computeUsesLogarithmic(index),
-        ),
+          logarithmic: getFirstDefinedItem(
+            entity.logarithmic,
+            this.config.logarithmic,
+            false,
+          ),
+        }),          
       );
     }
   }


### PR DESCRIPTION
Instead of passing a set of arguments into a constructor, a dictionary is passed.
This makes the code more clear & readable.