### PR TITLE
feat: read a series from statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ entities:
 | Option | Type | Default | Description
 |--------|------|---------|------------
 | period | string | derived from `hours_to_show` | `5minute`, `hour`, `day`, `week`, `month` or `year`.
-| type | string | `mean` | Which statistic to plot: `mean`, `min`, `max`, `sum` or `state`.
+| type | string | see below | Which statistic to plot: `mean`, `min`, `max`, `sum`, `state` or `change`.
 
 ```yaml
 entities:
@@ -351,8 +351,17 @@ the defaults, and `statistics: false` on an entity opts it back out.
 
 Notes:
 
-- Only entities with a `state_class` have statistics. Others produce an empty
-  graph, so leave them on raw history.
+- Only entities with a `state_class` have statistics; the card logs a warning
+  if there are none for an entity.
+- Which types exist depends on the `state_class`: `measurement` has `mean`,
+  `min` and `max`, `measurement_angle` has `mean` only (a circular mean),
+  `total` and `total_increasing` have `sum`, `state` and `change`. The card
+  reads the available types from a response, so a type which is not there is
+  replaced by a default one, with a warning in a console.
+- When `type` is not set, `mean` is used if it is available, otherwise `state`
+  - the reading a raw history would show. Use `change` to plot a consumption
+  per period instead, which is usually what is wanted for an energy, water or
+  gas sensor.
 - Home Assistant retains `5minute` statistics for a limited window (10 days by
   default) and hourly statistics indefinitely. When `period` is not set it is
   derived from `hours_to_show` so a long graph does not ask for data that has

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | group_by | string | `interval` | v0.8.0 | Specify type of grouping of data, dynamic `interval`, `date` or `hour`.
 | update_interval | number |  | v0.4.0 | Specify a custom update interval of the history data (in seconds), instead of on every state change.
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
-| statistics | boolean *or* object |  |  | Read the series from long-term statistics instead of raw history, see [Long-term statistics](#long-term-statistics).
+| statistics | boolean *or* object |  |  | Read the series from statistics instead of raw history, see [Statistics](#statistics).
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
@@ -159,7 +159,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | show_static_inactive | boolean |         | Set to true to disable hiding the line when a point of a line of another entity selected; meaningful for a [static line](#static-lines) only.
 | state_adaptive_color | boolean |         | Make the color of the state adapt to the entity/static value color.
 | y_axis | string |         | If 'secondary', displays using the secondary Y-axis on the right.
-| statistics | boolean *or* object |         | Override long-term statistics for this entity only, see [Long-term statistics](#long-term-statistics).
+| statistics | boolean *or* object |         | Override statistics for this entity only, see [Statistics](#statistics).
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
 | logarithmic | boolean |         | Override logarithmic scaling for this entity only (see [Logarithmic options](#logarithmic-options)).
@@ -313,15 +313,15 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
 
-### Long-term statistics
+### Statistics
 
 By default a series is read from the recorder's raw history. That history is
 bounded by the recorder's `purge_keep_days`, and it gets expensive over long
 spans - every state row in the window is fetched and then bucketed client side.
 
-Setting `statistics` reads the series from Home Assistant's long-term
-statistics instead. Those are pre-aggregated server side and kept far longer
-than raw history, so a wide graph costs a fraction of the rows.
+Setting `statistics` reads the series from Home Assistant's statistics
+instead. Those are pre-aggregated server side and kept far longer than raw
+history, so a wide graph costs a fraction of the rows.
 
 ```yaml
 type: custom:mini-graph-card

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ entities:
 
 | Option | Type | Default | Description
 |--------|------|---------|------------
