### PR TITLE
feat: Check lower/upper bounds in buildConfig()

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -13,7 +13,11 @@ import {
   DEFAULT_SHOW,
 } from './const';
 import { log } from './utils';
-import { checkNumericOption, checkIntegerOption } from './checkOption';
+import {
+  checkNumericOption,
+  checkIntegerOption,
+  checkBounds,
+} from './checkOption';
 import { getFactor } from './others';
 
 /**
@@ -170,6 +174,8 @@ export default (config) => {
   conf.hours_to_show = checkNumericOption(conf, 'hours_to_show', DEFAULT_HOURS_TO_SHOW, 0.01, undefined, true);
   conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, 0.001, undefined, true);
   conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, 0, undefined, true);
+
+  ({ lowerBound: conf.lower_bound, upperBound: conf.upper_bound } = checkBounds(conf));
 
   conf.min_bound_range = checkNumericOption(conf, 'min_bound_range', undefined, 0, undefined, true);
   conf.min_bound_range_secondary = checkNumericOption(conf, 'min_bound_range_secondary', undefined, 0, undefined, true);

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -123,7 +123,8 @@ const checkBoundOption = (config, option) => {
 /**
  * Check both upper/lower bounds for valid values
  * @param {object} config Config object
- * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Cleared bounds
+ * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Cleared
+ * bounds
  */
 const checkBounds = (config) => {
   const lowerBound = checkBoundOption(config, 'lower_bound');

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -123,7 +123,7 @@ const checkBoundOption = (config, option) => {
 /**
  * Check both upper/lower bounds for valid values
  * @param {object} config Config object
- * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Processed bounds
+ * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Cleared bounds
  */
 const checkBounds = (config) => {
   const lowerBound = checkBoundOption(config, 'lower_bound');

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -1,5 +1,5 @@
 import { log } from './utils';
-import { isNumeric } from './others';
+import { isNumeric, getBound } from './others';
 
 /**
  * Check if an option is numeric (if not undefined);
@@ -87,7 +87,69 @@ const checkIntegerOption = (
   return value;
 };
 
+/**
+ * "Check if a bound option is valid (accounting for an optional "~" prefix).
+ * @param {object} config Config object
+ * @param {string} option Name of the option to be checked
+ * @returns {number|string|undefined} Cleared value in its original format, or undefined
+ */
+const checkBoundOption = (config, option) => {
+  const value = config[option];
+
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'string') {
+    const parsed = getBound(value);
+    if (parsed !== undefined && isNumeric(parsed.value)) {
+      if (!parsed.soft && typeof value === 'string') {
+        log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
+      }
+
+      const cfg = { [option]: parsed.value };
+      if (checkNumericOption(cfg, option, undefined) !== undefined) {
+        return parsed.soft ? value : parsed.value;
+      }
+    }
+  }
+
+  // invalid type or value of the option
+  const invalidValue = typeof value === 'object' ? JSON.stringify(value) : value;
+  log(`Invalid option ${option}: [${invalidValue}] (not a numeric value); adjusting value to undefined`);
+  return undefined;
+};
+
+/**
+ * Check both upper/lower bounds for valid values
+ * @param {object} config Config object
+ * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Processed bounds
+ */
+const checkBounds = (config) => {
+  const lowerBound = checkBoundOption(config, 'lower_bound');
+  let upperBound = checkNumericOption(
+    config,
+    'upper_bound',
+    undefined,
+    undefined,
+    undefined,
+    true, // allowString
+  );
+
+  if (lowerBound !== undefined && upperBound !== undefined) {
+    const cleanLowerBount = getBound(lowerBound).value;
+    if (upperBound <= cleanLowerBount) {
+      log(`Invalid lower & upper bounds: [${lowerBound}, ${upperBound}]; unsetting value of upper_bound to undefined`);
+      upperBound = undefined;
+    }
+  }
+
+  return { lowerBound, upperBound };
+};
+
 export {
   checkNumericOption,
   checkIntegerOption,
+  checkBoundOption,
+  checkBounds,
 };

--- a/src/others.js
+++ b/src/others.js
@@ -102,7 +102,41 @@ const getFactor = (config, index = undefined) => {
   return 1;
 };
 
+/**
+  * Parse a bound value accounting for an optional "~" prefix.
+  * @param {number|string} bound Bound with a possible "~" prefix
+  * @returns {{value: number, soft: boolean}|undefined} Parsed value
+  */
+const getBound = (bound) => {
+  if (bound === undefined || bound === null || typeof bound === 'object') {
+    return undefined;
+  }
+
+  const strBound = String(bound).trim();
+  if (strBound.startsWith('~')) {
+    // soft bound
+    const value = strBound.slice(1);
+    if (isNumeric(value, true)) {
+      return {
+        value: Number(value),
+        soft: true,
+      };
+    }
+    return undefined;
+  }
+
+  // fixed bound
+  if (isNumeric(strBound, true)) {
+    return {
+      value: Number(strBound),
+      soft: false,
+    };
+  }
+  return undefined;
+};
+
 export {
   isNumeric,
   getFactor,
+  getBound,
 };

--- a/tests/checkBounds.test.ts.dis
+++ b/tests/checkBounds.test.ts.dis
@@ -1,0 +1,111 @@
+/**
+ * Tests for checkBounds().
+ *
+ * The file is disabled (renamed to *.dis) & thus is not used during a build process;
+ * remove the "dis" extension to use it locally in your VSCode devcontainer.
+ */
+
+import { assert, describe, it } from 'vitest';
+import { checkBounds } from '../checkOption';
+
+interface ConfigType {
+  lower_bound?: number | string | any;
+  upper_bound?: number | any;
+};
+
+const VARIANTS: any[] = [
+  {
+    description: 'undefined values',
+    config: { },
+    expected: { lowerBound: undefined, upperBound: undefined },
+  },
+  {
+    description: 'valid value for lower',
+    config: { lower_bound: 123 },
+    expected: { lowerBound: 123, upperBound: undefined },
+  },
+  {
+    description: 'valid value for upper',
+    config: { upper_bound: 456 },
+    expected: { lowerBound: undefined, upperBound: 456 },
+  },
+  {
+    description: 'valid values for lower & upper',
+    config: { lower_bound: 123, upper_bound: 456 },
+    expected: { lowerBound: 123, upperBound: 456 },
+  },
+  {
+    description: 'valid soft value for lower',
+    config: { lower_bound: '~123' },
+    expected: { lowerBound: '~123', upperBound: undefined },
+  },
+  {
+    description: 'invalid soft value for upper',
+    config: { upper_bound: '~456' },
+    expected: { lowerBound: undefined, upperBound: undefined },
+  },
+  {
+    description: 'valid soft value for lower, invalid soft value for upper',
+    config: { lower_bound: '~123', upper_bound: '~456' },
+    expected: { lowerBound: '~123', upperBound: undefined },
+  },
+  {
+    description: 'valid soft value for lower, valid value for upper',
+    config: { lower_bound: '~123', upper_bound: 456 },
+    expected: { lowerBound: '~123', upperBound: 456 },
+  },
+  {
+    description: 'lower = upper',
+    config: { lower_bound: 123, upper_bound: 123 },
+    expected: { lowerBound: 123, upperBound: undefined },
+  },
+  {
+    description: 'soft lower = upper',
+    config: { lower_bound: '~123', upper_bound: 123 },
+    expected: { lowerBound: '~123', upperBound: undefined },
+  },
+  {
+    description: 'lower > upper',
+    config: { lower_bound: 457, upper_bound: 456 },
+    expected: { lowerBound: 457, upperBound: undefined },
+  },
+  {
+    description: 'lower > upper(string)',
+    config: { lower_bound: 457, upper_bound: '456' },
+    expected: { lowerBound: 457, upperBound: undefined },
+  },
+  {
+    description: 'lower(string) > upper',
+    config: { lower_bound: '457', upper_bound: 456 },
+    expected: { lowerBound: 457, upperBound: undefined },
+  },
+  {
+    description: 'lower(string) > upper(string)',
+    config: { lower_bound: '457', upper_bound: '456' },
+    expected: { lowerBound: 457, upperBound: undefined },
+  },
+  {
+    description: 'soft lower > upper',
+    config: { lower_bound: '~457', upper_bound: 456 },
+    expected: { lowerBound: '~457', upperBound: undefined },
+  },
+  {
+    description: 'soft lower > upper(string)',
+    config: { lower_bound: '~457', upper_bound: '456' },
+    expected: { lowerBound: '~457', upperBound: undefined },
+  },
+];
+
+describe("checkBounds", () => {
+  VARIANTS.forEach((variant) => {
+    it(`checkBounds: check [${JSON.stringify(variant)}], ${variant.description}`, () => {
+      const result = checkBounds(variant.config);
+      const expectedValue = variant.expected;
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+});

--- a/tests/getBound.test.ts.dis
+++ b/tests/getBound.test.ts.dis
@@ -1,0 +1,151 @@
+/**
+ * Tests for getBound().
+ *
+ * The file is disabled (renamed to *.dis) & thus is not used during a build process;
+ * remove the "dis" extension to use it locally in your VSCode devcontainer.
+ */
+
+import { assert, describe, it } from 'vitest';
+import { getBound } from '../others';
+
+const NUMBERS: number[] = [
+  -1234567890,
+  -200.1,
+  -5,
+  -0.000000003,
+  0,
+  0.000000003,
+  5,
+  200.1,
+  1234567890,
+];
+
+const NUMBERS_AS_STRINGS: string[] = [
+  '-1234567890',
+  '-200.1',
+  '-5',
+  '-0.000000003',
+  '0',
+  '0.000000003',
+  '5',
+  '200.1',
+  '1234567890',
+];
+
+const NUMBERS_AS_STRINGS_WITH_WRONG_DELIMITER: string[] = [
+  '-200,1',
+  '-0,000000003',
+  '0,000000003',
+  '200,1',
+];
+
+const NUMBERS_WITH_SOFT: string[] = [
+  '~-1234567890',
+  '~-200.1',
+  '~-5',
+  '~-0.000000003',
+  '~0',
+  '~0.000000003',
+  '~5',
+  '~200.1',
+  '~1234567890',
+];
+
+const NUMBERS_WITH_SOFT_WITH_WRONG_DELIMITER: string[] = [
+  '~-200,1',
+  '~-0,000000003',
+  '~0,000000003',
+  '~200,1',
+];
+
+const STRINGS: string[] = [
+  '~abc',
+  '~-200.1abc',
+  'abc',
+];
+
+const OBJECTS: any[] = [
+  ['~123', 345],
+  { abc: 123, def: 456},
+];
+
+describe("getBound", () => {
+  NUMBERS.forEach((value) => {
+    it(`getBound: check a number [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = { value, soft: false };
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  NUMBERS_AS_STRINGS.forEach((value) => {
+    it(`getBound: check a string presentation of a number [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = { value: Number(value), soft: false };
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  NUMBERS_AS_STRINGS_WITH_WRONG_DELIMITER.forEach((value) => {
+    it(`getBound: check a string presentation of a number with a wrong delimiter [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = undefined;
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  NUMBERS_WITH_SOFT.forEach((value) => {
+    it(`getBound: check a ~value [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = { value: Number(value.slice(1)), soft: true };
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  NUMBERS_WITH_SOFT_WITH_WRONG_DELIMITER.forEach((value) => {
+    it(`getBound: check a ~value with a wrong delimiter [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = undefined;
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  STRINGS.forEach((value) => {
+    it(`getBound: check an obvious string [${value}]`, () => {
+      const result = getBound(value);
+      const expectedValue = undefined;
+      // check a value only
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+  OBJECTS.forEach((value) => {
+    it(`getBound: check an object [${JSON.stringify(value)}]`, () => {
+      const result = getBound(value);
+      const expectedValue = undefined;
+      assert.deepEqual(
+        result,
+        expectedValue,
+      );
+    });
+  });
+
+});


### PR DESCRIPTION
Currently, it is possible to define invalid values for `lower_bound` & `upper_bound`.
After this PR:
-- values are checked
-- in case of an error - values are unset to undefined, a message is logged in a browser console.

Tests are added. Tests are disabled (renamed to "*.dis").