### PR TITLE
fix: restore a passing lint on dev

### DIFF
--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -155,6 +155,7 @@ const checkBounds = (config) => {
   return { lowerBound, upperBound };
 };
 
+/* eslint-disable no-param-reassign */
 /**
  * Check color_thresholds array.
  * @param {object} config Config object containing color_thresholds
@@ -211,6 +212,7 @@ const checkColorThresholds = (config, configName) => {
       return { color: 'var(--primary-text-color)' };
     });
 };
+/* eslint-enable no-param-reassign */
 
 export {
   checkNumericOption,

--- a/src/others.js
+++ b/src/others.js
@@ -97,7 +97,7 @@ const getFactor = (config, index = undefined) => {
       logStringWarning(factor, 'factor');
       switch (type) {
         case 'exponent':
-          return getExponent(Number(factor))
+          return getExponent(Number(factor));
         default: // scale
           return Number(factor);
       }


### PR DESCRIPTION
"npm run lint" fails on dev with three errors, all from #1421:

  src/checkOption.js  174:5   no-param-reassign
  src/checkOption.js  178:3   no-param-reassign
  src/others.js       100:45  semi

They have been there since f1c8f1f on 7 August. CI last ran on dev on the 6th, and a pull request from a fork needs a maintainer to approve its run, so nothing has reported them.

checkColorThresholds() writes its result back into the config it is given, which is the same thing buildConfig.js does a few lines from where it is called - so this scopes the rule off around that function, matching the "eslint-disable no-param-reassign" already at buildConfig.js:204, rather than changing what the function does. The other one is a missing semicolon.