### PR TITLE
fix: Check numeric values - allow strings

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -193,6 +193,7 @@ export default (config) => {
   conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, undefined, undefined, true);
 
   // process per-entity configs
+  // eslint-disable-next-line no-param-reassign
   conf.entities.forEach((entity, i) => {
     if (typeof entity === 'string') {
       conf.entities[i] = { entity };

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -155,41 +155,27 @@ export default (config) => {
     show: { ...DEFAULT_SHOW, ...config.show },
   };
 
-  conf.entities.forEach((entity, i) => {
-    if (typeof entity === 'string') {
-      conf.entities[i] = { entity };
-    } else if (entity.color_thresholds) {
-      // eslint-disable-next-line no-param-reassign
-      entity.color_thresholds = computeThresholds(
-        entity.color_thresholds,
-        entity.color_thresholds_transition || conf.color_thresholds_transition,
-      );
-    }
-  });
-
   // check numeric options for validity
-  conf.font_size = checkNumericOption(conf, 'font_size', 100, 0.1);
-  conf.font_size_header = checkNumericOption(conf, 'font_size_header', DEFAULT_FONT_SIZE_HEADER, 0.1);
+  conf.font_size = checkNumericOption(conf, 'font_size', 100, 0.1, undefined, true);
+  conf.font_size_header = checkNumericOption(conf, 'font_size_header', DEFAULT_FONT_SIZE_HEADER, 0.1, undefined, true);
 
-  conf.bar_spacing = checkNumericOption(conf, 'bar_spacing', DEFAULT_BAR_SPACING, -1);
-  conf.bar_spacing_group = checkNumericOption(conf, 'bar_spacing_group', undefined, 0);
+  conf.bar_spacing = checkNumericOption(conf, 'bar_spacing', DEFAULT_BAR_SPACING, -1, undefined, true);
+  conf.bar_spacing_group = checkNumericOption(conf, 'bar_spacing_group', undefined, 0, undefined, true);
 
-  conf.height = checkNumericOption(conf, 'height', DEFAULT_GRAPH_HEIGHT, 0);
+  conf.height = checkNumericOption(conf, 'height', DEFAULT_GRAPH_HEIGHT, 0, undefined, true);
 
-  // per-entity options are not checked here
-  conf.line_width = checkNumericOption(conf, 'line_width', DEFAULT_MARGIN, 0);
+  conf.line_width = checkNumericOption(conf, 'line_width', DEFAULT_MARGIN, 0, undefined, true);
 
-  conf.hours_to_show = checkNumericOption(conf, 'hours_to_show', DEFAULT_HOURS_TO_SHOW, 0.01);
-  conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, 0.001);
-  conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, 0);
+  conf.hours_to_show = checkNumericOption(conf, 'hours_to_show', DEFAULT_HOURS_TO_SHOW, 0.01, undefined, true);
+  conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, 0.001, undefined, true);
+  conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, 0, undefined, true);
 
-  conf.min_bound_range = checkNumericOption(conf, 'min_bound_range', undefined, 0);
-  conf.min_bound_range_secondary = checkNumericOption(conf, 'min_bound_range_secondary', undefined, 0);
+  conf.min_bound_range = checkNumericOption(conf, 'min_bound_range', undefined, 0, undefined, true);
+  conf.min_bound_range_secondary = checkNumericOption(conf, 'min_bound_range_secondary', undefined, 0, undefined, true);
 
