### PR TITLE
feat: Check color thresholds

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -17,6 +17,7 @@ import {
   checkNumericOption,
   checkIntegerOption,
   checkBounds,
+  checkColorThresholds,
 } from './checkOption';
 import { getFactor } from './others';
 
@@ -211,6 +212,8 @@ export default (config) => {
       entity.fill_baseline = checkNumericOption(entity, 'fill_baseline', undefined, undefined, undefined, true);
 
       if (entity.color_thresholds) {
+        // check color_thresholds
+        checkColorThresholds(entity, `entities[${i}]`);
         // eslint-disable-next-line no-param-reassign
         entity.color_thresholds = computeThresholds(
           entity.color_thresholds,
@@ -239,6 +242,9 @@ export default (config) => {
     conf.line_color = [config.line_color, ...DEFAULT_COLORS];
 
   conf.font_size = (config.font_size / 100) * DEFAULT_FONT_SIZE || DEFAULT_FONT_SIZE;
+
+  // check color_thresholds
+  checkColorThresholds(conf, 'config');
   conf.color_thresholds = computeThresholds(
     conf.color_thresholds,
     conf.color_thresholds_transition,

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -1,9 +1,13 @@
 import { log } from './utils';
-import { isNumeric, getBound } from './others';
+import {
+  isNumeric,
+  logStringWarning,
+  getBound,
+} from './others';
 
 /**
  * Check if an option is numeric (if not undefined);
- * fallback to a default value if not numeric or out of bounds
+ * fallback to a default value if not numeric or out of bounds.
  * @param {object} config Config object
  * @param {string} option Name of option to be checked
  * @param {number} defaultValue Default fallback value
@@ -28,9 +32,8 @@ const checkNumericOption = (
   }
 
   if (isNumeric(value, allowString)) {
-    if (typeof value === 'string') {
-      log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
-    }
+    // log a warning in case of a string presentation of a number
+    logStringWarning(value, option);
 
     const valueNumeric = Number(value);
     const isMinValid = minBound === undefined || valueNumeric >= minBound;
@@ -60,7 +63,7 @@ const checkNumericOption = (
 /**
  * Check if an option is integer;
  * fallback to a default value if not numeric or out of bounds;
- * round to an integer if needed
+ * round to an integer if needed.
  * @param {object} config Config object
  * @param {string} option Name of option to be checked
  * @param {number} defaultValue Default fallback value
@@ -88,7 +91,7 @@ const checkIntegerOption = (
 };
 
 /**
- * "Check if a bound option is valid (accounting for an optional "~" prefix).
+ * Check if a bound option is valid (accounting for an optional "~" prefix).
  * @param {object} config Config object
  * @param {string} option Name of the option to be checked
  * @returns {number|string|undefined} Cleared value in its original format, or undefined
@@ -104,7 +107,9 @@ const checkBoundOption = (config, option) => {
     const parsed = getBound(value);
     if (parsed !== undefined && isNumeric(parsed.value)) {
       if (!parsed.soft && typeof value === 'string') {
-        log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
+        // check for a "string number" since this will not be cleared below
+        // log a warning in case of a string presentation of a number
+        logStringWarning(value, option);
       }
 
       const cfg = { [option]: parsed.value };
@@ -121,10 +126,12 @@ const checkBoundOption = (config, option) => {
 };
 
 /**
- * Check both upper/lower bounds for valid values
+ * Check both upper/lower bounds for valid values.
  * @param {object} config Config object
- * @returns {{lowerBound: string|number|undefined, upperBound: string|number|undefined}} Cleared
- * bounds
+ * @returns {{
+ *   lowerBound: string|number|undefined,
+ *   upperBound: string|number|undefined
+ * }} Cleared bounds
  */
 const checkBounds = (config) => {
   const lowerBound = checkBoundOption(config, 'lower_bound');
@@ -148,9 +155,67 @@ const checkBounds = (config) => {
   return { lowerBound, upperBound };
 };
 
+/**
+ * Check color_thresholds array.
+ * @param {object} config Config object containing color_thresholds
+ * @param {string} configName Name of a config object
+ */
+const checkColorThresholds = (config, configName) => {
+  const thresholds = config.color_thresholds;
+
+  if (thresholds === undefined || thresholds === null) {
+    // color_thresholds not defined
+    return;
+  }
+
+  if (!Array.isArray(thresholds)) {
+    // color_thresholds not a list
+    log(`Invalid option ${configName}.color_thresholds: expected a list; unsetting to []`);
+    config.color_thresholds = [];
+    return;
+  }
+
+  config.color_thresholds = thresholds
+    .map((threshold, idx) => {
+      if (typeof threshold === 'string') {
+        return { color: threshold };
+      }
+
+      if (threshold && typeof threshold === 'object') {
+        let { color, value } = threshold;
+
+        if (color === undefined || typeof color !== 'string') {
+          log(`Invalid option ${configName}.color_thresholds[${idx}]: "color" is missing or not a string; adjusting to "var(--primary-text-color)"`);
+          color = 'var(--primary-text-color)';
+        }
+
+        if (value !== undefined && value !== null) {
+          if (!isNumeric(value, true)) {
+            log(`Invalid option ${configName}.color_thresholds[${idx}]: "value" is not a numeric value; unsetting to undefined`);
+            value = undefined;
+          } else {
+            // log a warning in case of a string presentation of a number
+            logStringWarning(value, `${configName}.color_thresholds[${idx}].value`);
+            value = Number(value);
+          }
+        } else if (value === null) {
+          log(`Invalid option ${configName}.color_thresholds[${idx}]: "value" is null, unsetting to undefined`);
+          value = undefined;
+        }
+
+        return { color, value };
+      }
+
+      // other invalid content
+      log(`Invalid option ${configName}.color_thresholds[${idx}]: expected an object or color string; replacing with a default entry`);
+      return { color: 'var(--primary-text-color)' };
+    });
+};
+
 export {
   checkNumericOption,
   checkIntegerOption,
   checkBoundOption,
   checkBounds,
+  checkColorThresholds,
 };

--- a/src/others.js
+++ b/src/others.js
@@ -31,9 +31,16 @@ const isNumeric = (value, allowString = false) => {
   return false;
 };
 
-const getExponent = factor => 10 ** factor;
-
-const logValueFactor = factor_obj => log(`invalid value_factor: [${JSON.stringify(factor_obj)}]`);
+/**
+ * Log a warning if a configuration numeric value is passed as a string.
+ * @param {any} value Value to check
+ * @param {string} option Name of the option for the log message
+ */
+const logStringWarning = (value, option) => {
+  if (typeof value === 'string') {
+    log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
+  }
+};
 
 /**
   * Return a multiplying factor (exponental or scale) based on a "value_factor" option
@@ -74,6 +81,9 @@ const getFactor = (config, index = undefined) => {
     return 1;
   }
 
+  const getExponent = factor => 10 ** factor;
+  const logValueFactor = factor_obj => log(`invalid value_factor: [${JSON.stringify(factor_obj)}]`);
+
   if (typeof value_factor === 'object') {
     const { type, factor } = value_factor;
     if (type === undefined || factor === undefined
@@ -82,10 +92,15 @@ const getFactor = (config, index = undefined) => {
       logValueFactor(value_factor);
       return 1;
     }
-    if (type === 'exponent') {
-      return getExponent(Number(factor));
-    } else if (type === 'scale') {
-      return Number(factor);
+    if (type === 'exponent' || type === 'scale') {
+      // log a warning in case of a string presentation of a number
+      logStringWarning(factor, 'factor');
+      switch (type) {
+        case 'exponent':
+          return getExponent(Number(factor))
+        default: // scale
+          return Number(factor);
+      }
     }
     // invalid 'type' option
     logValueFactor(value_factor);
@@ -93,6 +108,8 @@ const getFactor = (config, index = undefined) => {
   }
 
   if (isNumeric(value_factor, true)) {
+    // log a warning in case of a string presentation of a number
+    logStringWarning(value_factor, 'value_factor');
     // use a legacy "exponent" way
     return getExponent(Number(value_factor));
   }
@@ -137,6 +154,7 @@ const getBound = (bound) => {
 
 export {
   isNumeric,
+  logStringWarning,
   getFactor,
   getBound,
 };

--- a/tests/checkColorThresholds.test.ts.dis
+++ b/tests/checkColorThresholds.test.ts.dis
@@ -1,0 +1,145 @@
+/**
+ * Tests for checkColorThresholds().
+ *
+ * The file is disabled (renamed to *.dis) & thus is not used during a build process;
+ * remove the "dis" extension to use it locally in your VSCode devcontainer.
+ */
+
+import { expect, describe, it } from 'vitest';
+import { checkColorThresholds } from '../checkOption';
+
+// prevent logging
+global.log = () => { };
+
+interface ConfigType {
+  color_thresholds?: any;
+};const COLORS: string[] = [
+
+  "red",
+  "#ff00ff",
+  "var(--red-color)",
+];
+
+describe("isNumeric", () => {
+
+  it('checkColorThresholds: check for undefined или null', () => {
+    const config1: ConfigType = {}; // check for undefined
+    const config2 = { color_thresholds: null }; // check for null
+    checkColorThresholds(config1, 'config');
+    checkColorThresholds(config2, 'config');
+    expect(config1.color_thresholds).toBeUndefined();
+    expect(config2.color_thresholds).toBeNull();
+  });
+
+  it('checkColorThresholds: if not an array (number) -> unsetting to []', () => {
+    const config = { color_thresholds: 123 };
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual([]);
+  });
+
+  it('checkColorThresholds: if not an array (string) -> unsetting to []', () => {
+    const config = { color_thresholds: 'abc' };
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual([]);
+  });
+
+  it('checkColorThresholds: if not an array (dict) -> unsetting to []', () => {
+    const config = { color_thresholds: { color: 'red', value: 123 } };
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual([]);
+  });
+
+  COLORS.forEach((color) => {
+    it(`checkColorThresholds: shorthand "color-only" [${color}] element`, () => {
+      const config = {
+        color_thresholds: [color],
+      };
+      const expected = [{ color: color }];
+      checkColorThresholds(config, 'config');
+      expect(config.color_thresholds).toEqual(expected);
+    });
+  });
+
+  COLORS.forEach((color) => {
+    it(`checkColorThresholds: shorthand "color-only" [${color}] dict element`, () => {
+      const config = {
+        color_thresholds: [{ color: color }],
+      };
+      const expected = [{ color: color }];
+      checkColorThresholds(config, 'config');
+      expect(config.color_thresholds).toEqual(expected);
+    });
+  });
+
+  it(`checkColorThresholds: color is missing`, () => {
+    const config = {
+      color_thresholds: ['red', {value: 123}],
+    };
+    const expected = [{ color: 'red' }, {color: 'var(--primary-text-color)', value: 123}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: color is not a string`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 123, value: 123}],
+    };
+    const expected = [{ color: 'red' }, {color: 'var(--primary-text-color)', value: 123}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is undefined`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: undefined}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red'}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is null`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: null}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red'}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is non-numeric ['abc']`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: 'abc'}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red'}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is non-numeric [{xyz: 123}]`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: {xyz: 123}}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red'}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is non-numeric [[123, 456]]`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: [123, 456]}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red'}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+
+  it(`checkColorThresholds: value is non-numeric ['123']`, () => {
+    const config = {
+      color_thresholds: ['red', {color: 'red', value: '123'}],
+    };
+    const expected = [{ color: 'red' }, {color: 'red', value: 123}];
+    checkColorThresholds(config, 'config');
+    expect(config.color_thresholds).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Added a `checkColorThresholds()` function checking `color_thresholds` object (both a global option & per-entity option).
The function is called in `buildConfig`.
Goal is to filter out wrong input values & notify a user.

1. In case of an error - default values are used (for a color - `var(--primary-text-color)`, for a value - `undefined`), a corresponding message is logged in a browser console.
2. If a `value` option is a string like `"123"`(string)  - then it is converted to `123` (number), a corresponding message is logged.
3. Test are added for `checkColorThresholds()`. Tests are disabled (renamed to ".dis").
4. (unrelated) `getFactor()` - added a logging of "string instead of number" warnings.