### PR TITLE
feat: add support of zeroline/baseline, bars with negative value

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -41,6 +41,11 @@ export default class Graph {
     this.margin = margin;
     this._max = 0;
     this._min = 0;
+    this._lmax = null;
+    this._lmin = null;
+    this._yRatio = null;
+    this._baseline = null;
+    this._bRatio = null;
     this.points = points; // stands for "points_per_hour"
     this.hours = hours; // stands for "hours_to_show"
     this.aggregateFuncName = aggregateFuncName;
@@ -57,11 +62,70 @@ export default class Graph {
 
   get max() { return this._max; }
 
-  set max(max) { this._max = max; }
+  set max(max) {
+    if (this._max !== max) {
+      this._max = max;
+      this._lmax = null;
+      this._yRatio = null;
+      this._baseline = null;
+      this._bRatio = null;
+    }
+  }
 
   get min() { return this._min; }
 
-  set min(min) { this._min = min; }
+  set min(min) {
+    if (this._min !== min) {
+      this._min = min;
+      this._lmin = null;
+      this._yRatio = null;
+      this._baseline = null;
+      this._bRatio = null;
+    }
+  }
+
+  get lmax() {
+    if (this._lmax === null) {
+      this._lmax = this.logarithmic ? Math.log10(Math.max(1, this.max)) : this.max;
+    }
+    return this._lmax;
+  }
+
+  get lmin() {
+    if (this._lmin === null) {
+      this._lmin = this.logarithmic ? Math.log10(Math.max(1, this.min)) : this.min;
+    }
+    return this._lmin;
+  }
+
+  get yRatio() {
+    if (this._yRatio === null) {
+      this._yRatio = ((this.lmax - this.lmin) / this.height) || 1;
+    }
+    return this._yRatio;
+  }
+
+  get baseline() {
+    if (this._baseline === null) {
+      let baseline;
+
+      // only positive values, positive and zero values, or only zero values
+      if (this.lmax >= 0 && this.lmin >= 0) baseline = this.height + this.margin[Y] * 4;
+      // only negative values, negative and zero values
+      else if (this.lmax <= 0) baseline = 0;
+      // positive and negative values (sign values)
+      else [[, baseline]] = this._calcY([[0, 0, 0]]);
+      this._baseline = baseline;
+    }
+    return this._baseline;
+  }
+
+  get bRatio() {
+    if (this._bRatio === null) {
+      this._bRatio = this.baseline / (this.height + this.margin[Y] * 4);
+    }
+    return this._bRatio;
+  }
 
   set history(data) { this._history = data; }
 
@@ -121,14 +185,9 @@ export default class Graph {
    * @returns Array of X, Y, Value, where Y - recalculated based on min/max thresholds
    */
   _calcY(coords) {
-    // account for logarithmic graph
-    const max = this.logarithmic ? Math.log10(Math.max(1, this.max)) : this.max;
-    const min = this.logarithmic ? Math.log10(Math.max(1, this.min)) : this.min;
-
-    const yRatio = ((max - min) / this.height) || 1;
     const coords2 = coords.map((coord) => {
       const val = this.logarithmic ? Math.log10(Math.max(1, coord[V])) : coord[V];
-      const coordY = this.height - ((val - min) / yRatio) + this.margin[Y] * 2;
+      const coordY = this.height - ((val - this.lmin) / this.yRatio) + this.margin[Y] * 2;
       return [coord[X], coordY, coord[V]];
     });
 
@@ -215,7 +274,7 @@ export default class Graph {
    * @returns SVG path for a fill
    */
   getFill(path) {
-    let height = this.height + this.margin[Y] * 4;
+    let height = this.baseline;
     if (this.fill_baseline !== undefined) {
       const [baselineCoord] = this._calcY([[0, 0, this.fill_baseline]]);
       [, height] = baselineCoord;
@@ -263,8 +322,8 @@ export default class Graph {
       x: this.margin[X]
         + (group_width + spacing_group) * i
         + (spacing === -1 ? 0 : (bar_width + spacing) * position),
-      y: coord[Y],
-      height: this.height - coord[Y] + this.margin[Y] * 4,
+      y: Math.min(this.baseline, coord[Y]),
+      height: Math.max(this.baseline, coord[Y]) - Math.min(this.baseline, coord[Y]),
       width: bar_width,
       value: coord[V],
     }));

--- a/src/graph.js
+++ b/src/graph.js
@@ -44,8 +44,8 @@ export default class Graph {
     this._lmax = null;
     this._lmin = null;
     this._yRatio = null;
-    this._baseline = null;
-    this._bRatio = null;
+    this._baselineCoordY = null;
+    this._baselineRatio = null;
     this.points = points; // stands for "points_per_hour"
     this.hours = hours; // stands for "hours_to_show"
     this.aggregateFuncName = aggregateFuncName;
@@ -67,8 +67,8 @@ export default class Graph {
       this._max = max;
       this._lmax = null;
       this._yRatio = null;
-      this._baseline = null;
-      this._bRatio = null;
+      this._baselineCoordY = null;
+      this._baselineRatio = null;
     }
   }
 
@@ -79,8 +79,8 @@ export default class Graph {
       this._min = min;
       this._lmin = null;
       this._yRatio = null;
-      this._baseline = null;
-      this._bRatio = null;
+      this._baselineCoordY = null;
+      this._baselineRatio = null;
     }
   }
 
@@ -105,26 +105,26 @@ export default class Graph {
     return this._yRatio;
   }
 
-  get baseline() {
-    if (this._baseline === null) {
-      let baseline;
+  get baselineCoordY() {
+    if (this._baselineCoordY === null) {
+      let baselineCoordY;
 
       // only positive values, positive and zero values, or only zero values
-      if (this.lmax >= 0 && this.lmin >= 0) baseline = this.height + this.margin[Y] * 4;
+      if (this.lmax >= 0 && this.lmin >= 0) baselineCoordY = this.height + this.margin[Y] * 4;
       // only negative values, negative and zero values
-      else if (this.lmax <= 0) baseline = 0;
+      else if (this.lmax <= 0) baselineCoordY = 0;
       // positive and negative values (sign values)
-      else [[, baseline]] = this._calcY([[0, 0, 0]]);
-      this._baseline = baseline;
+      else [[, baselineCoordY]] = this._calcY([[0, 0, 0]]);
+      this._baselineCoordY = baselineCoordY;
     }
-    return this._baseline;
+    return this._baselineCoordY;
   }
 
-  get bRatio() {
-    if (this._bRatio === null) {
-      this._bRatio = this.baseline / (this.height + this.margin[Y] * 4);
+  get baselineRatio() {
+    if (this._baselineRatio === null) {
+      this._baselineRatio = this.baselineCoordY / (this.height + this.margin[Y] * 4);
     }
-    return this._bRatio;
+    return this._baselineRatio;
   }
 
   set history(data) { this._history = data; }
@@ -274,7 +274,7 @@ export default class Graph {
    * @returns SVG path for a fill
    */
   getFill(path) {
-    let height = this.baseline;
+    let height = this.baselineCoordY;
     if (this.fill_baseline !== undefined) {
       const [baselineCoord] = this._calcY([[0, 0, this.fill_baseline]]);
       [, height] = baselineCoord;
@@ -322,8 +322,8 @@ export default class Graph {
       x: this.margin[X]
         + (group_width + spacing_group) * i
         + (spacing === -1 ? 0 : (bar_width + spacing) * position),
-      y: Math.min(this.baseline, coord[Y]),
-      height: Math.max(this.baseline, coord[Y]) - Math.min(this.baseline, coord[Y]),
+      y: Math.min(this.baselineCoordY, coord[Y]),
+      height: Math.max(this.baselineCoordY, coord[Y]) - Math.min(this.baselineCoordY, coord[Y]),
       width: bar_width,
       value: coord[V],
     }));

--- a/src/main.js
+++ b/src/main.js
@@ -759,11 +759,13 @@ class MiniGraphCard extends LitElement {
     if (!fill) return;
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
+    const { bRatio: offset } = this.Graph[index];
     return svg`
       <defs>
         <linearGradient id=${`fill-grad-${this.id}-${index}`} x1="0%" y1="0%" x2="0%" y2="100%">
           <stop stop-color='white' offset='0%' stop-opacity='1'/>
-          <stop stop-color='white' offset='100%' stop-opacity='.15'/>
+          <stop stop-color='white' offset='${offset * 100}%' stop-opacity='.15'/>
+          <stop stop-color='white' offset='100%' stop-opacity='1'/>
         </linearGradient>
         <mask id=${`fill-grad-mask-${this.id}-${index}`}>
           <rect width="100%" height="100%" fill=${`url(#fill-grad-${this.id}-${index})`} />

--- a/src/main.js
+++ b/src/main.js
@@ -759,7 +759,7 @@ class MiniGraphCard extends LitElement {
     if (!fill) return;
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
-    const { bRatio: offset } = this.Graph[index];
+    const { baselineRatio: offset } = this.Graph[index];
     return svg`
       <defs>
         <linearGradient id=${`fill-grad-${this.id}-${index}`} x1="0%" y1="0%" x2="0%" y2="100%">


### PR DESCRIPTION
Hi, this PR introduces a zero line (called baseline in code) which allows bars with negative values. The baseline is also the reference for the fill which is drawn in a line graph and for the gradient of the fill which now fades out to this baseline which is the zero line by default. To be honest the logarithmic option needs some testing.

Unfortunately, it overlaps a little bit with the merge of PR kalkih#1205. But with a small change you can also achieve the customization for the fill. 

Cached getters are used. These are only updated when there is a change for the bounds (min/max setters called by main.js). That affects also the _calcY function which is called multiple times.
Not sure about what is the best way to get values from Graph[i] from outside, by getter or defining a function which keeps all the data which are specific to the axis (max, min, baseline, yRatio, bRatio)

I tried to maintain the look of the bars.

- only zero values: (zero) line stays at the bottom. Margin (zero margin) at the bottom and the top
- only positive values, or positive and zero values. Margins at the top and bottom (zero margin).
- only negative values, or negative and zero values. Margins at the top (zero margin) and bottom.
- sign values (positive and negative values): Margins at the top and bottom. If there is a zero value no bar is drawn at the zeroline/baseline.

<img width="395" height="271" alt="image" src="https://github.com/user-attachments/assets/4b5d4252-ab4d-49c9-a6bf-4a4b78a68491" />
<img width="393" height="163" alt="image" src="https://github.com/user-attachments/assets/591b83a4-f397-4c3f-a04f-141e782b56c9" />
<img width="389" height="224" alt="image" src="https://github.com/user-attachments/assets/93b7cd1a-a8eb-4082-8774-cf10ecbcc838" />