-| period | string | derived from `hours_to_show` | `5minute`, `hour`, `day`, `week` or `month`.
+| period | string | derived from `hours_to_show` | `5minute`, `hour`, `day`, `week`, `month` or `year`.
 | type | string | `mean` | Which statistic to plot: `mean`, `min`, `max`, `sum` or `state`.
 
 ```yaml
@@ -361,6 +361,14 @@ Notes:
   point per period only produces empty buckets.
 - The whole window is refetched on update rather than appended to the cached
   tail, because a period's bucket is revised until that period completes.
+- `statistics` cannot be combined with `attribute` or `state_map`. Statistics
+  hold numeric aggregates of the state, so there is no attribute to read and
+  no non-numeric state to map. Either combination logs a warning and the
+  entity falls back to raw history, which honours both options.
+- Values arrive in the entity's own unit. Home Assistant converts a statistic
+  from the unit it was recorded in to the entity's current
+  `unit_of_measurement` before returning it, which is the unit the card labels
+  the axis with.
 
 ### Static lines
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | group_by | string | `interval` | v0.8.0 | Specify type of grouping of data, dynamic `interval`, `date` or `hour`.
 | update_interval | number |  | v0.4.0 | Specify a custom update interval of the history data (in seconds), instead of on every state change.
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
+| statistics | boolean *or* object |  |  | Read the series from long-term statistics instead of raw history, see [Long-term statistics](#long-term-statistics).
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
@@ -158,6 +159,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | show_static_inactive | boolean |         | Set to true to disable hiding the line when a point of a line of another entity selected; meaningful for a [static line](#static-lines) only.
 | state_adaptive_color | boolean |         | Make the color of the state adapt to the entity/static value color.
 | y_axis | string |         | If 'secondary', displays using the secondary Y-axis on the right.
+| statistics | boolean *or* object |         | Override long-term statistics for this entity only, see [Long-term statistics](#long-term-statistics).
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
 | logarithmic | boolean |         | Override logarithmic scaling for this entity only (see [Logarithmic options](#logarithmic-options)).
@@ -310,6 +312,55 @@ These buckets are converted later to single point/bar on the graph. Aggregate fu
 | `sum` | v0.9.2 |
 | `delta` | v0.9.4 | Calculates difference between max and min value
 | `diff` | v0.11.0 | Calculates difference between first and last value
+
+### Long-term statistics
+
+By default a series is read from the recorder's raw history. That history is
+bounded by the recorder's `purge_keep_days`, and it gets expensive over long
+spans - every state row in the window is fetched and then bucketed client side.
+
+Setting `statistics` reads the series from Home Assistant's long-term
+statistics instead. Those are pre-aggregated server side and kept far longer
+than raw history, so a wide graph costs a fraction of the rows.
+
+```yaml
+type: custom:mini-graph-card
+hours_to_show: 336
+points_per_hour: 1
+entities:
+  - entity: sensor.outside_temperature
+    statistics: true
+```
+
+| Option | Type | Default | Description
+|--------|------|---------|------------
+| period | string | derived from `hours_to_show` | `5minute`, `hour`, `day`, `week` or `month`.
+| type | string | `mean` | Which statistic to plot: `mean`, `min`, `max`, `sum` or `state`.
+
+```yaml
+entities:
+  - entity: sensor.outside_temperature
+    statistics:
+      period: hour
+      type: max
+```
+
+`statistics` may be set per entity or card-wide, in which case it applies to
+every entity that does not override it. `statistics: true` is shorthand for
+the defaults, and `statistics: false` on an entity opts it back out.
+
+Notes:
+
+- Only entities with a `state_class` have statistics. Others produce an empty
+  graph, so leave them on raw history.
+- Home Assistant retains `5minute` statistics for a limited window (10 days by
+  default) and hourly statistics indefinitely. When `period` is not set it is
+  derived from `hours_to_show` so a long graph does not ask for data that has
+  already been purged.
+- Statistics are aggregated into fixed periods, so `points_per_hour` beyond one
+  point per period only produces empty buckets.
+- The whole window is refetched on update rather than appended to the cached
+  tail, because a period's bucket is revised until that period completes.
 
 ### Static lines
 

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -18,6 +18,7 @@ import {
   checkIntegerOption,
   checkBounds,
   checkColorThresholds,
+  checkStatistics,
 } from './checkOption';
 import { getFactor } from './others';
 
@@ -221,6 +222,9 @@ export default (config) => {
         );
       }
     }
+    // `statistics` may be set per entity or card-wide, and accepts a bare
+    // `true` as shorthand for the defaults.
+    checkStatistics(conf, i);
   });
   /* eslint-enable no-param-reassign */
 

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -2,7 +2,6 @@ import {
   URL_DOCS,
   STATISTICS_PERIODS,
   STATISTICS_TYPES,
-  DEFAULT_STATISTICS_TYPE,
 } from './const';
 import { log } from './utils';
 import {
@@ -253,7 +252,7 @@ const checkStatistics = (config, index) => {
   if (opts.type !== undefined && !STATISTICS_TYPES.includes(opts.type))
     throw new Error(`"statistics.type" must be one of ${STATISTICS_TYPES.join(', ')}.\n See ${URL_DOCS}`);
 
-  entity.statistics = { type: DEFAULT_STATISTICS_TYPE, ...opts };
+  entity.statistics = { ...opts };
 };
 /* eslint-enable no-param-reassign */
 

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -220,9 +220,10 @@ const checkColorThresholds = (config, configName) => {
 
 
 /**
- * Validate and normalise the `statistics` option for entity `index`.
- * May be set per entity or card-wide; `true` is shorthand for the defaults.
- * Sourcing a series from long-term statistics instead of raw history.
+ * Check the `statistics` option (may be set per entity or card-wide);
+ * `true` is a shorthand for the defaults.
+ * @param {object} config Config object
+ * @param {number} index Index of an entity
  */
 /* eslint-disable no-param-reassign */
 const checkStatistics = (config, index) => {
@@ -230,6 +231,16 @@ const checkStatistics = (config, index) => {
   const stats = entity.statistics !== undefined ? entity.statistics : config.statistics;
 
   if (stats === undefined || stats === false) {
+    delete entity.statistics;
+    return;
+  }
+
+  // Statistics are numeric aggregates of a state: no attribute to read,
+  // no non-numeric state to map. Fall back to a raw history.
+  const incompatible = (entity.attribute !== undefined && 'attribute')
+    || (Array.isArray(config.state_map) && config.state_map.length > 0 && 'state_map');
+  if (incompatible) {
+    log(`Option statistics of entities[${index}] is not compatible with ${incompatible}; ignoring statistics and reading raw history instead`);
     delete entity.statistics;
     return;
   }

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -1,3 +1,9 @@
+import {
+  URL_DOCS,
+  STATISTICS_PERIODS,
+  STATISTICS_TYPES,
+  DEFAULT_STATISTICS_TYPE,
+} from './const';
 import { log } from './utils';
 import {
   isNumeric,
@@ -212,7 +218,36 @@ const checkColorThresholds = (config, configName) => {
     });
 };
 
+
+/**
+ * Validate and normalise the `statistics` option for entity `index`.
+ * May be set per entity or card-wide; `true` is shorthand for the defaults.
+ * Sourcing a series from long-term statistics instead of raw history.
+ */
+/* eslint-disable no-param-reassign */
+const checkStatistics = (config, index) => {
+  const entity = config.entities[index];
+  const stats = entity.statistics !== undefined ? entity.statistics : config.statistics;
+
+  if (stats === undefined || stats === false) {
+    delete entity.statistics;
+    return;
+  }
+
+  const opts = stats === true ? {} : stats;
+  if (typeof opts !== 'object' || Array.isArray(opts))
+    throw new Error(`"statistics" must be a boolean or an object.\n See ${URL_DOCS}`);
+  if (opts.period !== undefined && !STATISTICS_PERIODS.includes(opts.period))
+    throw new Error(`"statistics.period" must be one of ${STATISTICS_PERIODS.join(', ')}.\n See ${URL_DOCS}`);
+  if (opts.type !== undefined && !STATISTICS_TYPES.includes(opts.type))
+    throw new Error(`"statistics.type" must be one of ${STATISTICS_TYPES.join(', ')}.\n See ${URL_DOCS}`);
+
+  entity.statistics = { type: DEFAULT_STATISTICS_TYPE, ...opts };
+};
+/* eslint-enable no-param-reassign */
+
 export {
+  checkStatistics,
   checkNumericOption,
   checkIntegerOption,
   checkBoundOption,

--- a/src/const.js
+++ b/src/const.js
@@ -57,7 +57,7 @@ const Y = 1;
 const V = 2;
 const ONE_HOUR = 1000 * 3600;
 
-// Long-term statistics
+// Statistics
 const STATISTICS_PERIODS = ['5minute', 'hour', 'day', 'week', 'month', 'year'];
 const STATISTICS_TYPES = ['mean', 'min', 'max', 'sum', 'state'];
 const DEFAULT_STATISTICS_TYPE = 'mean';

--- a/src/const.js
+++ b/src/const.js
@@ -57,6 +57,20 @@ const Y = 1;
 const V = 2;
 const ONE_HOUR = 1000 * 3600;
 
+// Long-term statistics. HA keeps 5-minute statistics for a short window
+// (10 days by default) and hourly statistics indefinitely, so the period is
+// derived from hours_to_show unless the user pins one.
+const STATISTICS_PERIODS = ['5minute', 'hour', 'day', 'week', 'month'];
+const STATISTICS_TYPES = ['mean', 'min', 'max', 'sum', 'state'];
+const DEFAULT_STATISTICS_TYPE = 'mean';
+// Hours up to which each period is a sensible default.
+const STATISTICS_PERIOD_THRESHOLDS = [
+  { hours: 24, period: '5minute' },
+  { hours: 24 * 90, period: 'hour' },
+  { hours: 24 * 730, period: 'day' },
+];
+const STATISTICS_PERIOD_FALLBACK = 'month';
+
 export {
   URL_DOCS,
   MAX_BARS,
@@ -77,4 +91,9 @@ export {
   Y,
   V,
   ONE_HOUR,
+  STATISTICS_PERIODS,
+  STATISTICS_TYPES,
+  DEFAULT_STATISTICS_TYPE,
+  STATISTICS_PERIOD_THRESHOLDS,
+  STATISTICS_PERIOD_FALLBACK,
 };

--- a/src/const.js
+++ b/src/const.js
@@ -59,8 +59,10 @@ const ONE_HOUR = 1000 * 3600;
 
 // Statistics
 const STATISTICS_PERIODS = ['5minute', 'hour', 'day', 'week', 'month', 'year'];
-const STATISTICS_TYPES = ['mean', 'min', 'max', 'sum', 'state'];
-const DEFAULT_STATISTICS_TYPE = 'mean';
+// "mean" statistics hold mean/min/max, "sum" ones - sum/state/change
+const STATISTICS_TYPES = ['mean', 'min', 'max', 'sum', 'state', 'change'];
+// A preferred type, in order of preference
+const DEFAULT_STATISTICS_TYPES = ['mean', 'state'];
 // A default period, by hours_to_show; HA keeps 5-minute statistics ~10 days only.
 const STATISTICS_PERIOD_THRESHOLDS = [
   { hours: 24, period: '5minute' },
@@ -91,7 +93,7 @@ export {
   ONE_HOUR,
   STATISTICS_PERIODS,
   STATISTICS_TYPES,
-  DEFAULT_STATISTICS_TYPE,
+  DEFAULT_STATISTICS_TYPES,
   STATISTICS_PERIOD_THRESHOLDS,
   STATISTICS_PERIOD_FALLBACK,
 };

--- a/src/const.js
+++ b/src/const.js
@@ -57,13 +57,11 @@ const Y = 1;
 const V = 2;
 const ONE_HOUR = 1000 * 3600;
 
-// Long-term statistics. HA keeps 5-minute statistics for a short window
-// (10 days by default) and hourly statistics indefinitely, so the period is
-// derived from hours_to_show unless the user pins one.
-const STATISTICS_PERIODS = ['5minute', 'hour', 'day', 'week', 'month'];
+// Long-term statistics
+const STATISTICS_PERIODS = ['5minute', 'hour', 'day', 'week', 'month', 'year'];
 const STATISTICS_TYPES = ['mean', 'min', 'max', 'sum', 'state'];
 const DEFAULT_STATISTICS_TYPE = 'mean';
-// Hours up to which each period is a sensible default.
+// A default period, by hours_to_show; HA keeps 5-minute statistics ~10 days only.
 const STATISTICS_PERIOD_THRESHOLDS = [
   { hours: 24, period: '5minute' },
   { hours: 24 * 90, period: 'hour' },

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ import {
   STATISTICS_PERIOD_THRESHOLDS,
   STATISTICS_PERIOD_FALLBACK,
 } from './const';
-import { isNumeric } from './others';
+import { isNumeric, getStatisticsType } from './others';
 import {
   getMin, getAvg, getMax,
   getMilli,
@@ -64,6 +64,7 @@ class MiniGraphCard extends LitElement {
     this.stateChanged = false;
     this.initial = true;
     this._md5Config = undefined;
+    this.loggedMessages = new Set();
 
     // update datetime settings periodically
     this.updateHour24 = true;
@@ -1783,10 +1784,24 @@ class MiniGraphCard extends LitElement {
     if (statistics) {
       const period = statistics.period || this.statisticsPeriod();
       const stats = await this.fetchStatistics(entity.entity_id, initStart, end, period);
+      if (stats.length === 0) {
+        this.logOnce(`No ${period} statistics for ${entity.entity_id} in a shown period`);
+        return;
+      }
+      // A type is resolved here & not in buildConfig(): only a response tells
+      // whether an entity has "mean" or "sum" statistics.
+      const type = getStatisticsType(stats, statistics.type);
+      if (type === undefined) {
+        this.logOnce(`No statistics types for ${entity.entity_id}`);
+        return;
+      }
+      if (statistics.type !== undefined && statistics.type !== type) {
+        this.logOnce(`Statistics type ${statistics.type} is not available for ${entity.entity_id}; using ${type}`);
+      }
       const statHistory = stats
         .map(item => ({
           last_changed: new Date(item.start).toISOString(),
-          state: item[statistics.type],
+          state: item[type],
         }))
         .filter(item => !Number.isNaN(parseFloat(item.state)));
       this.applyHistory(entity, index, statHistory);
@@ -1878,6 +1893,13 @@ class MiniGraphCard extends LitElement {
     }
 
     this.applyHistory(entity, index, stateHistory);
+  }
+
+  /** Log a message once: updateEntity() is called on every update. */
+  logOnce(message) {
+    if (this.loggedMessages.has(message)) return;
+    this.loggedMessages.add(message);
+    log(message);
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -1777,10 +1777,8 @@ class MiniGraphCard extends LitElement {
 
     this.updateQueue = this.updateQueue.filter(entry => entry !== `${entity.entity_id}-${index}`);
 
-    // Long-term statistics are pre-aggregated server side, so the whole
-    // window is refetched rather than appended to a cached tail: buckets are
-    // revised as a period completes, and an incremental merge would duplicate
-    // or truncate the boundary bucket.
+    // The whole window is refetched, not appended to a cached tail:
+    // a bucket is revised until its period completes.
     const { statistics } = this.config.entities[index];
     if (statistics) {
       const period = statistics.period || this.statisticsPeriod();
@@ -1883,9 +1881,8 @@ class MiniGraphCard extends LitElement {
   }
 
   /**
-   * Hand a normalised [{last_changed, state}] series to the graph. Shared by
-   * the recorder-history and long-term-statistics paths - nothing downstream
-   * cares which one produced it.
+   * Pass a [{last_changed, state}] series to the graph;
+   * used by both the history & the statistics paths.
    */
   applyHistory(entity, index, stateHistory) {
     if (stateHistory.length === 0) return;
@@ -1902,11 +1899,7 @@ class MiniGraphCard extends LitElement {
     }
   }
 
-  /**
-   * Pick a statistics period wide enough for the window being shown. HA only
-   * retains 5-minute statistics for a short time, so long spans must step up
-   * to hourly or coarser.
-   */
+  /** Pick a period wide enough for hours_to_show. */
   statisticsPeriod() {
     const match = STATISTICS_PERIOD_THRESHOLDS
       .find(({ hours }) => this.config.hours_to_show <= hours);

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,8 @@ import {
   DEFAULT_GRAPH_HEIGHT,
   DEFAULT_MARGIN,
   NBSP,
+  STATISTICS_PERIOD_THRESHOLDS,
+  STATISTICS_PERIOD_FALLBACK,
 } from './const';
 import { isNumeric } from './others';
 import {
@@ -1775,6 +1777,24 @@ class MiniGraphCard extends LitElement {
 
     this.updateQueue = this.updateQueue.filter(entry => entry !== `${entity.entity_id}-${index}`);
 
+    // Long-term statistics are pre-aggregated server side, so the whole
+    // window is refetched rather than appended to a cached tail: buckets are
+    // revised as a period completes, and an incremental merge would duplicate
+    // or truncate the boundary bucket.
+    const { statistics } = this.config.entities[index];
+    if (statistics) {
+      const period = statistics.period || this.statisticsPeriod();
+      const stats = await this.fetchStatistics(entity.entity_id, initStart, end, period);
+      const statHistory = stats
+        .map(item => ({
+          last_changed: new Date(item.start).toISOString(),
+          state: item[statistics.type],
+        }))
+        .filter(item => !Number.isNaN(parseFloat(item.state)));
+      this.applyHistory(entity, index, statHistory);
+      return;
+    }
+
     let stateHistory = [];
     let start = initStart;
     let skipInitialState = false;
@@ -1859,6 +1879,15 @@ class MiniGraphCard extends LitElement {
       }
     }
 
+    this.applyHistory(entity, index, stateHistory);
+  }
+
+  /**
+   * Hand a normalised [{last_changed, state}] series to the graph. Shared by
+   * the recorder-history and long-term-statistics paths - nothing downstream
+   * cares which one produced it.
+   */
+  applyHistory(entity, index, stateHistory) {
     if (stateHistory.length === 0) return;
 
     if (this.entity[0] && entity.entity_id === this.entity[0].entity_id) {
@@ -1871,6 +1900,28 @@ class MiniGraphCard extends LitElement {
     } else {
       this.Graph[index].history = stateHistory;
     }
+  }
+
+  /**
+   * Pick a statistics period wide enough for the window being shown. HA only
+   * retains 5-minute statistics for a short time, so long spans must step up
+   * to hourly or coarser.
+   */
+  statisticsPeriod() {
+    const match = STATISTICS_PERIOD_THRESHOLDS
+      .find(({ hours }) => this.config.hours_to_show <= hours);
+    return match ? match.period : STATISTICS_PERIOD_FALLBACK;
+  }
+
+  async fetchStatistics(entityId, start, end, period) {
+    const result = await this._hass.callWS({
+      type: 'recorder/statistics_during_period',
+      start_time: start ? start.toISOString() : undefined,
+      end_time: end ? end.toISOString() : undefined,
+      statistic_ids: [entityId],
+      period,
+    });
+    return (result && result[entityId]) || [];
   }
 
   async fetchRecent(entityId, start, end, skipInitialState, withAttributes) {

--- a/src/others.js
+++ b/src/others.js
@@ -6,6 +6,7 @@
  */
 
 import { log } from './utils';
+import { STATISTICS_TYPES, DEFAULT_STATISTICS_TYPES } from './const';
 
 /**
   * Check if a value is a valid number
@@ -152,8 +153,29 @@ const getBound = (bound) => {
   return undefined;
 };
 
+/**
+ * Pick a statistics type which is really present in buckets: available types
+ * depend on a state_class, and an absent one is missing or null in every bucket.
+ * A requested type is returned only if it is available; compare a result with
+ * a requested type to see whether it was replaced.
+ * @param {Array} stats Statistics buckets
+ * @param {string} [requested] A type from a config
+ * @returns {string|undefined} A type to use, or undefined if there are none
+ */
+const getStatisticsType = (stats, requested) => {
+  const hasType = (item, type) => item && item[type] !== undefined && item[type] !== null;
+  const available = Array.isArray(stats)
+    ? STATISTICS_TYPES.filter(type => stats.some(item => hasType(item, type)))
+    : [];
+  if (requested !== undefined && available.includes(requested)) {
+    return requested;
+  }
+  return DEFAULT_STATISTICS_TYPES.find(type => available.includes(type)) || available[0];
+};
+
 export {
   isNumeric,
+  getStatisticsType,
   logStringWarning,
   getFactor,
   getBound,

--- a/tests/checkStatistics.test.ts.dis
+++ b/tests/checkStatistics.test.ts.dis
@@ -7,7 +7,7 @@
 
 import { expect, describe, it, vi, afterEach } from 'vitest';
 import { checkStatistics } from '../checkOption';
-import { STATISTICS_PERIODS, STATISTICS_TYPES, DEFAULT_STATISTICS_TYPE } from '../const';
+import { STATISTICS_PERIODS, STATISTICS_TYPES } from '../const';
 
 interface ConfigType {
   entities: any[];
@@ -45,16 +45,16 @@ describe('checkStatistics', () => {
     expect(config.entities[0].statistics).toBeUndefined();
   });
 
-  it('checkStatistics: [true] -> shorthand for the defaults', () => {
+  it('checkStatistics: [true] -> an empty object', () => {
     const config = makeConfig({ entity: ENTITY, statistics: true });
     checkStatistics(config, 0);
-    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+    expect(config.entities[0].statistics).toEqual({});
   });
 
   it('checkStatistics: card-wide [true] applies to an entity', () => {
     const config = makeConfig({ entity: ENTITY }, true);
     checkStatistics(config, 0);
-    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+    expect(config.entities[0].statistics).toEqual({});
   });
 
   it('checkStatistics: card-wide [true], entity [false] -> entity opts out', () => {
@@ -73,12 +73,12 @@ describe('checkStatistics', () => {
     it(`checkStatistics: valid period [${period}]`, () => {
       const config = makeConfig({ entity: ENTITY, statistics: { period } });
       checkStatistics(config, 0);
-      expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE, period });
+      expect(config.entities[0].statistics).toEqual({ period });
     });
   });
 
   STATISTICS_TYPES.forEach((type) => {
-    it(`checkStatistics: valid type [${type}] is not replaced by a default`, () => {
+    it(`checkStatistics: valid type [${type}]`, () => {
       const config = makeConfig({ entity: ENTITY, statistics: { type } });
       checkStatistics(config, 0);
       expect(config.entities[0].statistics).toEqual({ type });
@@ -98,7 +98,7 @@ describe('checkStatistics', () => {
     });
   });
 
-  ['average', 'MEAN', 'median', 'change', 'last_reset', '', 123, null].forEach((type) => {
+  ['average', 'MEAN', 'median', 'last_reset', '', 123, null].forEach((type) => {
     it(`checkStatistics: invalid type [${JSON.stringify(type)}] -> throws`, () => {
       const config = makeConfig({ entity: ENTITY, statistics: { type } });
       expect(() => checkStatistics(config, 0)).toThrowError(/statistics.type/);
@@ -115,8 +115,7 @@ describe('checkStatistics', () => {
   it('checkStatistics: an unknown sub-option is kept as is', () => {
     const config = makeConfig({ entity: ENTITY, statistics: { some_option: 123 } });
     checkStatistics(config, 0);
-    expect(config.entities[0].statistics)
-      .toEqual({ type: DEFAULT_STATISTICS_TYPE, some_option: 123 });
+    expect(config.entities[0].statistics).toEqual({ some_option: 123 });
   });
 
   it('checkStatistics: with [attribute] -> warns & falls back to a raw history', () => {
@@ -178,7 +177,7 @@ describe('checkStatistics', () => {
       const warn = mockWarn();
       const config = makeConfig({ entity: ENTITY, statistics: true }, undefined, state_map);
       checkStatistics(config, 0);
-      expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+      expect(config.entities[0].statistics).toEqual({});
       expect(warn).not.toHaveBeenCalled();
     });
   });
@@ -202,7 +201,7 @@ describe('checkStatistics', () => {
       ],
     };
     checkStatistics(config, 0);
-    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+    expect(config.entities[0].statistics).toEqual({});
     expect(config.entities[1].statistics).toBeUndefined();
   });
 });

--- a/tests/checkStatistics.test.ts.dis
+++ b/tests/checkStatistics.test.ts.dis
@@ -1,0 +1,208 @@
+/**
+ * Tests for checkStatistics().
+ *
+ * The file is disabled (renamed to *.dis) & thus is not used during a build process;
+ * remove the "dis" extension to use it locally in your VSCode devcontainer.
+ */
+
+import { expect, describe, it, vi, afterEach } from 'vitest';
+import { checkStatistics } from '../checkOption';
+import { STATISTICS_PERIODS, STATISTICS_TYPES, DEFAULT_STATISTICS_TYPE } from '../const';
+
+interface ConfigType {
+  entities: any[];
+  statistics?: any;
+  state_map?: any;
+};
+
+const ENTITY = 'sensor.test';
+
+const makeConfig = (entity: any, cardWide?: any, stateMap?: any): ConfigType => {
+  const config: ConfigType = { entities: [entity] };
+  if (cardWide !== undefined) config.statistics = cardWide;
+  if (stateMap !== undefined) config.state_map = stateMap;
+  return config;
+};
+
+// log() -> console.warn
+const mockWarn = () => vi.spyOn(console, 'warn').mockImplementation(() => { });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('checkStatistics', () => {
+
+  it('checkStatistics: option not set -> undefined', () => {
+    const config = makeConfig({ entity: ENTITY });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+  });
+
+  it('checkStatistics: [false] -> unsetting to undefined', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: false });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+  });
+
+  it('checkStatistics: [true] -> shorthand for the defaults', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: true });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+  });
+
+  it('checkStatistics: card-wide [true] applies to an entity', () => {
+    const config = makeConfig({ entity: ENTITY }, true);
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+  });
+
+  it('checkStatistics: card-wide [true], entity [false] -> entity opts out', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: false }, true);
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+  });
+
+  it('checkStatistics: an entity option overrides a card-wide option', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: { type: 'max' } }, { type: 'min' });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toEqual({ type: 'max' });
+  });
+
+  STATISTICS_PERIODS.forEach((period) => {
+    it(`checkStatistics: valid period [${period}]`, () => {
+      const config = makeConfig({ entity: ENTITY, statistics: { period } });
+      checkStatistics(config, 0);
+      expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE, period });
+    });
+  });
+
+  STATISTICS_TYPES.forEach((type) => {
+    it(`checkStatistics: valid type [${type}] is not replaced by a default`, () => {
+      const config = makeConfig({ entity: ENTITY, statistics: { type } });
+      checkStatistics(config, 0);
+      expect(config.entities[0].statistics).toEqual({ type });
+    });
+  });
+
+  it('checkStatistics: period is not set -> not stored', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: { type: 'max' } });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics.period).toBeUndefined();
+  });
+
+  ['minute', '5MINUTE', 'decade', '', 123, null].forEach((period) => {
+    it(`checkStatistics: invalid period [${JSON.stringify(period)}] -> throws`, () => {
+      const config = makeConfig({ entity: ENTITY, statistics: { period } });
+      expect(() => checkStatistics(config, 0)).toThrowError(/statistics.period/);
+    });
+  });
+
+  ['average', 'MEAN', 'median', 'change', 'last_reset', '', 123, null].forEach((type) => {
+    it(`checkStatistics: invalid type [${JSON.stringify(type)}] -> throws`, () => {
+      const config = makeConfig({ entity: ENTITY, statistics: { type } });
+      expect(() => checkStatistics(config, 0)).toThrowError(/statistics.type/);
+    });
+  });
+
+  ['mean', 123, ['mean'], []].forEach((statistics) => {
+    it(`checkStatistics: not a boolean or an object [${JSON.stringify(statistics)}] -> throws`, () => {
+      const config = makeConfig({ entity: ENTITY, statistics });
+      expect(() => checkStatistics(config, 0)).toThrowError(/must be a boolean or an object/);
+    });
+  });
+
+  it('checkStatistics: an unknown sub-option is kept as is', () => {
+    const config = makeConfig({ entity: ENTITY, statistics: { some_option: 123 } });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics)
+      .toEqual({ type: DEFAULT_STATISTICS_TYPE, some_option: 123 });
+  });
+
+  it('checkStatistics: with [attribute] -> warns & falls back to a raw history', () => {
+    const warn = mockWarn();
+    const config = makeConfig({ entity: ENTITY, statistics: true, attribute: 'some_attribute' });
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+    expect(config.entities[0].attribute).toBe('some_attribute');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0].join(' ')).toContain('attribute');
+  });
+
+  it('checkStatistics: with [state_map] -> warns & falls back to a raw history', () => {
+    const warn = mockWarn();
+    const config = makeConfig({ entity: ENTITY, statistics: true }, undefined, ['off', 'on']);
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+    expect(config.state_map).toEqual(['off', 'on']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0].join(' ')).toContain('state_map');
+  });
+
+  it('checkStatistics: card-wide statistics with [state_map] -> falls back too', () => {
+    const warn = mockWarn();
+    const config = makeConfig({ entity: ENTITY }, true, ['off', 'on']);
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('checkStatistics: [attribute] without statistics -> no warning', () => {
+    const warn = mockWarn();
+    const config = makeConfig({ entity: ENTITY, attribute: 'some_attribute' });
+    checkStatistics(config, 0);
+    expect(config.entities[0].attribute).toBe('some_attribute');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('checkStatistics: [state_map] without statistics -> no warning', () => {
+    const warn = mockWarn();
+    const config = makeConfig({ entity: ENTITY }, undefined, ['off', 'on']);
+    checkStatistics(config, 0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('checkStatistics: card-wide statistics, entity opts out of an incompatible one', () => {
+    const warn = mockWarn();
+    const config = makeConfig(
+      { entity: ENTITY, statistics: false, attribute: 'some_attribute' }, true, ['off', 'on'],
+    );
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // buildConfig() defaults state_map to []
+  [[], undefined, null, 'off', 123, { off: 0 }].forEach((state_map) => {
+    it(`checkStatistics: state_map [${JSON.stringify(state_map)}] is not a configured map`, () => {
+      const warn = mockWarn();
+      const config = makeConfig({ entity: ENTITY, statistics: true }, undefined, state_map);
+      checkStatistics(config, 0);
+      expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  it('checkStatistics: [attribute] wins over [state_map] in a warning', () => {
+    const warn = mockWarn();
+    const config = makeConfig(
+      { entity: ENTITY, statistics: true, attribute: 'some_attribute' }, undefined, ['off', 'on'],
+    );
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0].join(' ')).toContain('attribute');
+  });
+
+  it('checkStatistics: only an addressed entity is affected', () => {
+    const config: ConfigType = {
+      entities: [
+        { entity: 'sensor.first', statistics: true },
+        { entity: 'sensor.second' },
+      ],
+    };
+    checkStatistics(config, 0);
+    expect(config.entities[0].statistics).toEqual({ type: DEFAULT_STATISTICS_TYPE });
+    expect(config.entities[1].statistics).toBeUndefined();
+  });
+});

--- a/tests/getStatisticsType.test.ts.dis
+++ b/tests/getStatisticsType.test.ts.dis
@@ -1,0 +1,92 @@
+/**
+ * Tests for getStatisticsType().
+ *
+ * The file is disabled (renamed to *.dis) & thus is not used during a build process;
+ * remove the "dis" extension to use it locally in your VSCode devcontainer.
+ */
+
+import { expect, describe, it } from 'vitest';
+import { getStatisticsType } from '../others';
+import { STATISTICS_TYPES } from '../const';
+
+// buckets as returned by "recorder/statistics_during_period",
+// one set per state_class (see DEFAULT_STATISTICS in HA sensor/recorder.py)
+const MEASUREMENT = [
+  { start: 1786215600000, end: 1786219200000, last_reset: null, mean: 16.15, min: 15.6, max: 17.6 },
+  { start: 1786219200000, end: 1786222800000, last_reset: null, mean: 16.4, min: 16.1, max: 17.2 },
+];
+// a circular mean: min/max are present but always null
+const MEASUREMENT_ANGLE = [
+  { start: 1786215600000, end: 1786219200000, last_reset: null, mean: 225.34, min: null, max: null },
+  { start: 1786219200000, end: 1786222800000, last_reset: null, mean: 231.02, min: null, max: null },
+];
+const TOTAL_INCREASING = [
+  { start: 1786215600000, end: 1786219200000, last_reset: null, sum: 335632.3, state: 39.96, change: 0.02 },
+  { start: 1786219200000, end: 1786222800000, last_reset: null, sum: 335632.31, state: 39.97, change: 0.01 },
+];
+
+describe('getStatisticsType', () => {
+
+  it('getStatisticsType: measurement, no type requested -> mean', () => {
+    expect(getStatisticsType(MEASUREMENT)).toBe('mean');
+  });
+
+  it('getStatisticsType: measurement_angle, no type requested -> mean', () => {
+    expect(getStatisticsType(MEASUREMENT_ANGLE)).toBe('mean');
+  });
+
+  it('getStatisticsType: total_increasing, no type requested -> state', () => {
+    expect(getStatisticsType(TOTAL_INCREASING)).toBe('state');
+  });
+
+  ['mean', 'min', 'max'].forEach((type) => {
+    it(`getStatisticsType: measurement has [${type}]`, () => {
+      expect(getStatisticsType(MEASUREMENT, type)).toBe(type);
+    });
+  });
+
+  ['sum', 'state', 'change'].forEach((type) => {
+    it(`getStatisticsType: total_increasing has [${type}]`, () => {
+      expect(getStatisticsType(TOTAL_INCREASING, type)).toBe(type);
+    });
+  });
+
+  // a circular mean has no min/max, even though the keys are there
+  ['min', 'max'].forEach((type) => {
+    it(`getStatisticsType: measurement_angle has no [${type}] -> mean`, () => {
+      expect(getStatisticsType(MEASUREMENT_ANGLE, type)).toBe('mean');
+    });
+  });
+
+  ['sum', 'state', 'change'].forEach((type) => {
+    it(`getStatisticsType: measurement has no [${type}] -> mean`, () => {
+      expect(getStatisticsType(MEASUREMENT, type)).toBe('mean');
+    });
+  });
+
+  ['mean', 'min', 'max'].forEach((type) => {
+    it(`getStatisticsType: total_increasing has no [${type}] -> state`, () => {
+      expect(getStatisticsType(TOTAL_INCREASING, type)).toBe('state');
+    });
+  });
+
+  it('getStatisticsType: "last_reset" is not a graph type', () => {
+    expect(STATISTICS_TYPES).not.toContain('last_reset');
+    expect(getStatisticsType(MEASUREMENT, 'last_reset')).toBe('mean');
+  });
+
+  it('getStatisticsType: a gap in a single bucket does not hide a type', () => {
+    const stats = [{ ...MEASUREMENT[0], mean: null }, MEASUREMENT[1]];
+    expect(getStatisticsType(stats, 'mean')).toBe('mean');
+  });
+
+  it('getStatisticsType: neither default is available -> a first available type', () => {
+    expect(getStatisticsType([{ start: 1, min: 1, max: 2 }])).toBe('min');
+  });
+
+  [undefined, null, [], [{}], [{ start: 1, end: 2, last_reset: null }]].forEach((stats) => {
+    it(`getStatisticsType: no types in [${JSON.stringify(stats)}] -> undefined`, () => {
+      expect(getStatisticsType(stats, 'mean')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `statistics` option, per entity or card-wide, that sources a series from Home Assistant's long-term statistics instead of raw recorder history.

```yaml
type: custom:mini-graph-card
hours_to_show: 336
points_per_hour: 1
entities:
  - entity: sensor.outside_temperature
    statistics: true          # or: { period: hour, type: mean }
