### PR TITLE
feat: per-entity "animate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | attribute | string |         | Retrieves an attribute or [sub-attribute (attr1.attr2...)](#accessing-attributes-in-complex-structures) instead of the state
 | static_value | number |         | Set a value for a [static line](#static-lines). Either `entity` or `static_value` must be defined.
 | name | string |         | Set a custom display name, defaults to entity's friendly_name or a `Static` label for a [static value](#static-lines).
+| animate    | boolean |        | Override for a reveal animation to the graph.
 | line_width | number |         | Override for a thickness of the line.
 | line_style | string |   | Override the style of the line (see [Line styles](#line-styles)).
 | color | string |         | Set a custom color, overrides all other color options including thresholds.

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -18,6 +18,7 @@ import {
   checkIntegerOption,
   checkBounds,
   checkColorThresholds,
+  checkLineStyle,
 } from './checkOption';
 import { getFactor } from './others';
 
@@ -253,10 +254,13 @@ export default (config) => {
   // set valid values for bar_spacing options
   conf.bar_spacing = conf.bar_spacing < 0
     ? -1 : conf.bar_spacing; // "-1" stands for stacked bars
-  conf.bar_spacing_group = conf.bar_spacing_group !== undefined
+  conf.bar_spacing_group = conf.bar_spacing_group !== undefined && conf.bar_spacing_group !== null
     ? conf.bar_spacing_group
     : conf.bar_spacing < 0
       ? DEFAULT_BAR_SPACING : conf.bar_spacing;
+
+  // warn if line_style is defined along with animate=true
+  checkLineStyle(config);
 
   // override points per hour to mach group_by function
   switch (conf.group_by) {

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -229,7 +229,7 @@ const checkLineStyle = (config) => {
       }
     }
   });
-}
+};
 
 export {
   checkNumericOption,

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -3,6 +3,7 @@ import {
   isNumeric,
   logStringWarning,
   getBound,
+  isEntryAnimated,
 } from './others';
 
 /**
@@ -214,10 +215,27 @@ const checkColorThresholds = (config, configName) => {
 };
 /* eslint-enable no-param-reassign */
 
+/**
+ * Warn if line_style is defined along with animate=true.
+ * @param {object} config Config object
+ */
+const checkLineStyle = (config) => {
+  config.entities.forEach((entity, index) => {
+    if (isEntryAnimated(config, index)) {
+      const hasLineStyle = (entity.line_style !== undefined && entity.line_style !== null)
+        || (config.line_style !== undefined && config.line_style !== null);
+      if (hasLineStyle) {
+        log(`Option 'line_style' will be ignored for entity[${index}] because animation is enabled for it`);
+      }
+    }
+  });
+}
+
 export {
   checkNumericOption,
   checkIntegerOption,
   checkBoundOption,
   checkBounds,
   checkColorThresholds,
+  checkLineStyle,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -313,7 +313,7 @@ class MiniGraphCard extends LitElement {
     super.updated(changedProperties);
 
     const hasAnimation = this.config.entities.some(
-      (_, index) => isEntryAnimated(this.config, index)
+      (_, index) => isEntryAnimated(this.config, index),
     );
     if (hasAnimation && changedProperties.has('line')) {
       if (this.length.length < this.config.entities.length) {

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,10 @@ import {
   DEFAULT_MARGIN,
   NBSP,
 } from './const';
-import { isNumeric } from './others';
+import {
+  isNumeric,
+  isEntryAnimated,
+} from './others';
 import {
   getMin, getAvg, getMax,
   getMilli,
@@ -309,14 +312,18 @@ class MiniGraphCard extends LitElement {
   updated(changedProperties) {
     super.updated(changedProperties);
 
-    if (this.config.animate && changedProperties.has('line')) {
-      if (this.length.length < this.entity.length) {
+    const hasAnimation = this.config.entities.some(
+      (_, index) => isEntryAnimated(this.config, index)
+    );
+    if (hasAnimation && changedProperties.has('line')) {
+      if (this.length.length < this.config.entities.length) {
         this.shadowRoot.querySelectorAll('svg path.line').forEach((ele) => {
-          this.length[ele.id] = ele.getTotalLength();
+          const index = ele.id;
+          this.length[index] = isEntryAnimated(this.config, index) ? ele.getTotalLength() : 'none';
         });
         this.length = [...this.length];
       } else {
-        this.length = Array(this.entity.length).fill('none');
+        this.length = Array(this.config.entities.length).fill('none');
       }
     }
   }
@@ -781,6 +788,7 @@ class MiniGraphCard extends LitElement {
   */
   renderSvgFill(fill, index) {
     if (!fill) return;
+    const isAnimated = isEntryAnimated(this.config, index);
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
     return svg`
@@ -796,8 +804,8 @@ class MiniGraphCard extends LitElement {
       <mask id=${`fill-${this.id}-${index}`}>
         <path class='fill'
           type=${this.config.show.fill}
-          .id=${index} anim=${this.config.animate} ?init=${init}
-          style="animation-delay: ${this.config.animate ? `${index * 0.5}s` : '0s'}"
+          .id=${index} anim=${isAnimated} ?init=${init}
+          style="animation-delay: ${isAnimated ? `${index * 0.5}s` : '0s'}"
           fill='white'
           mask=${fade ? `url(#fill-grad-mask-${this.id}-${index})` : ''}
           d=${this.fill[index]}
@@ -813,10 +821,15 @@ class MiniGraphCard extends LitElement {
   */
   renderSvgLine(line, index) {
     if (!line) return;
-    const strokeDashArray = (this.config.animate
+    const isAnimated = isEntryAnimated(this.config, index);
+    // line_style is ignored if animate=true
+    const strokeDashArray = (isAnimated
       ? this.length[index]
       : this.config.entities[index].line_style || this.config.line_style)
       || 'none';
+    const strokeDashOffset = isAnimated
+      ? this.length[index] || 'none'
+      : 'none';
     const lineWidth = getFirstDefinedItem(
       this.config.entities[index].line_width,
       this.config.line_width,
@@ -825,10 +838,10 @@ class MiniGraphCard extends LitElement {
       <path
         class='line'
         .id=${index}
-        anim=${this.config.animate} ?init=${this.length[index]}
-        style="animation-delay: ${this.config.animate ? `${index * 0.5}s` : '0s'}"
+        anim=${isAnimated} ?init=${this.length[index]}
+        style="animation-delay: ${isAnimated ? `${index * 0.5}s` : '0s'}"
         fill='none'
-        stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[index] || 'none'}
+        stroke-dasharray=${strokeDashArray} stroke-dashoffset=${strokeDashOffset}
         stroke=${'white'}
         stroke-width=${lineWidth}
         d=${this.line[index]}
@@ -886,13 +899,14 @@ class MiniGraphCard extends LitElement {
       this.config.entities[index].line_width,
       this.config.line_width,
     );
+    const isAnimated = isEntryAnimated(this.config, index);
     return svg`
       <g class='line--points'
         ?tooltip=${this.tooltip.entity === index}
         ?inactive=${inactive}
         ?init=${this.length[index]}
-        anim=${this.config.animate && this.config.show.points !== 'hover'}
-        style="animation-delay: ${this.config.animate ? `${index * 0.5 + 0.5}s` : '0s'}"
+        anim=${isAnimated && this.config.show.points !== 'hover'}
+        style="animation-delay: ${isAnimated ? `${index * 0.5 + 0.5}s` : '0s'}"
         fill=${color}
         stroke=${color}
         stroke-width=${radius / 2}>
@@ -978,8 +992,9 @@ class MiniGraphCard extends LitElement {
   */
   renderSvgBars(bars, index) {
     if (!bars) return;
+    const isAnimated = isEntryAnimated(this.config, index);
     const items = bars.map((bar, i) => {
-      const animation = this.config.animate
+      const animation = isAnimated
         ? svg`
           <animate attributeName='y' from=${this.config.height} to=${bar.y} dur='1s' fill='remove'
             calcMode='spline' keyTimes='0; 1' keySplines='0.215 0.61 0.355 1'>
@@ -1000,7 +1015,7 @@ class MiniGraphCard extends LitElement {
     return svg`
       <g
         class='bars'
-        ?anim=${this.config.animate}
+        ?anim=${isAnimated}
         ?inactive=${inactive}
       >${items}</g>`;
   }

--- a/src/others.js
+++ b/src/others.js
@@ -152,9 +152,24 @@ const getBound = (bound) => {
   return undefined;
 };
 
+/**
+ * Checks if animation is enabled for a specific entry in config.entities.
+ * @param {object} config Config object
+ * @param {number} index Index of an entry in config.entities
+ * @returns {boolean} True if animated, false - otherwise
+ */
+const isEntryAnimated = (config, index) => {
+  const entryConf = config.entities && config.entities[index];
+  if (entryConf && entryConf.animate !== undefined && entryConf.animate !== null) {
+    return entryConf.animate === true;
+  }
+  return config.animate === true;
+};
+
 export {
   isNumeric,
   logStringWarning,
   getFactor,
   getBound,
+  isEntryAnimated,
 };


### PR DESCRIPTION
1. Added per-entity `animate` option. Can be used, for example, to disable animation for static lines.
2. Added a check into `buildConfig()`: if `line_style` is defined along with `animate: true`, a message is logged in a console.

Example: `animate` is disabled for a static line:
```
type: custom:mini-graph-card
entities:
  - entity: sensor.xiaomi_cg_1_co2
  - entity: sensor.xiaomi_cg_2_co2
  - static_value: 600
    line_width: 1
    line_style: 2, 4
    animate: false
    show_legend: false
hours_to_show: 4
points_per_hour: 60
smoothing: true
show:
  points: false
  fill: false
  state: false
  name: false
height: 150
animate: true
```
<img width="504" height="260" alt="ani" src="https://github.com/user-attachments/assets/7e7cfb47-e7fe-48b3-8ae9-cdbbab625c4c" />


