### PR TITLE
fix: Minor fixes & optimizations (#3)

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -58,7 +58,7 @@ const checkNumericOption = (
       errorDescr = `out of bounds, maximum allowed: ${maxBound}`;
     }
   }
-  log(`Invalid option ${option}: ${invalidValue} (${errorDescr}); adjusting value to ${clearedValue}`);
+  log(`Invalid option ${option}: [${invalidValue}] (${errorDescr}); adjusting value to ${clearedValue}`);
   return clearedValue;
 };
 
@@ -83,7 +83,7 @@ const checkIntegerOption = (
   const value = checkNumericOption(config, option, defaultValue, minBound, maxBound);
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value);
-    log(`Invalid integer option ${option}: ${value}; rounding value to ${roundedValue}`);
+    log(`Invalid integer option ${option}: [${value}]; rounding value to ${roundedValue}`);
     return roundedValue;
   }
   return value;

--- a/src/graph.js
+++ b/src/graph.js
@@ -45,7 +45,7 @@ export default class Graph {
     this.aggregateFuncName = aggregateFuncName;
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
-    this._logarithmic = logarithmic;
+    this.logarithmic = logarithmic;
     this.bar_spacing = bar_spacing;
     this.bar_spacing_group = bar_spacing_group;
     this.total_bars_in_group = total_bars_in_group;
@@ -60,10 +60,6 @@ export default class Graph {
   get min() { return this._min; }
 
   set min(min) { this._min = min; }
-
-  get logarithmic() { return this._logarithmic; }
-
-  set logarithmic(logarithmic) { this._logarithmic = logarithmic; }
 
   set history(data) { this._history = data; }
 
@@ -119,12 +115,12 @@ export default class Graph {
 
   _calcY(coords) {
     // account for logarithmic graph
-    const max = this._logarithmic ? Math.log10(Math.max(1, this.max)) : this.max;
-    const min = this._logarithmic ? Math.log10(Math.max(1, this.min)) : this.min;
+    const max = this.logarithmic ? Math.log10(Math.max(1, this.max)) : this.max;
+    const min = this.logarithmic ? Math.log10(Math.max(1, this.min)) : this.min;
 
     const yRatio = ((max - min) / this.height) || 1;
     const coords2 = coords.map((coord) => {
-      const val = this._logarithmic ? Math.log10(Math.max(1, coord[V])) : coord[V];
+      const val = this.logarithmic ? Math.log10(Math.max(1, coord[V])) : coord[V];
       const coordY = this.height - ((val - min) / yRatio) + this.margin[Y] * 2;
       return [coord[X], coordY, coord[V]];
     });
@@ -176,7 +172,7 @@ export default class Graph {
   }
 
   computeGradient(thresholds) {
-    const scale = this._logarithmic
+    const scale = this.logarithmic
       ? Math.log10(Math.max(1, this._max)) - Math.log10(Math.max(1, this._min))
       : this._max - this._min;
 
@@ -192,7 +188,7 @@ export default class Graph {
       let offset;
       if (scale <= 0) {
         offset = 0;
-      } else if (this._logarithmic) {
+      } else if (this.logarithmic) {
         offset = (Math.log10(Math.max(1, this._max))
           - Math.log10(Math.max(1, stop.value)))
           * (100 / scale);

--- a/src/graph.js
+++ b/src/graph.js
@@ -2,7 +2,9 @@ import { interpolateRGB } from './color';
 import {
   X, Y, V,
   ONE_HOUR,
+  DEFAULT_BAR_SPACING,
 } from './const';
+import { log } from './utils';
 
 export default class Graph {
   constructor({
@@ -15,6 +17,9 @@ export default class Graph {
     groupBy = 'interval',
     smoothing = true,
     logarithmic = false,
+    bar_spacing = DEFAULT_BAR_SPACING, // spacing between bars
+    bar_spacing_group = DEFAULT_BAR_SPACING, // spacing between groups of bars
+    total_bars_in_group = 1, // number of bars (i.e. number of entities with a shown bar graph)
   }) {
     const aggregateFuncMap = {
       avg: this._average,
@@ -41,6 +46,9 @@ export default class Graph {
     this._calcPoint = aggregateFuncMap[aggregateFuncName] || this._average;
     this._smoothing = smoothing;
     this._logarithmic = logarithmic;
+    this.bar_spacing = bar_spacing;
+    this.bar_spacing_group = bar_spacing_group;
+    this.total_bars_in_group = total_bars_in_group;
     this._groupBy = groupBy;
     this._endTime = 0;
   }
@@ -211,22 +219,34 @@ export default class Graph {
    * Get bars for an entity
    * @param {number} position Index of a bar (0,1,..)
    * (i.e. index of an entity with a shown bar graph)
-   * @param {number} total Number of bars (i.e. number of entities with a shown bar graph)
-   * @param {number} spacing Spacing between bars
-   * @param {number} spacing_group Spacing between groups of bars
    * @returns Bars for an entity to be shown at a `position` index
    */
-  getBars(position, total, spacing, spacing_group) {
+  getBars(position) {
+    const spacing = this.bar_spacing;
+    const spacing_group = this.bar_spacing_group;
+    const total = this.total_bars_in_group;
+
     const coords = this._calcY(this.coords);
+
     // number of measures
     const total_groups = Math.ceil(this.hours * this.points);
+
     // width of a group of bars
     const group_width = (this.width - spacing_group * (total_groups - 1))
       / total_groups;
-    // a width of a bar
-    const bar_width = spacing === -1
-      ? group_width
-      : (group_width - spacing * (total - 1)) / total;
+
+    // width of a bar
+    let bar_width;
+    if (spacing === -1) {
+      bar_width = group_width;
+    } else {
+      bar_width = (group_width - spacing * (total - 1)) / total;
+      if (bar_width <= 0) {
+        bar_width = 1;
+        log(`Invalid bar_width, adjusted to 1 (bar_spacing ${spacing}, bar_spacing_group ${spacing_group})`);
+      }
+    }
+
     return coords.map((coord, i) => ({
       x: this.margin[X]
         + (group_width + spacing_group) * i

--- a/src/locale.js
+++ b/src/locale.js
@@ -246,7 +246,9 @@ const parseDateTimeFormatFromCfg = (dateTimeFormat) => {
   */
   const trimmed = dateTimeFormat.trim();
   if (!regex.test(trimmed)) {
+    // invalid datetime_format
     // fallback to a default "legacy" format
+    log(`invalid datetime_format [${dateTimeFormat}], fallback to legacy 'day_weekday'`);
     return { day_weekday: true };
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -855,7 +855,7 @@ class MiniGraphCard extends LitElement {
       && !this.isShowStaticInactive(index);
     const radius = getFirstDefinedItem(
       this.config.entities[index].line_width,
-      this.config.line_width
+      this.config.line_width,
     );
     return svg`
       <g class='line--points'

--- a/src/main.js
+++ b/src/main.js
@@ -791,6 +791,9 @@ class MiniGraphCard extends LitElement {
       ? this.length[index]
       : this.config.entities[index].line_style || this.config.line_style)
       || 'none';
+    const lineWidth = getFirstDefinedItem(
+      this.config.entities[index].line_width,
+      this.config.line_width);
     const path = svg`
       <path
         class='line'
@@ -800,10 +803,9 @@ class MiniGraphCard extends LitElement {
         fill='none'
         stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[index] || 'none'}
         stroke=${'white'}
-        stroke-width=${this.config.entities[index].line_width || this.config.line_width}
+        stroke-width=${lineWidth}
         d=${this.line[index]}
       />`;
-
     return svg`
       <mask id=${`line-${this.id}-${index}`}>
         ${path}

--- a/src/main.js
+++ b/src/main.js
@@ -747,61 +747,61 @@ class MiniGraphCard extends LitElement {
     /* eslint-enable indent */
   }
 
-  renderSvgFill(fill, i) {
+  renderSvgFill(fill, index) {
     if (!fill) return;
     const fade = this.config.show.fill === 'fade';
-    const init = this.length[i] || this.config.entities[i].show_line === false;
+    const init = this.length[index] || this.config.entities[index].show_line === false;
     return svg`
       <defs>
-        <linearGradient id=${`fill-grad-${this.id}-${i}`} x1="0%" y1="0%" x2="0%" y2="100%">
+        <linearGradient id=${`fill-grad-${this.id}-${index}`} x1="0%" y1="0%" x2="0%" y2="100%">
           <stop stop-color='white' offset='0%' stop-opacity='1'/>
           <stop stop-color='white' offset='100%' stop-opacity='.15'/>
         </linearGradient>
-        <mask id=${`fill-grad-mask-${this.id}-${i}`}>
-          <rect width="100%" height="100%" fill=${`url(#fill-grad-${this.id}-${i})`} />
+        <mask id=${`fill-grad-mask-${this.id}-${index}`}>
+          <rect width="100%" height="100%" fill=${`url(#fill-grad-${this.id}-${index})`} />
         </mask>
       </defs>
-      <mask id=${`fill-${this.id}-${i}`}>
+      <mask id=${`fill-${this.id}-${index}`}>
         <path class='fill'
           type=${this.config.show.fill}
-          .id=${i} anim=${this.config.animate} ?init=${init}
-          style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+          .id=${index} anim=${this.config.animate} ?init=${init}
+          style="animation-delay: ${this.config.animate ? `${index * 0.5}s` : '0s'}"
           fill='white'
-          mask=${fade ? `url(#fill-grad-mask-${this.id}-${i})` : ''}
-          d=${this.fill[i]}
+          mask=${fade ? `url(#fill-grad-mask-${this.id}-${index})` : ''}
+          d=${this.fill[index]}
         />
       </mask>`;
   }
 
-  renderSvgLine(line, i) {
+  renderSvgLine(line, index) {
     if (!line) return;
 
     const strokeDashArray = (this.config.animate
-      ? this.length[i]
-      : this.config.entities[i].line_style || this.config.line_style)
+      ? this.length[index]
+      : this.config.entities[index].line_style || this.config.line_style)
       || 'none';
     const path = svg`
       <path
         class='line'
-        .id=${i}
-        anim=${this.config.animate} ?init=${this.length[i]}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5}s` : '0s'}"
+        .id=${index}
+        anim=${this.config.animate} ?init=${this.length[index]}
+        style="animation-delay: ${this.config.animate ? `${index * 0.5}s` : '0s'}"
         fill='none'
-        stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[i] || 'none'}
+        stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[index] || 'none'}
         stroke=${'white'}
-        stroke-width=${this.config.entities[i].line_width || this.config.line_width}
-        d=${this.line[i]}
+        stroke-width=${this.config.entities[index].line_width || this.config.line_width}
+        d=${this.line[index]}
       />`;
 
     return svg`
-      <mask id=${`line-${this.id}-${i}`}>
+      <mask id=${`line-${this.id}-${index}`}>
         ${path}
       </mask>
     `;
   }
 
-  renderSvgPoint(point, i) {
-    const color = this.gradient[i] ? this.computeColor(point[V], i) : 'inherit';
+  renderSvgPoint(point, index) {
+    const color = this.gradient[index] ? this.computeColor(point[V], index) : 'inherit';
     return svg`
       <circle
         class='line--point'
@@ -809,30 +809,30 @@ class MiniGraphCard extends LitElement {
         style=${`--mcg-hover: ${color};`}
         stroke=${color}
         fill=${color}
-        cx=${point[X]} cy=${point[Y]} r=${this.config.entities[i].line_width || this.config.line_width}
-        @mouseover=${() => this.setTooltip(i, point[3], point[V])}
+        cx=${point[X]} cy=${point[Y]} r=${this.config.entities[index].line_width || this.config.line_width}
+        @mouseover=${() => this.setTooltip(index, point[3], point[V])}
         @mouseout=${() => (this.tooltip = {})}
       />
     `;
   }
 
-  renderSvgPoints(points, i) {
+  renderSvgPoints(points, index) {
     if (!points) return;
-    const state = this.entity[i] !== undefined
-      ? this.entity[i].state
-      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
-    const color = this.computeColor(state, i);
+    const state = this.entity[index] !== undefined
+      ? this.entity[index].state
+      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+    const color = this.computeColor(state, index);
     return svg`
       <g class='line--points'
-        ?tooltip=${this.tooltip.entity === i}
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
-        ?init=${this.length[i]}
+        ?tooltip=${this.tooltip.entity === index}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        ?init=${this.length[index]}
         anim=${this.config.animate && this.config.show.points !== 'hover'}
-        style="animation-delay: ${this.config.animate ? `${i * 0.5 + 0.5}s` : '0s'}"
+        style="animation-delay: ${this.config.animate ? `${index * 0.5 + 0.5}s` : '0s'}"
         fill=${color}
         stroke=${color}
-        stroke-width=${(this.config.entities[i].line_width || this.config.line_width) / 2}>
-        ${points.map(point => this.renderSvgPoint(point, i))}
+        stroke-width=${(this.config.entities[index].line_width || this.config.line_width) / 2}>
+        ${points.map(point => this.renderSvgPoint(point, index))}
       </g>`;
   }
 
@@ -850,37 +850,37 @@ class MiniGraphCard extends LitElement {
     return svg`${items}`;
   }
 
-  renderSvgLineRect(line, i) {
+  renderSvgLineRect(line, index) {
     if (!line) return;
-    const state = this.entity[i] !== undefined
-      ? this.entity[i].state
-      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
-    const fill = this.gradient[i]
-      ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(state, i);
+    const state = this.entity[index] !== undefined
+      ? this.entity[index].state
+      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+    const fill = this.gradient[index]
+      ? `url(#grad-${this.id}-${index})`
+      : this.computeColor(state, index);
     return svg`
       <rect class='line--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
-        id=${`rect-${this.id}-${i}`}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        id=${`rect-${this.id}-${index}`}
         fill=${fill} height="100%" width="100%"
-        mask=${`url(#line-${this.id}-${i})`}
+        mask=${`url(#line-${this.id}-${index})`}
       />`;
   }
 
-  renderSvgFillRect(fill, i) {
+  renderSvgFillRect(fill, index) {
     if (!fill) return;
-    const state = this.entity[i] !== undefined
-      ? this.entity[i].state
-      : this.isStaticValue(i) ? this.config.entities[i].static_value : undefined;
-    const svgFill = this.gradient[i]
-      ? `url(#grad-${this.id}-${i})`
-      : this.computeColor(state, i);
+    const state = this.entity[index] !== undefined
+      ? this.entity[index].state
+      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+    const svgFill = this.gradient[index]
+      ? `url(#grad-${this.id}-${index})`
+      : this.computeColor(state, index);
     return svg`
       <rect class='fill--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== i && !this.isShowStaticInactive(i)}
-        id=${`fill-rect-${this.id}-${i}`}
+        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        id=${`fill-rect-${this.id}-${index}`}
         fill=${svgFill} height="100%" width="100%"
-        mask=${`url(#fill-${this.id}-${i})`}
+        mask=${`url(#fill-${this.id}-${index})`}
       />`;
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -787,7 +787,6 @@ class MiniGraphCard extends LitElement {
   */
   renderSvgLine(line, index) {
     if (!line) return;
-
     const strokeDashArray = (this.config.animate
       ? this.length[index]
       : this.config.entities[index].line_style || this.config.line_style)
@@ -817,9 +816,12 @@ class MiniGraphCard extends LitElement {
   * @returns {SVGTemplateResult} SVG element
   * @param {Array} point Point for a particular entity/static value
   * @param {number} index Index of an entry in config.entities
+  * @param {number} radius Previously calculated radius of a point
   */
-  renderSvgPoint(point, index) {
-    const color = this.gradient[index] ? this.computeColor(point[V], index) : 'inherit';
+  renderSvgPoint(point, index, radius) {
+    const color = this.gradient[index]
+      ? this.computeColor(point[V], index)
+      : 'inherit';
     return svg`
       <circle
         class='line--point'
@@ -827,7 +829,7 @@ class MiniGraphCard extends LitElement {
         style=${`--mcg-hover: ${color};`}
         stroke=${color}
         fill=${color}
-        cx=${point[X]} cy=${point[Y]} r=${this.config.entities[index].line_width || this.config.line_width}
+        cx=${point[X]} cy=${point[Y]} r=${radius}
         @mouseover=${() => this.setTooltip(index, point[3], point[V])}
         @mouseout=${() => (this.tooltip = {})}
       />
@@ -844,19 +846,28 @@ class MiniGraphCard extends LitElement {
     if (!points) return;
     const state = this.entity[index] !== undefined
       ? this.entity[index].state
-      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+      : this.isStaticValue(index)
+        ? this.config.entities[index].static_value
+        : undefined;
     const color = this.computeColor(state, index);
+    const inactive = this.tooltip.entity !== undefined
+      && this.tooltip.entity !== index
+      && !this.isShowStaticInactive(index);
+    const radius = getFirstDefinedItem(
+      this.config.entities[index].line_width,
+      this.config.line_width
+    );
     return svg`
       <g class='line--points'
         ?tooltip=${this.tooltip.entity === index}
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        ?inactive=${inactive}
         ?init=${this.length[index]}
         anim=${this.config.animate && this.config.show.points !== 'hover'}
         style="animation-delay: ${this.config.animate ? `${index * 0.5 + 0.5}s` : '0s'}"
         fill=${color}
         stroke=${color}
-        stroke-width=${(this.config.entities[index].line_width || this.config.line_width) / 2}>
-        ${points.map(point => this.renderSvgPoint(point, index))}
+        stroke-width=${radius / 2}>
+        ${points.map(point => this.renderSvgPoint(point, index, radius))}
       </g>`;
   }
 
@@ -884,13 +895,18 @@ class MiniGraphCard extends LitElement {
     if (!line) return;
     const state = this.entity[index] !== undefined
       ? this.entity[index].state
-      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+      : this.isStaticValue(index)
+        ? this.config.entities[index].static_value
+        : undefined;
     const fill = this.gradient[index]
       ? `url(#grad-${this.id}-${index})`
       : this.computeColor(state, index);
+    const inactive = this.tooltip.entity !== undefined
+      && this.tooltip.entity !== index
+      && !this.isShowStaticInactive(index);
     return svg`
       <rect class='line--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        ?inactive=${inactive}
         id=${`rect-${this.id}-${index}`}
         fill=${fill} height="100%" width="100%"
         mask=${`url(#line-${this.id}-${index})`}
@@ -911,9 +927,12 @@ class MiniGraphCard extends LitElement {
     const svgFill = this.gradient[index]
       ? `url(#grad-${this.id}-${index})`
       : this.computeColor(state, index);
+    const inactive = this.tooltip.entity !== undefined
+      && this.tooltip.entity !== index
+      && !this.isShowStaticInactive(index);
     return svg`
       <rect class='fill--rect'
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index && !this.isShowStaticInactive(index)}
+        ?inactive=${inactive}
         id=${`fill-rect-${this.id}-${index}`}
         fill=${svgFill} height="100%" width="100%"
         mask=${`url(#fill-${this.id}-${index})`}
@@ -944,12 +963,14 @@ class MiniGraphCard extends LitElement {
           ${animation}
         </rect>`;
     });
+    const inactive = this.tooltip.entity !== undefined
+      && this.tooltip.entity !== index
+      && !this.isShowStaticInactive(index);
     return svg`
       <g
         class='bars'
         ?anim=${this.config.animate}
-        ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
-          && !this.isShowStaticInactive(index)}
+        ?inactive=${inactive}
       >${items}</g>`;
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -87,10 +87,6 @@ class MiniGraphCard extends LitElement {
 
     // initialize memoized data
     this._datetimeFormatFromCfgParsedCache = null;
-    this._visibleEntitiesCache = null;
-    this._primaryYaxisEntitiesCache = null;
-    this._secondaryYaxisEntitiesCache = null;
-    this._visibleLegendsCache = null;
 
     this.config.entities.forEach((entity, index) => {
       this.config.entities[index].index = index; // Required for filtered views
@@ -171,6 +167,12 @@ class MiniGraphCard extends LitElement {
     this.config = buildConfig(config);
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
+
+    // initialize memoized data
+    this._visibleEntitiesCache = null;
+    this._primaryYaxisEntitiesCache = null;
+    this._secondaryYaxisEntitiesCache = null;
+    this._visibleLegendsCache = null;
 
     // update datetime settings periodically
     this.updateHour24 = config.hour24 === undefined;

--- a/src/main.js
+++ b/src/main.js
@@ -925,7 +925,9 @@ class MiniGraphCard extends LitElement {
     if (!fill) return;
     const state = this.entity[index] !== undefined
       ? this.entity[index].state
-      : this.isStaticValue(index) ? this.config.entities[index].static_value : undefined;
+      : this.isStaticValue(index)
+        ? this.config.entities[index].static_value
+        : undefined;
     const svgFill = this.gradient[index]
       ? `url(#grad-${this.id}-${index})`
       : this.computeColor(state, index);

--- a/src/main.js
+++ b/src/main.js
@@ -206,6 +206,9 @@ class MiniGraphCard extends LitElement {
             this.config.logarithmic,
             false,
           ),
+          bar_spacing: this.config.bar_spacing,
+          bar_spacing_group: this.config.bar_spacing_group,
+          total_bars_in_group: this.visibleEntities.length,
         }),
       );
     }
@@ -1576,13 +1579,7 @@ class MiniGraphCard extends LitElement {
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
         if (config.show.graph === 'bar') {
-          const numVisible = this.visibleEntities.length;
-          this.bar[i] = this.Graph[i].getBars(
-            graphPos,
-            numVisible,
-            config.bar_spacing,
-            config.bar_spacing_group,
-          );
+          this.bar[i] = this.Graph[i].getBars(graphPos);
           graphPos += 1;
         } else {
           const line = this.Graph[i].getPath();

--- a/src/main.js
+++ b/src/main.js
@@ -793,7 +793,8 @@ class MiniGraphCard extends LitElement {
       || 'none';
     const lineWidth = getFirstDefinedItem(
       this.config.entities[index].line_width,
-      this.config.line_width);
+      this.config.line_width,
+    );
     const path = svg`
       <path
         class='line'

--- a/src/main.js
+++ b/src/main.js
@@ -747,6 +747,12 @@ class MiniGraphCard extends LitElement {
     /* eslint-enable indent */
   }
 
+  /**
+  * Renders a fill mask for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} fill Array of fill for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgFill(fill, index) {
     if (!fill) return;
     const fade = this.config.show.fill === 'fade';
@@ -773,6 +779,12 @@ class MiniGraphCard extends LitElement {
       </mask>`;
   }
 
+  /**
+  * Renders a line for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} line Array of lines for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgLine(line, index) {
     if (!line) return;
 
@@ -800,6 +812,12 @@ class MiniGraphCard extends LitElement {
     `;
   }
 
+  /**
+  * Renders a line point for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} point Point for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgPoint(point, index) {
     const color = this.gradient[index] ? this.computeColor(point[V], index) : 'inherit';
     return svg`
@@ -816,6 +834,12 @@ class MiniGraphCard extends LitElement {
     `;
   }
 
+  /**
+  * Renders points for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} points Array of points for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgPoints(points, index) {
     if (!points) return;
     const state = this.entity[index] !== undefined
@@ -850,6 +874,12 @@ class MiniGraphCard extends LitElement {
     return svg`${items}`;
   }
 
+  /**
+  * Renders a background rectangle for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} line Array of lines for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgLineRect(line, index) {
     if (!line) return;
     const state = this.entity[index] !== undefined
@@ -867,6 +897,12 @@ class MiniGraphCard extends LitElement {
       />`;
   }
 
+  /**
+  * Renders a background fill rectangle for a particular entity/static value
+  * @returns {SVGTemplateResult} SVG element
+  * @param {Array} fill Array of fill for a particular entity/static value
+  * @param {number} index Index of an entry in config.entities
+  */
   renderSvgFillRect(fill, index) {
     if (!fill) return;
     const state = this.entity[index] !== undefined
@@ -887,7 +923,7 @@ class MiniGraphCard extends LitElement {
   /**
   * Renders bars for a particular entity/static value
   * @returns {SVGTemplateResult} SVG element
-  * @param bars Array of bars for a particular entity/static value
+  * @param {Array} bars Array of bars for a particular entity/static value
   * @param {number} index Index of an entry in config.entities
   */
   renderSvgBars(bars, index) {
@@ -918,7 +954,7 @@ class MiniGraphCard extends LitElement {
   }
 
   /** Returns a rendered SVG part (fill, line, bars, points)
-   * in a direct or a reversed order
+  * in a direct or a reversed order
   * @returns {SVGTemplateResult[]} SVG part
   * @param {any[]} data Array of data to render an SVG part
   * @param {Function} renderFunc Function to render an SVG part

--- a/src/others.js
+++ b/src/others.js
@@ -11,7 +11,7 @@ const isNumeric = value => typeof value === 'number' && Number.isFinite(value);
 
 const getExponent = factor => 10 ** factor;
 
-const logValueFactor = factor_obj => log(`invalid value_factor: ${JSON.stringify(factor_obj)}`);
+const logValueFactor = factor_obj => log(`invalid value_factor: [${JSON.stringify(factor_obj)}]`);
 
 /**
   * Return a multiplying factor (exponental or scale) based on a "value_factor" option


### PR DESCRIPTION
1. Warnings in console: place logged values into brackets for clarity.
2. Warnings in console: log invalid datetime_format.
3. `getBars()`: add bars-related options into constructor instead of paasing them into `getBars()`.
4. `Graph` class: remove getter/setter for `logarithmic` property.
5. Move initialization of memoized arrays out of `set hass()` (that was a mistake to place them there in https://github.com/kalkih/mini-graph-card/pull/1397).
6. `renderSvg` methods: replace "i -> index" for consistency.
7. `renderSvg` methods: add JDoc descriptions.
8. `renderSvg` methods: minor optimization & styling fixes.