```

## Rationale

The card has one data path: `history/period`, i.e. raw recorder history. That has two consequences for long graphs.

**It is bounded by the recorder.** With `purge_keep_days: 30`, a graph cannot show more than 30 days no matter what `hours_to_show` says. Long-term statistics are kept indefinitely, so ranges the recorder simply cannot serve become possible — on my install these sensors have hourly statistics back to 2022 against 30 days of raw history.

**It scales with state rows, not with pixels.** Every state row in the window is fetched and then bucketed client side, so cost is driven by how chattily the sensor reports rather than by how much the graph can actually display. A 336 h graph on a ~300 px card can show a few hundred points; fetching six figures of rows to draw them is pure overhead. Statistics are pre-aggregated server side, so the fetch is already close to what gets drawn.

This matters most exactly where the card is least usable today, and it is opt-in — nothing changes unless `statistics` is set.

## Example: a real dashboard

A plant dashboard with 10 cards, each a 4-tab set (1 h / 6 h / 24 h / 14 d) over 2 entities — 40 card instances, 80 series, all fetched when the view opens.

Measured per tab, via `history/history_during_period` for all 10 cards:

| tab | recorder time | rows returned |
|---|---|---|
| 1 h | 0.10 s | 473 |
| 6 h | 0.16 s | 2,749 |
| 24 h | 0.49 s | 11,815 |
| **14 d** | **13.26 s** | **152,087** |
| **total** | **14.01 s** | **167,124** |

The 14-day tab is **95 % of the page's history cost**. The same 20 series over the same 14 days, via `recorder/statistics_during_period` at `period: hour`:

| source | time | points |
|---|---|---|
| raw history | 13.26 s | 152,087 rows |
| hourly statistics | **1.04 s** | 6,700 points |

**~13x faster for the same window**, and visually identical: 336 hourly points per series is already more than a 300 px-wide graph can resolve.

Because the option is per entity/card, the short tabs can stay on raw history where sub-hour resolution actually matters, and only the long tab switches:

```yaml
# 1h / 6h / 24h tabs — unchanged, raw history
# 14d tab:
hours_to_show: 336
points_per_hour: 1
statistics:
  type: mean
