### PR TITLE
fix: pass the built config to checkLineStyle

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -260,7 +260,7 @@ export default (config) => {
       ? DEFAULT_BAR_SPACING : conf.bar_spacing;
 
   // warn if line_style is defined along with animate=true
-  checkLineStyle(config);
+  checkLineStyle(conf);
 
   // override points per hour to mach group_by function
   switch (conf.group_by) {


### PR DESCRIPTION
Just a minor consistency fix.

Every other check in buildConfig receives `conf`.

`checkLineStyle()` receives the raw `config`.

No behaviour change today, but if `checkLineStyle` is extended (the name suggest that it could do more than just logging a warning) it would probably be a good idea to give it the normalized `conf` instead of the raw `config`.