### PR TITLE
fix: getFactor() optimization

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -14,6 +14,7 @@ import {
 } from './const';
 import { log } from './utils';
 import { checkNumericOption, checkIntegerOption } from './checkOption';
+import { getFactor } from './others';
 
 /**
  * Starting from the given index, increment the index until an array element with a
@@ -214,6 +215,13 @@ export default (config) => {
   });
   /* eslint-enable no-param-reassign */
 
+  // prepare predefined factors
+  const entityFactors = conf.entities.map((_, index) => getFactor(conf, index));
+  const axisFactors = {
+    primary: getFactor(conf),
+    secondary: getFactor(conf, -1),
+  };
+
   conf.state_map.forEach((state, i) => {
     // convert string values to objects
     if (typeof state === 'string') conf.state_map[i] = { value: state, label: state };
@@ -258,5 +266,9 @@ export default (config) => {
     }
   }
 
-  return conf;
+  return {
+    config: conf,
+    entityFactors,
+    axisFactors,
+  };
 };

--- a/src/main.js
+++ b/src/main.js
@@ -25,10 +25,7 @@ import {
   DEFAULT_MARGIN,
   NBSP,
 } from './const';
-import {
-  getFactor,
-  isNumeric,
-} from './others';
+import { isNumeric } from './others';
 import {
   getMin, getAvg, getMax,
   getMilli,
@@ -161,7 +158,12 @@ class MiniGraphCard extends LitElement {
   }
 
   setConfig(config) {
-    this.config = buildConfig(config);
+    ({
+      config: this.config,
+      entityFactors: this.entityFactors, // predefined factors
+      axisFactors: this.axisFactors, // predefined factors
+    } = buildConfig(config));
+
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
 
@@ -1409,7 +1411,11 @@ class MiniGraphCard extends LitElement {
       // as is presented as a number
       state = Number(inState);
     }
-    const factor = getFactor(this.config, index);
+    const factor = index === undefined
+      ? this.axisFactors.primary
+      : index === -1
+        ? this.axisFactors.secondary
+        : this.entityFactors[index];
     // safely process with a factor
     state = Number.isNaN(Number(state)) ? state : state * factor;
 


### PR DESCRIPTION
Currently `getFactor()` is called in every run of `computeState()`.
This was optimized - factors are predefined in `setConfig()` and then used.