```

For reference, a full year of the same 20 series at `period: day` costs 3.0 s / 3,864 points — a range raw history cannot produce at all under a 30-day purge.

## Implementation

The fetch is the only thing that changes. Both paths produce the same normalised `[{last_changed, state}]` series, so bucketing, extrema, colour thresholds, bounds and the secondary y-axis are untouched. The shared tail of `updateEntity()` is extracted into `applyHistory()` and called from both.

- `period` defaults from `hours_to_show`, since HA only retains `5minute` statistics for a limited window (10 days by default) while hourly are kept indefinitely — so a long graph does not ask for data that has been purged.
- `type` selects `mean` (default), `min`, `max`, `sum` or `state`.
- Validation lives in `checkOption.js` as `checkStatistics()`, alongside the existing option checks.
- Statistics refetch the whole window rather than appending to the cached tail: a period's bucket is revised until that period completes, so an incremental merge would duplicate or truncate the boundary bucket. Cache separation is automatic, as the key already includes the config hash.

Entities without a `state_class` have no statistics; that is documented rather than silently falling back, so the failure is visible.

Refs #641

## Notes

- No new lint errors. `dev` currently reports 3 (`checkOption.js` x2 `no-param-reassign`, `others.js` missing semicolon); this branch reports the same 3.
- README documents the option, including the interaction with `points_per_hour` (statistics are aggregated into fixed periods, so more than one point per period only yields empty buckets).