### PR TITLE
feat: Refactor alignment for header, name, icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | datetime_format | string | | v.0.14.0 | Set a custom [format](#custom-format-for-datetime-values) for datetime values.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
 | font_size_header | number | `14` | v0.3.1 | Adjust the font size of the header, size in pixels.
-| align_header | string |  | v0.2.0 | Set the alignment of the header, `left`, `right` or `center`. See more details [here](#alignment-for-name--icon-elements).
+| align_header | string |  | v0.2.0 | Set the alignment of the name in the header, `left`, `right` or `center`. See more details [here](#alignment-for-name--icon-elements).
 | align_icon | string | `right` | v0.2.0 | Set the alignment of the icon, `left`, `right` or `state`. See more details [here](#alignment-for-name--icon-elements).
 | align_state | string | `left` | v0.2.0 | Set the alignment of the current state, `left`, `right` or `center`.
 | lower_bound | number *or* string |  | v0.2.3 | Set a fixed lower bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | datetime_format | string | | v.0.14.0 | Set a custom [format](#custom-format-for-datetime-values) for datetime values.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
 | font_size_header | number | `14` | v0.3.1 | Adjust the font size of the header, size in pixels.
-| align_header | string | `default` | v0.2.0 | Set the alignment of the header, `left`, `right`, `center` or `default`.
-| align_icon | string | `right` | v0.2.0 | Set the alignment of the icon, `left`, `right` or `state`.
+| align_header | string |  | v0.2.0 | Set the alignment of the header, `left`, `right` or `center`. See more details [here](#alignment-for-name--icon-elements).
+| align_icon | string | `right` | v0.2.0 | Set the alignment of the icon, `left`, `right` or `state`. See more details [here](#alignment-for-name--icon-elements).
 | align_state | string | `left` | v0.2.0 | Set the alignment of the current state, `left`, `right` or `center`.
 | lower_bound | number *or* string |  | v0.2.3 | Set a fixed lower bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | upper_bound | number *or* string |  | v0.2.3 | Set a fixed upper bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
@@ -310,6 +310,20 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `sum` | v0.9.2 |
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
+
+### Alignment for "name" & "icon" elements
+
+Depending on the configuration, the "name" & "icon" elements are aligned as follows:
+
+1. If the icon is hidden (`show.icon: false`) & `align_header` is not defined — the "name" is aligned to the left.
+2. If the icon is hidden (`show.icon: false`) & `align_header` is defined — the "name" is aligned to the left/center/right depending on `align_header`.
+3. If the icon is shown (here and below) & both `align_header` and `align_icon` are not defined — the "name" is on the left, and the "icon" is on the right.
+4. If `align_header` is defined & the name is hidden (`show.name: false`) & `align_icon` is not defined — the "icon" is aligned to the right.
+5. If `align_header` is defined & the name is shown & `align_icon` is not defined — the "name" is aligned to the left/center/right depending on `align_header`, and the "icon" is placed on the left (if `align_header: right`) or on the right (if `align_header: left/center`).
+6. If both `align_header` & `align_icon` are defined — the "icon" is aligned to the left/right depending on `align_icon`, and the "name" is placed on the left (if `align_icon: right`), on the right (if `align_icon: left`), or in the center (if `align_header: center`), meaning `align_icon` takes precedence.
+7. If `align_header` is not defined & `align_icon` is defined — the "icon" is aligned to the left/right depending on `align_icon`, and the "name" is placed on the left (if `align_icon: right`) or on the right (if `align_icon: left`).
+
+
 
 ### Static lines
 

--- a/src/main.js
+++ b/src/main.js
@@ -368,14 +368,28 @@ class MiniGraphCard extends LitElement {
       show, align_icon, align_header, font_size_header,
     } = this.config;
     const showIcon = show.icon && align_icon !== 'state';
+
+    let iconLoc;
+    if (align_icon === undefined) {
+      iconLoc = align_header === 'right' && show.name
+        ? 'left'
+        : 'right';
+    } else {
+      iconLoc = align_icon;
+    }
+    const nameLoc = align_header === 'center'
+      ? 'center'
+      : iconLoc === 'left'
+        ? 'right'
+        : 'left';
+
     return show.name || showIcon
       ? html`
           <div
-            class="header flex"
-            loc="${align_header || 'left'}"
+            class="header"
             style="font-size: ${font_size_header}px;"
           >
-            ${show.name ? this.renderName() : html``}${showIcon ? this.renderIcon() : html``}
+            ${show.name ? this.renderName(nameLoc) : html``}${showIcon ? this.renderIcon(iconLoc) : html``}
           </div>
         `
       : html``;
@@ -383,12 +397,16 @@ class MiniGraphCard extends LitElement {
 
   /**
   * Renders an icon
+  * @param {string} iconLoc Location of an icon in a header (left/right)
   * @returns {TemplateResult} Lit template result
   */
-  renderIcon() {
+  renderIcon(iconLoc) {
     if (this.config.icon_image !== undefined) {
       return html`
-        <div class="icon">
+        <div
+          class="icon"
+          loc="${iconLoc}"
+        >
           <img src="${this.config.icon_image}" height="25"/>
         </div>
       `;
@@ -408,7 +426,7 @@ class MiniGraphCard extends LitElement {
     return html`
       <div
         class="icon"
-        loc="${this.config.align_icon}"
+        loc="${iconLoc}"
         style="${iconColor !== undefined ? `color: ${iconColor};` : ''}"
       >
         <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
@@ -418,9 +436,10 @@ class MiniGraphCard extends LitElement {
 
   /**
   * Renders a name
+  * @param {string} nameLoc Location of a name in a header (left/right/center)
   * @returns {TemplateResult} Lit template result
   */
-  renderName() {
+  renderName(nameLoc) {
     if (!this.config.show.name) {
       return html``;
     }
@@ -432,7 +451,10 @@ class MiniGraphCard extends LitElement {
       ? `opacity: 1; color: ${this.color};`
       : '';
     return html`
-      <div class="name flex">
+      <div
+        class="name"
+        loc="${nameLoc}"
+      >
         <span
           class="ellipsis"
           style="${color}"

--- a/src/main.js
+++ b/src/main.js
@@ -731,10 +731,7 @@ class MiniGraphCard extends LitElement {
 
     /* eslint-disable indent */
     return html`
-      <div
-        class="graph__static_value_labels"
-        loc="${this.config.show.static_value_labels}"
-      >
+      <div class="graph__static_value_labels">
         ${this.config.entities.map((_, index) => {
           if (!this.isStaticValue(index)
             || this.config.entities[index].show_static_value_label === false) {

--- a/src/main.js
+++ b/src/main.js
@@ -731,7 +731,10 @@ class MiniGraphCard extends LitElement {
 
     /* eslint-disable indent */
     return html`
-      <div class="graph__static_value_labels">
+      <div
+        class="graph__static_value_labels"
+        loc="${this.config.show.static_value_labels}"
+      >
         ${this.config.entities.map((_, index) => {
           if (!this.isStaticValue(index)
             || this.config.entities[index].show_static_value_label === false) {

--- a/src/style.js
+++ b/src/style.js
@@ -71,21 +71,38 @@ const style = css`
     min-width: 0;
   }
   .header {
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-rows: 1fr;
+    align-items: center;
+    width: 100%;
+    box-sizing: border-box;
   }
-  .header[loc="center"] {
-    justify-content: space-around;
-  }
-  .header[loc="left"] {
-    align-self: flex-start;
-  }
-  .header[loc="right"] {
-    align-self: flex-end;
+  .header > * {
+    grid-row: 1;
   }
   .name {
-    align-items: center;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     min-width: 0;
+    width: 100%;
     letter-spacing: var(--mcg-title-letter-spacing, normal);
+    overflow: hidden;
+  }
+  .name[loc="left"] {
+    grid-column: 1 / 3;
+    justify-self: start;
+    text-align: left;
+  }
+  .name[loc="center"] {
+    grid-column: 1 / 4;
+    justify-self: center;
+    text-align: center;
+  }
+  .name[loc="right"]  {
+    grid-column: 2 / 4;
+    justify-self: end;
+    text-align: right;
   }
   .name > span {
     font-size: 1.2em;
@@ -96,21 +113,18 @@ const style = css`
   }
   .icon {
     color: var(--state-icon-color, #44739e);
-    display: inline-block;
-    flex: 0 0 1.7em;
-    text-align: center;
   }
   .icon > ha-icon {
     height: 1.7em;
     width: 1.7em;
   }
   .icon[loc="left"] {
-    order: -1;
-    margin-right: .6em;
-    margin-left: 0;
+    grid-column: 1;
+    justify-self: start;
   }
   .icon[loc="right"] {
-    margin-left: auto;
+    grid-column: 3;
+    justify-self: end;
   }
   .icon[loc="state"] {
     align-self: center;


### PR DESCRIPTION
We have `align_header` & `align_icon`.
Unfortunately, these options may give a confusing result.

Consider this example:
```
type: custom:mini-graph-card
entities:
  - entity: sensor.system_monitor_processor_use
align_header: center
```
<img width="479" height="220" alt="image" src="https://github.com/user-attachments/assets/e423f268-24e0-47a1-b683-aa0444f667db" />

Note that here a "header" is treated as "name AND icon".
And in Docs it is said:
<img width="849" height="132" alt="image" src="https://github.com/user-attachments/assets/9b81723a-7e29-49ad-a09a-cc70994fc6ad" />

Where the possible confusion is?
From another point of view, the "header" is just a "name". Note that the "icon" element may be placed near a "state" element - thus OUTSIDE the "header".
Means - very imho - the "header" should refer to the "name" element only, and the `align_header` option should also define an alignment for the "name" only.

This PR proposes the following changes:
1. The "header" stands for the "name" element only.
2. The `align_header` option now defines an alignment for the "name" element only.
3. The `align_header` option is NOT renamed to `align_name` (can be revised in future based on a real user experience & feedback).

How `align_header` & `align_icon` are related?
(note - this description was provided for "left-to-right" locales; for RTL there could be differences, but in fact the card is not adapted for RTL yet)
1. If the icon is hidden (`show.icon: false`) & `align_header` is not defined — the "name" is aligned to the left.
2. If the icon is hidden (`show.icon: false`) & `align_header` is defined — the "name" is aligned to the left/center/right depending on `align_header`.
3. If the icon is shown (here and below) & both `align_header` and `align_icon` are not defined — the "name" is on the left, and the "icon" is on the right.
4. If `align_header` is defined & the name is hidden (`show.name: false`) & `align_icon` is not defined — the "icon" is aligned to the right.
5. If `align_header` is defined & the name is shown & `align_icon` is not defined — the "name" is aligned to the left/center/right depending on `align_header`, and the "icon" is placed on the left (if `align_header: right`) or on the right (if `align_header: left/center`).
6. If both `align_header` & `align_icon` are defined — the "icon" is aligned to the left/right depending on `align_icon`, and the "name" is placed on the left (if `align_icon: right`), on the right (if `align_icon: left`), or in the center (if `align_header: center`), meaning `align_icon` takes precedence.
7. If `align_header` is not defined & `align_icon` is defined — the "icon" is aligned to the left/right depending on `align_icon`, and the "name" is placed on the left (if `align_icon: right`) or on the right (if `align_icon: left`).