-  conf.decimals_primary_labels = checkIntegerOption(conf, 'decimals_primary_labels', undefined, 0);
-  conf.decimals_secondary_labels = checkIntegerOption(conf, 'decimals_secondary_labels', undefined, 0);
-  // per-entity options are not checked here
-  conf.decimals = checkIntegerOption(conf, 'decimals', undefined, 0);
+  conf.decimals_primary_labels = checkIntegerOption(conf, 'decimals_primary_labels', undefined, 0, undefined, true);
+  conf.decimals_secondary_labels = checkIntegerOption(conf, 'decimals_secondary_labels', undefined, 0, undefined, true);
+  conf.decimals = checkIntegerOption(conf, 'decimals', undefined, 0, undefined, true);
 
   conf.static_value_label_offset = checkNumericOption(
     conf,
@@ -197,13 +183,34 @@ export default (config) => {
     DEFAULT_STATIC_VALUE_LABEL_OFFSET,
     0,
     100,
+    true,
   );
   if (conf.static_value_label_offset === undefined
     || conf.static_value_label_offset === null) {
     conf.static_value_label_offset = DEFAULT_STATIC_VALUE_LABEL_OFFSET;
   }
 
-  conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined);
+  conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, undefined, undefined, true);
+
+  // process per-entity configs
+  conf.entities.forEach((entity, i) => {
+    if (typeof entity === 'string') {
+      conf.entities[i] = { entity };
+    } else {
+      // check numeric per-entity options for validity
+      entity.line_width = checkNumericOption(entity, 'line_width', conf.line_width, 0, undefined, true);
+      entity.decimals = checkIntegerOption(entity, 'decimals', conf.decimals, 0, undefined, true);
+      entity.fill_baseline = checkNumericOption(entity, 'fill_baseline', undefined, undefined, undefined, true);
+
+      if (entity.color_thresholds) {
+        // eslint-disable-next-line no-param-reassign
+        entity.color_thresholds = computeThresholds(
+          entity.color_thresholds,
+          entity.color_thresholds_transition || conf.color_thresholds_transition,
+        );
+      }
+    }
+  });
 
   conf.state_map.forEach((state, i) => {
     // convert string values to objects

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -193,7 +193,7 @@ export default (config) => {
   conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, undefined, undefined, true);
 
   // process per-entity configs
-  // eslint-disable-next-line no-param-reassign
+  /* eslint-disable no-param-reassign */
   conf.entities.forEach((entity, i) => {
     if (typeof entity === 'string') {
       conf.entities[i] = { entity };
@@ -212,6 +212,7 @@ export default (config) => {
       }
     }
   });
+  /* eslint-enable no-param-reassign */
 
   conf.state_map.forEach((state, i) => {
     // convert string values to objects

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -9,6 +9,7 @@ import { isNumeric } from './others';
  * @param {number} defaultValue Default fallback value
  * @param {number} minBound Optional minimum allowed value
  * @param {number} maxBound Optional maximum allowed value
+ * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
  * @returns {number} Cleared value
  */
 const checkNumericOption = (
@@ -17,6 +18,7 @@ const checkNumericOption = (
   defaultValue,
   minBound = undefined,
   maxBound = undefined,
+  allowString = false,
 ) => {
   const value = config[option];
 
@@ -24,11 +26,16 @@ const checkNumericOption = (
     return undefined;
   }
 
-  if (isNumeric(value)) {
-    const isMinValid = minBound === undefined || value >= minBound;
-    const isMaxValid = maxBound === undefined || value <= maxBound;
+  if (isNumeric(value, allowString)) {
+    if (typeof value === 'string') {
+      log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
+    }
+
+    const valueNumeric = Number(value);
+    const isMinValid = minBound === undefined || valueNumeric >= minBound;
+    const isMaxValid = maxBound === undefined || valueNumeric <= maxBound;
     if (isMinValid && isMaxValid) {
-      return value;
+      return valueNumeric; // return type 'number'
     }
   }
 
@@ -37,10 +44,11 @@ const checkNumericOption = (
     ? JSON.stringify(value)
     : value;
   let errorDescr = 'not a numeric value';
-  if (isNumeric(value)) {
-    if (minBound !== undefined && value < minBound) {
+  if (isNumeric(value, allowString)) {
+    const valueNumeric = Number(value);
+    if (minBound !== undefined && valueNumeric < minBound) {
       errorDescr = `out of bounds, minimum allowed: ${minBound}`;
-    } else if (maxBound !== undefined && value > maxBound) {
+    } else if (maxBound !== undefined && valueNumeric > maxBound) {
       errorDescr = `out of bounds, maximum allowed: ${maxBound}`;
     }
   }
@@ -57,6 +65,7 @@ const checkNumericOption = (
  * @param {number} defaultValue Default fallback value
  * @param {number} minBound Optional minimum allowed value
  * @param {number} maxBound Optional maximum allowed value
+ * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
  * @returns {number} Cleared value
  */
 const checkIntegerOption = (
@@ -65,8 +74,9 @@ const checkIntegerOption = (
   defaultValue,
   minBound = undefined,
   maxBound = undefined,
+  allowString = false,
 ) => {
-  const value = checkNumericOption(config, option, defaultValue, minBound, maxBound);
+  const value = checkNumericOption(config, option, defaultValue, minBound, maxBound, allowString);
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value) + 0; // prevent "-0" value
     log(`Invalid integer option ${option}: [${value}]; rounding value to ${roundedValue}`);

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -9,7 +9,8 @@ import { isNumeric } from './others';
  * @param {number} defaultValue Default fallback value
  * @param {number} minBound Optional minimum allowed value
  * @param {number} maxBound Optional maximum allowed value
- * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
+ * @param {boolean} [allowString=false] Optional flag
+ * to allow string representations of numbers (like "123")
  * @returns {number} Cleared value
  */
 const checkNumericOption = (
@@ -65,7 +66,8 @@ const checkNumericOption = (
  * @param {number} defaultValue Default fallback value
  * @param {number} minBound Optional minimum allowed value
  * @param {number} maxBound Optional maximum allowed value
- * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
+ * @param {boolean} [allowString=false] Optional flag
+ * to allow string representations of numbers (like "123")
  * @returns {number} Cleared value
  */
 const checkIntegerOption = (

--- a/src/others.js
+++ b/src/others.js
@@ -10,9 +10,25 @@ import { log } from './utils';
 /**
   * Check if a value is a valid number
   * @param {any} value Value to be checked
+  * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
   * @returns {boolean} True if value is a valid number, false - otherwise
   */
-const isNumeric = value => typeof value === 'number' && Number.isFinite(value);
+const isNumeric = (value, allowString = false) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return true;
+  }
+  if (allowString && typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      // empty string
+      return false;
+    }
+    // try to convert a string to a number
+    const num = Number(trimmed);
+    return Number.isFinite(num);
+  }
+  return false;
+};
 
 const getExponent = factor => 10 ** factor;
 

--- a/src/others.js
+++ b/src/others.js
@@ -10,7 +10,8 @@ import { log } from './utils';
 /**
   * Check if a value is a valid number
   * @param {any} value Value to be checked
-  * @param {boolean} [allowString=false] Optional flag to allow string representations of numbers (like "123")
+  * @param {boolean} [allowString=false] Optional flag
+  * to allow string representations of numbers (like "123")
   * @returns {boolean} True if value is a valid number, false - otherwise
   */
 const isNumeric = (value, allowString = false) => {

--- a/src/others.js
+++ b/src/others.js
@@ -76,24 +76,24 @@ const getFactor = (config, index = undefined) => {
   if (typeof value_factor === 'object') {
     const { type, factor } = value_factor;
     if (type === undefined || factor === undefined
-      || typeof type !== 'string' || !isNumeric(factor)) {
+      || typeof type !== 'string' || !isNumeric(factor, true)) {
       // invalid options, fallback to a default factor
       logValueFactor(value_factor);
       return 1;
     }
     if (type === 'exponent') {
-      return getExponent(factor);
+      return getExponent(Number(factor));
     } else if (type === 'scale') {
-      return factor;
+      return Number(factor);
     }
     // invalid 'type' option
     logValueFactor(value_factor);
     return 1;
   }
 
-  if (isNumeric(value_factor)) {
+  if (isNumeric(value_factor, true)) {
     // use a legacy "exponent" way
-    return getExponent(value_factor);
+    return getExponent(Number(value_factor));
   }
 
   logValueFactor(value_factor);

--- a/tests/checkNumericOption.test.ts.dis
+++ b/tests/checkNumericOption.test.ts.dis
@@ -97,9 +97,21 @@ const VARIANTS: any[] = [
     expectedValue: DEFAULT,
   },
   {
+    value: '123',
+    defaultValue: DEFAULT,
+    expectedValue: 123,
+    allowString: true,
+  },
+  {
     value: '-123',
     defaultValue: DEFAULT,
     expectedValue: DEFAULT,
+  },
+  {
+    value: '-123',
+    defaultValue: DEFAULT,
+    expectedValue: -123,
+    allowString: true,
   },
   {
     value: '123.456',
@@ -107,9 +119,21 @@ const VARIANTS: any[] = [
     expectedValue: DEFAULT,
   },
   {
+    value: '123.456',
+    defaultValue: DEFAULT,
+    expectedValue: 123.456,
+    allowString: true,
+  },
+  {
     value: '-123.456',
     defaultValue: DEFAULT,
     expectedValue: DEFAULT,
+  },
+  {
+    value: '-123.456',
+    defaultValue: DEFAULT,
+    expectedValue: -123.456,
+    allowString: true,
   },
   {
     value: '123,456',
@@ -149,9 +173,9 @@ describe("checkNumericOption, checkIntegerOption", () => {
           some_option: variant.value,
         };
 
-        const isValueNumeric = isNumeric(variant.value);
+        const isValueNumeric = isNumeric(variant.value, variant.allowString);
         const valueNumber = isValueNumeric
-          ? variant.value as number
+          ? Number(variant.value)
           : 0;
         const valueBigger = isValueNumeric
           ? valueNumber + 1
@@ -166,9 +190,8 @@ describe("checkNumericOption, checkIntegerOption", () => {
           ? valueNumber - 2
           : HUGE_NEGATIVE;
 
-        // let expectedValue = option === OPTION_NON_EXISTING
-        //   ? undefined
-        //   : variant.expectedValue;
+        const allowStringNote = variant.allowString
+          ? ' (allowString)' : '';
 
         let expectedValue = option === OPTION_NON_EXISTING
           ? undefined
@@ -178,11 +201,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
                 : Math.round(variant.expectedValue) + 0 // prevent "-0" value
               : variant.expectedValue;
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}] (no min/maxBound)`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}] (no min/maxBound)${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
+            undefined,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -190,12 +216,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
         ///////////////////////////////////////
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound undefined`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound undefined${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -203,13 +231,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound undefined`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound undefined${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
             undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -217,12 +246,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
         ///////////////////////////////////////
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = HUGE_NEGATIVE`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = HUGE_NEGATIVE${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             HUGE_NEGATIVE,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -230,13 +261,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = HUGE_POSITIVE`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = HUGE_POSITIVE${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
             HUGE_POSITIVE,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -244,13 +276,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = HUGE_*`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = HUGE_*${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             HUGE_NEGATIVE,
             HUGE_POSITIVE,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -260,12 +293,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
 
         ///////////////////////////////////////
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = option's value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = option's value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueNumber,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -273,13 +308,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = option's value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = option's value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
             valueNumber,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -287,13 +323,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = option's value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = option's value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueNumber,
             valueNumber,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -301,12 +338,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
         ///////////////////////////////////////
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueSmaller,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -314,13 +353,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = some bigger value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = some bigger value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
             valueBigger,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -328,13 +368,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value, maxBound = option's value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value, maxBound = option's value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueSmaller,
             valueNumber,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -342,13 +383,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = option's value, maxBound = some bigger value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = option's value, maxBound = some bigger value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueNumber,
             valueBigger,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -356,13 +398,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value, maxBound = some bigger value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some smaller value, maxBound = some bigger value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueSmaller,
             valueBigger,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -376,12 +419,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
             ? undefined
             : DEFAULT;
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some bigger value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], minBound = some bigger value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueBigger,
+            undefined,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -389,13 +434,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = some bigger value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = some bigger value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueBigger,
             valueMuchBigger,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -403,13 +449,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = some smaller value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], maxBound = some smaller value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             undefined,
             valueSmaller,
+            variant.allowString,
           );
           assert.strictEqual(
             result,
@@ -417,13 +464,14 @@ describe("checkNumericOption, checkIntegerOption", () => {
           );
         });
 
-        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = some smaller value`, () => {
+        it(`${functionName}: test global config [${LOG_VALUE(variant.value)}], min/maxBound = some smaller value${allowStringNote}`, () => {
           const result = checkFunction(
             config,
             option,
             variant.defaultValue,
             valueMuchSmaller,
             valueSmaller,
+            variant.allowString,
           );
           assert.strictEqual(
             result,

--- a/tests/getFactor.test.ts.dis
+++ b/tests/getFactor.test.ts.dis
@@ -45,9 +45,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value;
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits adter a point
       );
     });
 
@@ -58,9 +59,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits adter a point
       );
     });
 
@@ -70,9 +72,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -81,9 +84,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -96,9 +100,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -109,9 +114,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -122,9 +128,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, -1);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -139,9 +146,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 0);
       const expectedValue = value;  // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -156,9 +164,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 1);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -168,9 +177,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -179,9 +189,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -196,9 +207,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -214,9 +226,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 0);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -232,9 +245,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 1);
       const expectedValue = value;
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -251,9 +265,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 1);
       const expectedValue = value * (10 ** exponent_secondary);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -268,9 +283,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 1);
       const expectedValue = value;
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -287,9 +303,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config, 1);
       const expectedValue = value;
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -306,9 +323,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value * (10 ** exponent);
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -322,9 +340,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value * scale;
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -340,9 +359,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -354,9 +374,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -369,9 +390,26 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`getFactor [value: ${value}]: value_factor: value_factor = object, exponent = string`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'exponent',
+          factor: '-2',
+        },
+      };
+      const result = value * getFactor(config);
+      const expectedValue = value * (10 ** Number(config.value_factor.factor));
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -383,9 +421,26 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`getFactor [value: ${value}]: value_factor: value_factor = object, scale = string`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'scale',
+          factor: '123',
+        },
+      };
+      const result = value * getFactor(config);
+      const expectedValue = value * Number(config.value_factor.factor);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -398,9 +453,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 
@@ -412,9 +468,10 @@ describe("getFactor", () => {
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "exponent = 1"
-      assert.strictEqual(
+      assert.closeTo(
         result,
         expectedValue,
+        6, // number of digits after a point
       );
     });
 

--- a/tests/isNumeric.test.ts.dis
+++ b/tests/isNumeric.test.ts.dis
@@ -27,7 +27,16 @@ const NUMBERS_AS_STRINGS: string[] = [
   '2.3',
   '5',
   '1234567890',
-  '1234.567',
+  //////////////
+  ' 1234.567 ',
+  '-200.1  ',
+  '  -1.002345',
+  '0  ',
+  '    0.000000003',
+  '2.3    ',
+  ' 5  ',
+  '   1234567890  ',
+  ' 1234.567 ',
 ];
 
 const NUMBERS_AS_STRINGS_WITH_WRONG_DELIMITER: string[] = [
@@ -43,6 +52,9 @@ const STRINGS: string[] = [
   'abc123',
   'abc',
   '@#123%^&',
+  '',
+  ' ',
+  '  ',
 ];
 
 const OBJECTS: any[] = [
@@ -73,6 +85,17 @@ describe("isNumeric", () => {
     });
   });
 
+  NUMBERS_AS_STRINGS.forEach((value) => {
+    it(`isNumeric: check a string presentation of a number [${value}] with allowString=true`, () => {
+      const result = isNumeric(value, true);
+      const expectedValue = true;
+      assert.strictEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
   NUMBERS_AS_STRINGS_WITH_WRONG_DELIMITER.forEach((value) => {
     it(`isNumeric: check a string presentation of a number with a wrong delimiter [${value}]`, () => {
       const result = isNumeric(value);
@@ -84,9 +107,31 @@ describe("isNumeric", () => {
     });
   });
 
+  NUMBERS_AS_STRINGS_WITH_WRONG_DELIMITER.forEach((value) => {
+    it(`isNumeric: check a string presentation of a number with a wrong delimiter [${value}] with allowString=true`, () => {
+      const result = isNumeric(value, true);
+      const expectedValue = false;
+      assert.strictEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
   STRINGS.forEach((value) => {
     it(`isNumeric: check an obvious string [${value}]`, () => {
       const result = isNumeric(value);
+      const expectedValue = false;
+      assert.strictEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  STRINGS.forEach((value) => {
+    it(`isNumeric: check an obvious string [${value}] with allowString=true`, () => {
+      const result = isNumeric(value, true);
       const expectedValue = false;
       assert.strictEqual(
         result,


### PR DESCRIPTION
There is a chance that an option expecting a numeric value will get a string value:
```
some_option: '123'
```
instead of
```
some_option: 123
```
For some options, it MAY NOT cause a wrong result since a string value may be automatically converted to a number.
But in cases like `value + 1` where a `value` is a string instead of a number - there will be an error.

The best way - oblige a user to always input the proper `123` value.
But when the card is used inside some custom templates-supporting cards (like config-template-card, auto-entities), a templated value could be generated as a string (as a result of some inadvertence).

This PR includes:
1. `isNumeric()` (the basic way to check if a value is a number) now support `allowString` optional parameter to treat values like `"123"` as numeric.
2. Corresponding tests are added for `isNumeric()`.
3. `checkNumericOption()`, `checkIntegerOption()` (basic functions for checking options' values in `setConfig()`) - the `allowString` parameter is added.
4. Corresponding tests are added for `checkNumericOption()`, `checkIntegerOption()` .
5. `buildConfig()` (called from `setConfig()`) - calls of  `checkNumericOption()`, `checkIntegerOption()` are upgraded accounting the `allowString` parameter. Means - if an option initially has a string value like `"123"` then this option gets a valid number value `123` (along with a warning in a browser console suggesting a user to review a config value).
6. (unrelated) `buildConfig()` - checks for per-entity options `line_width`, `decimals` & `fill_baseline` are added.
7. `getFactor` (processing of a `value_factor` option) - support of `allowString` parameter is added.
8. Corresponding tests are added for `getFactor()`.

So, in short:
if a user inputs a string value `"123"` instead of a number `123`:
-- the option gets a valid number value `123`;
-- a warning is sent to a browser console suggesting a user to review a config value.