### PR TITLE
feat: Adaptive height

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
-| height | number | `150` | v0.0.1 | Set a custom height of the line graph.
+| height | number | `100` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph. Value `-1` is used to place bars on each other. See [examples](#bar-spacing-examples).
 | bar_spacing_group | number |   | 0.14.0 | Set an additional spacing between bar groups (multiple entities) in bar graph. Fallback to `bar_spacing` if undefined; if `bar_spacing: -1` - then a default `4` value is used. See [examples](#bar-spacing-examples).
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
-| height | number | `100` | v0.0.1 | Set a custom height of the line graph.
+| height | number | `100` | v0.0.1 | Set the height of the line graph in pixels.<br>If omitted, the height is calculated automatically (minimum `100`) when placed inside a `horizontal-stack` card, `grid` card, or sections view layout. Otherwise, it defaults to `100`. |
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph. Value `-1` is used to place bars on each other. See [examples](#bar-spacing-examples).
 | bar_spacing_group | number |   | 0.14.0 | Set an additional spacing between bar groups (multiple entities) in bar graph. Fallback to `bar_spacing` if undefined; if `bar_spacing: -1` - then a default `4` value is used. See [examples](#bar-spacing-examples).
 | line_width | number | `5` | v0.0.1 | Set the thickness of the line.

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -4,7 +4,6 @@ import {
   DEFAULT_FONT_SIZE,
   DEFAULT_FONT_SIZE_HEADER,
   DEFAULT_BAR_SPACING,
-  DEFAULT_GRAPH_HEIGHT,
   DEFAULT_MARGIN,
   DEFAULT_HOURS_TO_SHOW,
   DEFAULT_POINTS_PER_HOUR,
@@ -140,7 +139,6 @@ export default (config) => {
     animate: false,
     font_size: DEFAULT_FONT_SIZE,
     font_size_header: DEFAULT_FONT_SIZE_HEADER,
-    height: DEFAULT_GRAPH_HEIGHT,
     hours_to_show: DEFAULT_HOURS_TO_SHOW,
     points_per_hour: DEFAULT_POINTS_PER_HOUR,
     aggregate_func: 'avg',
@@ -168,7 +166,7 @@ export default (config) => {
   conf.bar_spacing = checkNumericOption(conf, 'bar_spacing', DEFAULT_BAR_SPACING, -1, undefined, true);
   conf.bar_spacing_group = checkNumericOption(conf, 'bar_spacing_group', undefined, 0, undefined, true);
 
-  conf.height = checkNumericOption(conf, 'height', DEFAULT_GRAPH_HEIGHT, 0, undefined, true);
+  conf.height = checkNumericOption(conf, 'height', undefined, 0, undefined, true);
 
   conf.line_width = checkNumericOption(conf, 'line_width', DEFAULT_MARGIN, 0, undefined, true);
 

--- a/src/main.js
+++ b/src/main.js
@@ -192,7 +192,7 @@ class MiniGraphCard extends LitElement {
       this.Graph = this.config.entities.map(
         (entity, index) => new Graph({
           width: 500,
-          height: this.config.height,
+          height: this.getGraphHeight(),
           margin,
           hours_to_show: this.config.hours_to_show,
           points_per_hour: this.config.points_per_hour,
@@ -218,6 +218,16 @@ class MiniGraphCard extends LitElement {
         }),
       );
     }
+  }
+
+  /**
+   * Safely returns a graph's height
+   * @returns {number} Graph's height
+   */
+  getGraphHeight() {
+    return this.config.height !== undefined
+      ? this.config.height
+      : DEFAULT_GRAPH_HEIGHT;
   }
 
   /**
@@ -723,8 +733,7 @@ class MiniGraphCard extends LitElement {
       return html``;
     }
 
-    const graphHeight = this.config.height !== undefined
-      ? this.config.height : DEFAULT_GRAPH_HEIGHT;
+    const graphHeight = this.getGraphHeight();
     if (!isNumeric(graphHeight) || graphHeight <= 0) {
       return html``;
     }
@@ -981,7 +990,7 @@ class MiniGraphCard extends LitElement {
     const items = bars.map((bar, i) => {
       const animation = this.config.animate
         ? svg`
-          <animate attributeName='y' from=${this.config.height} to=${bar.y} dur='1s' fill='remove'
+          <animate attributeName='y' from=${this.getGraphHeight()} to=${bar.y} dur='1s' fill='remove'
             calcMode='spline' keyTimes='0; 1' keySplines='0.215 0.61 0.355 1'>
           </animate>`
         : '';
@@ -1032,7 +1041,8 @@ class MiniGraphCard extends LitElement {
   * @returns {SVGTemplateResult} SVG element
   */
   renderSvg() {
-    const { height, show } = this.config;
+    const height = this.getGraphHeight();
+    const { show } = this.config;
     const reversed = show.graph_order === 'reversed';
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'

--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,7 @@ class MiniGraphCard extends LitElement {
       }
       this.Graph = this.createGraph(this.getGraphHeight());
     }
+  }
 
   /**
    * Create an array of Graph objects

--- a/src/main.js
+++ b/src/main.js
@@ -352,7 +352,7 @@ class MiniGraphCard extends LitElement {
       return;
     }
 
-    this._graphResizeObserver = new ResizeObserver((entries) => {
+    this._graphResizeObserver = new window.ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) {
         return;
@@ -398,11 +398,10 @@ class MiniGraphCard extends LitElement {
 
           window.requestAnimationFrame(() => {
             // save histories
-            const savedHistories = this.Graph.map((graph) => (graph ? graph.history : undefined));
+            const savedHistories = this.Graph.map(graph => (graph ? graph.history : undefined));
             // re-create Graph objects
             this.Graph = this.createGraph(newHeight);
             // upload histories
-           
             this.Graph.forEach((graph, index) => {
               if (graph && savedHistories[index]) {
                 /* eslint-disable no-param-reassign */

--- a/src/main.js
+++ b/src/main.js
@@ -74,8 +74,8 @@ class MiniGraphCard extends LitElement {
     // for a currently unavailable entity
     this._preservedUom = [];
     this._preservedOrder = [];
-  
-      // resizing
+
+    // resizing
     this._computedHeight = undefined;
     this._graphResizeObserver = undefined;
     this._graphContainer = undefined;
@@ -229,7 +229,7 @@ class MiniGraphCard extends LitElement {
     return this.config.entities.map(
       (entity, index) => new Graph({
         width: 500,
-        height: this.getGraphHeight(),
+        height: height,
         margin: this._graphMargin,
         hours_to_show: this.config.hours_to_show,
         points_per_hour: this.config.points_per_hour,
@@ -353,7 +353,7 @@ class MiniGraphCard extends LitElement {
     }
 
     this._graphResizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0]; 
+      const entry = entries[0];
       if (!entry) {
         return;
       }
@@ -361,8 +361,8 @@ class MiniGraphCard extends LitElement {
       let pxWidth = entry.contentRect.width;
       let pxHeight = entry.contentRect.height;
 
-      const isShrinking = this._lastPxWidth !== undefined && 
-        (pxWidth < this._lastPxWidth || pxHeight < this._lastPxHeight);
+      const isShrinking = this._lastPxWidth !== undefined
+        && (pxWidth < this._lastPxWidth || pxHeight < this._lastPxHeight);
       const svgElement = graphContainer.querySelector('svg');
       if (svgElement && isShrinking) {
         // hide a graph, then measure an empty container, then unhide a graph
@@ -387,8 +387,8 @@ class MiniGraphCard extends LitElement {
         }
 
         // difference in height
-        const heightDelta = this._computedHeight !== undefined 
-          ? Math.abs(newHeight - this._computedHeight) 
+        const heightDelta = this._computedHeight !== undefined
+          ? Math.abs(newHeight - this._computedHeight)
           : Infinity;
 
         // re-create Graph only if a difference is significant
@@ -399,14 +399,14 @@ class MiniGraphCard extends LitElement {
           window.requestAnimationFrame(() => {
             // save histories
             const savedHistories = this.Graph.map(graph => graph ? graph.history : undefined);
-            //re-create Graph objects
+            // re-create Graph objects
             this.Graph = this.createGraph(newHeight);
             // upload histories
             this.Graph.forEach((graph, index) => {
               if (graph && savedHistories[index]) {
                 graph.history = savedHistories[index];
               }
-            });            
+            });
             this.updateData();
           });
         }
@@ -809,7 +809,7 @@ class MiniGraphCard extends LitElement {
     /* eslint-disable indent */
     return this.config.show.graph
       ? html`
-          <div class="graph">
+          <div class="graph ${graphAdditionalClass}">
             ${ready
               ? html`
                   <div class="graph__container">
@@ -1161,7 +1161,6 @@ class MiniGraphCard extends LitElement {
   renderSvgBars(bars, index) {
     if (!bars) return;
     const isAnimated = isEntryAnimated(this.config, index);
-    const graphHeight = this.config.height;
     const items = bars.map((bar, i) => {
       const barStyle = isAnimated ? 'transform-origin: 50% 100%;' : '';
       const color = this.computeColor(bar.value, index);

--- a/src/main.js
+++ b/src/main.js
@@ -398,13 +398,16 @@ class MiniGraphCard extends LitElement {
 
           window.requestAnimationFrame(() => {
             // save histories
-            const savedHistories = this.Graph.map((graph) => graph ? graph.history : undefined);
+            const savedHistories = this.Graph.map((graph) => (graph ? graph.history : undefined));
             // re-create Graph objects
             this.Graph = this.createGraph(newHeight);
             // upload histories
+           
             this.Graph.forEach((graph, index) => {
               if (graph && savedHistories[index]) {
+                /* eslint-disable no-param-reassign */
                 graph.history = savedHistories[index];
+                /* eslint-enable no-param-reassign */
               }
             });
             this.updateData();

--- a/src/main.js
+++ b/src/main.js
@@ -229,7 +229,7 @@ class MiniGraphCard extends LitElement {
     return this.config.entities.map(
       (entity, index) => new Graph({
         width: 500,
-        height: height,
+        height,
         margin: this._graphMargin,
         hours_to_show: this.config.hours_to_show,
         points_per_hour: this.config.points_per_hour,
@@ -378,7 +378,7 @@ class MiniGraphCard extends LitElement {
       if (pxWidth > 0 && pxHeight > 0) {
         let newHeight = 500 * (pxHeight / pxWidth);
         newHeight = Math.max(DEFAULT_GRAPH_HEIGHT, newHeight);
-        newHeight = parseInt(newHeight);
+        newHeight = parseInt(newHeight, 10);
 
         if (this._computedHeight === undefined && newHeight === DEFAULT_GRAPH_HEIGHT) {
           this._computedHeight = newHeight;
@@ -398,7 +398,7 @@ class MiniGraphCard extends LitElement {
 
           window.requestAnimationFrame(() => {
             // save histories
-            const savedHistories = this.Graph.map(graph => graph ? graph.history : undefined);
+            const savedHistories = this.Graph.map((graph) => graph ? graph.history : undefined);
             // re-create Graph objects
             this.Graph = this.createGraph(newHeight);
             // upload histories

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,27 @@ class MiniGraphCard extends LitElement {
     // for a currently unavailable entity
     this.preserved_uom = [];
     this.preserved_order = [];
+  
+      // resizing
+    this._computedHeight = undefined;
+    this._graphResizeObserver = undefined;
+    this._graphContainer = undefined;
+    // last SVG sizes
+    this._lastPxWidth = undefined;
+    this._lastPxHeight = undefined;
+
+    // track orientation change events on a mobile client
+    this._handleOrientationResize = () => {
+      if (this.config && (this.config.height === undefined || this.config.height === null)) {
+        this._computedHeight = undefined;
+        this.length = [];
+        setTimeout(() => {
+          if (this.line) {
+            this.line = [...this.line];
+          }
+        }, 300);
+      }
+    };
   }
 
   static get styles() {
@@ -178,56 +199,69 @@ class MiniGraphCard extends LitElement {
     this.updateHour24 = config.hour24 === undefined;
     this.updateDateTimeFormat = config.datetime_format === undefined;
 
+    const {
+      min: min_line_width,
+      max: max_line_width,
+    } = this.getMinMaxLineWidth();
+    this._graphMargin = this.config.show.graph === 'bar'
+      ? [DEFAULT_MARGIN, DEFAULT_MARGIN]
+      : this.config.show.fill
+        ? [0, max_line_width]
+        : [min_line_width, max_line_width];
+
     if (!this.Graph || entitiesChanged) {
-      if (this._hass) this.hass = this._hass;
-      const {
-        min: min_line_width,
-        max: max_line_width,
-      } = this.getMinMaxLineWidth();
-      const margin = this.config.show.graph === 'bar'
-        ? [DEFAULT_MARGIN, DEFAULT_MARGIN]
-        : this.config.show.fill
-          ? [0, max_line_width]
-          : [min_line_width, max_line_width];
-      this.Graph = this.config.entities.map(
-        (entity, index) => new Graph({
-          width: 500,
-          height: this.getGraphHeight(),
-          margin,
-          hours_to_show: this.config.hours_to_show,
-          points_per_hour: this.config.points_per_hour,
-          aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
-          groupBy: this.config.group_by,
-          smoothing: getFirstDefinedItem(
-            entity.smoothing,
-            this.config.smoothing,
-            this.getDefaultSmoothing(index),
-          ),
-          logarithmic: getFirstDefinedItem(
-            entity.logarithmic,
-            this.config.logarithmic,
-            false,
-          ),
-          bar_spacing: this.config.bar_spacing,
-          bar_spacing_group: this.config.bar_spacing_group,
-          total_bars_in_group: this.visibleEntities.length,
-          fill_baseline: getFirstDefinedItem(
-            entity.fill_baseline,
-            this.config.fill_baseline,
-          ),
-        }),
-      );
+      if (this._hass) {
+        this.hass = this._hass;
+      }
+      this.Graph = this.createGraph(this.getGraphHeight());
     }
+
+  /**
+   * Create an array of Graph objects
+   * @param {number} height Graph's height
+   * @returns {Array} Array of Graph objects
+   */
+  createGraph(height) {
+    return this.config.entities.map(
+      (entity, index) => new Graph({
+        width: 500,
+        height: this.getGraphHeight(),
+        margin: this._graphMargin,
+        hours_to_show: this.config.hours_to_show,
+        points_per_hour: this.config.points_per_hour,
+        aggregateFuncName: entity.aggregate_func || this.config.aggregate_func,
+        groupBy: this.config.group_by,
+        smoothing: getFirstDefinedItem(
+          entity.smoothing,
+          this.config.smoothing,
+          this.getDefaultSmoothing(index),
+        ),
+        logarithmic: getFirstDefinedItem(
+          entity.logarithmic,
+          this.config.logarithmic,
+          false,
+        ),
+        bar_spacing: this.config.bar_spacing,
+        bar_spacing_group: this.config.bar_spacing_group,
+        total_bars_in_group: this.visibleEntities.length,
+        fill_baseline: getFirstDefinedItem(
+          entity.fill_baseline,
+          this.config.fill_baseline,
+        ),
+      }),
+    );
   }
 
   /**
-   * Safely returns a graph's height
+   * Safely return a graph's height.
    * @returns {number} Graph's height
    */
   getGraphHeight() {
     return this.config.height !== undefined
       ? this.config.height
-      : DEFAULT_GRAPH_HEIGHT;
+      : this._computedHeight !== undefined
+        ? this._computedHeight
+        : DEFAULT_GRAPH_HEIGHT;
   }
 
   /**
@@ -280,6 +314,116 @@ class MiniGraphCard extends LitElement {
     }
   }
 
+  /**
+   * Initialize ResizeObserver to track container's height changes
+   * @returns {void}
+   */
+  observeGraphHeight() {
+    if (this.config.show.graph === false
+      || (this.config.height !== undefined && this.config.height !== null)) {
+      // no need to track
+      return;
+    }
+
+    const graphContainer = this.shadowRoot.querySelector('.graph__container');
+    if (!graphContainer) {
+      // graph__container not created yet
+      return;
+    }
+
+    const isContainerChanged = this._graphContainer !== graphContainer;
+    const oldGraphContainer = this._graphContainer;
+    this._graphContainer = graphContainer;
+
+    if (this._graphResizeObserver) {
+      if (isContainerChanged) {
+        // graph__container is changed, reconnect observer
+        // disconnect from the old container
+        this._graphResizeObserver.unobserve(oldGraphContainer);
+        // connect to the new container
+        this._graphResizeObserver.observe(graphContainer);
+      } else {
+        // do not do anything, just ignore
+      }
+      return;
+    }
+
+    this._graphResizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0]; 
+      if (!entry) {
+        return;
+      }
+
+      let pxWidth = entry.contentRect.width;
+      let pxHeight = entry.contentRect.height;
+
+      const isShrinking = this._lastPxWidth !== undefined && 
+        (pxWidth < this._lastPxWidth || pxHeight < this._lastPxHeight);
+      const svgElement = graphContainer.querySelector('svg');
+      if (svgElement && isShrinking) {
+        // hide a graph, then measure an empty container, then unhide a graph
+        svgElement.style.display = 'none';
+        pxWidth = graphContainer.clientWidth;
+        pxHeight = graphContainer.clientHeight;
+        svgElement.style.display = 'block';
+      }
+
+      this._lastPxWidth = pxWidth;
+      this._lastPxHeight = pxHeight;
+
+      if (pxWidth > 0 && pxHeight > 0) {
+        let newHeight = 500 * (pxHeight / pxWidth);
+        newHeight = Math.max(DEFAULT_GRAPH_HEIGHT, newHeight);
+        newHeight = parseInt(newHeight);
+
+        if (this._computedHeight === undefined && newHeight === DEFAULT_GRAPH_HEIGHT) {
+          this._computedHeight = newHeight;
+          // do not do anything, just exit
+          return;
+        }
+
+        // difference in height
+        const heightDelta = this._computedHeight !== undefined 
+          ? Math.abs(newHeight - this._computedHeight) 
+          : Infinity;
+
+        // re-create Graph only if a difference is significant
+        if (this._computedHeight === undefined || heightDelta > 3) {
+          this._computedHeight = newHeight;
+          this.length = []; // re-initiate animation
+
+          window.requestAnimationFrame(() => {
+            // save histories
+            const savedHistories = this.Graph.map(graph => graph ? graph.history : undefined);
+            //re-create Graph objects
+            this.Graph = this.createGraph(newHeight);
+            // upload histories
+            this.Graph.forEach((graph, index) => {
+              if (graph && savedHistories[index]) {
+                graph.history = savedHistories[index];
+              }
+            });            
+            this.updateData();
+          });
+        }
+      }
+    });
+
+    this._graphResizeObserver.observe(graphContainer);
+  }
+
+  /**
+   * Disconnect and clean up ResizeObserver.
+   * @returns {void}
+   */
+  unobserveGraphHeight() {
+    if (this._graphResizeObserver) {
+      this._graphResizeObserver.disconnect();
+      this._graphResizeObserver = undefined;
+      this._graphContainer = undefined;
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
     if (this.config.update_interval) {
@@ -291,11 +435,19 @@ class MiniGraphCard extends LitElement {
         this.config.update_interval * 1000,
       );
     }
+    // track orientation change events on a mobile client
+    window.addEventListener('resize', this._handleOrientationResize);
   }
 
   disconnectedCallback() {
     if (this.interval) {
       clearInterval(this.interval);
+    }
+    // disconnect resize observer
+    this.unobserveGraphHeight();
+    // remove listener for orientation change events
+    if (this._handleOrientationResize) {
+      window.removeEventListener('resize', this._handleOrientationResize);
     }
     super.disconnectedCallback();
   }
@@ -311,13 +463,17 @@ class MiniGraphCard extends LitElement {
     }
   }
 
-  firstUpdated() {
+  firstUpdated(changedProperties) {
+    super.firstUpdated(changedProperties);
     this.initial = false;
     this.updateFormatFromLocale(true);
   }
 
   updated(changedProperties) {
     super.updated(changedProperties);
+
+    // track a graph container's height
+    this.observeGraphHeight();
 
     if (this.config.animate && changedProperties.has('line')) {
       if (this.length.length < this.entity.length) {
@@ -639,7 +795,9 @@ class MiniGraphCard extends LitElement {
           && this.config.entities[index].show_graph !== false,
       ))
     || this.config.show.loading_indicator === false;
-
+    const graphAdditionalClass = this.config.height === undefined || this.config.height === null
+      ? 'graph--auto-height'
+      : 'graph--custom-height';
     /* eslint-disable indent */
     return this.config.show.graph
       ? html`
@@ -647,10 +805,8 @@ class MiniGraphCard extends LitElement {
             ${ready
               ? html`
                   <div class="graph__container">
-                    <div class="graph__container__svg">
-                      ${this.renderSvg()}
-                      ${this.renderStaticLabels()}
-                    </div>
+                    ${this.renderSvg()}
+                    ${this.renderStaticLabels()}
                     ${this.renderLabels()}
                     ${this.renderLabelsSecondary()}
                   </div>
@@ -840,6 +996,7 @@ class MiniGraphCard extends LitElement {
         stroke-dasharray=${strokeDashArray} stroke-dashoffset=${this.length[index] || 'none'}
         stroke=${'white'}
         stroke-width=${lineWidth}
+        vector-effect="non-scaling-stroke"
         d=${this.line[index]}
       />`;
     return svg`
@@ -868,6 +1025,7 @@ class MiniGraphCard extends LitElement {
         stroke=${color}
         fill=${color}
         cx=${point[X]} cy=${point[Y]} r=${radius}
+        vector-effect="non-scaling-stroke"
         @mouseover=${() => this.setTooltip(index, point[3], point[V])}
         @mouseout=${() => (this.tooltip = {})}
       />
@@ -988,19 +1146,14 @@ class MiniGraphCard extends LitElement {
   renderSvgBars(bars, index) {
     if (!bars) return;
     const items = bars.map((bar, i) => {
-      const animation = this.config.animate
-        ? svg`
-          <animate attributeName='y' from=${this.getGraphHeight()} to=${bar.y} dur='1s' fill='remove'
-            calcMode='spline' keyTimes='0; 1' keySplines='0.215 0.61 0.355 1'>
-          </animate>`
-        : '';
+      const barStyle = isAnimated ? 'transform-origin: 50% 100%;' : '';
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
           height=${bar.height} width=${bar.width} fill=${color}
+          style=${barStyle}
           @mouseover=${() => this.setTooltip(index, i, bar.value)}
           @mouseout=${() => (this.tooltip = {})}>
-          ${animation}
         </rect>`;
     });
     const inactive = this.tooltip.entity !== undefined
@@ -1046,6 +1199,7 @@ class MiniGraphCard extends LitElement {
     const reversed = show.graph_order === 'reversed';
     return svg`
       <svg width='100%' height=${height !== 0 ? '100%' : 0} viewBox='0 0 500 ${height}'
+        preserveAspectRatio="xMidYMin meet"
         @click=${e => e.stopPropagation()}>
         <g>
           <defs>

--- a/src/style.js
+++ b/src/style.js
@@ -2,11 +2,13 @@ import { css } from 'lit-element';
 
 const style = css`
   ha-card {
+    display: flex;
     flex-direction: column;
+    height: 100%;
+    min-height: 0;
     flex: 1;
     padding: 16px 0 0 0;
     position: relative;
-    height: 100%;
     overflow: hidden;
   }
   ha-card > div {
@@ -243,8 +245,33 @@ const style = css`
     left: initial;
     right: 0;
   }
+  .graph.graph--custom-height,
+  .graph.graph--custom-height .graph__container,
+  .graph.graph--custom-height .graph__container svg {
+    flex-grow: 0;
+    flex-shrink: 0;
+    height: auto;
+  }
+  .graph.graph--auto-height {
+    flex-grow: 1;
+    flex-shrink: 1;
+    min-height: 0;
+  }
+  .graph.graph--auto-height .graph__container {
+    flex-grow: 1;
+    flex-shrink: 1;
+    min-height: 0;
+    position: relative;
+  }
+  .graph.graph--auto-height .graph__container svg {
+    flex-grow: 0;
+    flex-shrink: 1;
+    min-height: 0;
+    height: auto;
+    width: 100%;
+    position: static;
+  }    
   .graph {
-    align-self: flex-end;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
@@ -254,14 +281,16 @@ const style = css`
     order: 10;
   }
   .graph__container {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
+    display: flex;
+    flex-direction: column;
     align-items: stretch;
+    position: relative;
+    width: 100%;
   }
   .graph__container svg {
     overflow: hidden;
     display: block;
+    cursor: default;
   }
   .fill[anim="false"] {
     animation: reveal .25s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;
@@ -296,14 +325,17 @@ const style = css`
   .bars {
     animation: pop .25s cubic-bezier(0.215, 0.61, 0.355, 1);
   }
+  .bars[anim] .bar {
+    animation: growbar .6s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;
+  }
   .bars[anim] {
-    animation: bars .5s cubic-bezier(0.215, 0.61, 0.355, 1);
+    animation: pop .4s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;
   }
   .bar {
     transition: opacity .25s cubic-bezier(0.215, 0.61, 0.355, 1);
   }
   .bar:hover {
-    opacity: .5;
+    opacity: .5 !important;
     cursor: pointer;
   }
   path,
@@ -437,18 +469,13 @@ const style = css`
     0% { opacity: 0; }
     100% { opacity: 1; }
   }
-  @keyframes bars {
-    0% { opacity: 0; }
-    50% { opacity: 0; }
-    100% { opacity: 1; }
+  @keyframes growbar {
+    0% { transform: scaleY(0); }
+    100% { transform: scaleY(1); }
   }
   @keyframes dash {
-    0% {
-      opacity: 0;
-    }
-    25% {
-      opacity: 1;
-    }
+    0% { opacity: 0; }
+    25% { opacity: 1; }
     100% {
       opacity: 1;
       stroke-dashoffset: 0;

--- a/src/style.js
+++ b/src/style.js
@@ -1,15 +1,12 @@
 import { css } from 'lit-element';
 
 const style = css`
-  :host {
-    display: flex;
-    flex-direction: column;
-  }
   ha-card {
     flex-direction: column;
     flex: 1;
     padding: 16px 0 0 0;
     position: relative;
+    height: 100%;
     overflow: hidden;
   }
   ha-card > div {
@@ -17,10 +14,6 @@ const style = css`
   }
   ha-card > div:last-child {
     padding-bottom: 0;
-  }
-  ha-card .graph {
-    padding: 0;
-    order: 10;
   }
   ha-card[points] .line--points,
   ha-card[labels] .graph__labels.--primary,
@@ -32,7 +25,7 @@ const style = css`
   ha-card[points]:hover .line--points,
   ha-card:hover .graph__labels.--primary,
   ha-card:hover .graph__labels.--secondary {
-      opacity: 1;
+    opacity: 1;
   }
   ha-card[fill] path {
     stroke-linecap: initial;
@@ -253,6 +246,8 @@ const style = css`
     flex-direction: column;
     margin-top: auto;
     width: 100%;
+    padding: 0;
+    order: 10;
   }
   .graph__container {
     display: grid;
@@ -260,16 +255,7 @@ const style = css`
     grid-template-rows: 1fr;
     align-items: stretch;
   }
-  .graph__container__svg {
-    cursor: default;
-    position: relative;
-    display: block;
-    width: 100%;
-    height: 100%;
-    grid-column: 1;
-    grid-row: 1;
-  }
-  svg {
+  .graph__container svg {
     overflow: hidden;
     display: block;
   }
@@ -346,14 +332,12 @@ const style = css`
     padding: .6em;
     pointer-events: none;
     opacity: var(--mcg-label-axis-opacity, .75);
-    grid-column: 1;
-    grid-row: 1;
-    position: relative;
+    position: absolute;
+    top: 0; bottom: 0;
+    left: 0; right: 0;
   }
   .graph__labels.--secondary {
     align-items: flex-end;
-    grid-column: 1;
-    grid-row: 1;
   }
   .graph__labels > span {
     cursor: pointer;
@@ -361,8 +345,8 @@ const style = css`
   }
   .graph__static_value_labels {
     font-size: calc(.15em + 8.5px);
-    position: absolute;
     pointer-events: none;
+    position: absolute;
     top: 0; bottom: 0;
     left: 0; right: 0;
   }

--- a/src/style.js
+++ b/src/style.js
@@ -31,6 +31,10 @@ const style = css`
     stroke-linecap: initial;
     stroke-linejoin: initial;
   }
+  path {
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
   .graph__legend {
     order: -1;
     padding: 0 16px 8px 16px;
@@ -258,10 +262,6 @@ const style = css`
   .graph__container svg {
     overflow: hidden;
     display: block;
-  }
-  path {
-    stroke-linecap: round;
-    stroke-linejoin: round;
   }
   .fill[anim="false"] {
     animation: reveal .25s cubic-bezier(0.215, 0.61, 0.355, 1) forwards;


### PR DESCRIPTION
Adaptive height of a graph when a card is placed inside a `horizontal-stack` or `grid` cards (and a sections layout which uses the `grid` internally) and a `height` option is not defined.
If the `height` option is defined - it is respected. Although this may cause a distortion: for example, when a mini-graph-card (MGC) becomes higher than a neighbouring card and this card DOES NOT support adaptive scaling.
Actually, same distortion may happen even with an undefined `height`: assume MGC is placed into a stack along with a very low card which does not scale itself, and MGC is automatically scaled down to a minimal height (100).

Two methods were considered:

1. Stretch/shrink a canvas. Managed to fix some distortions, failed to fix others.
2. Recreate a Graph object with a new height. After plenty of "try-fail-repeat", concluded that was the "truthy" way - so THIS method is implemented.

Both methods needed to track height changes & calculate a REQUIRED graph height (for method 2) or a CURRENT vertical scale (for method 1, was mainly needed to compensate distortions).

Important: now the card can adjust own height dynamically during a life cycle: for example, MGC is placed into a stack with a card with a dynamic height (like a vertical stack with cards with visibility conditions):

<img width="524" height="672" alt="hhh" src="https://github.com/user-attachments/assets/93d79350-9aaf-405d-87cb-5f976a3fa02a" />

(animation is intentionally switched on, that is why the card is shown “not instantly”)



Notes:
1. Readme is corrected: a default value of `height` option is `100` (and has been at least from a creation of "buildConfig" module a few years ago) instead of `150`, let's consider this as a typo or a leftout from old versions.
2. This mentioned default value `100` now is only used when a card is NOT placed inside a `horizontal-stack` or `grid` cards (and a sections layout); otherwise this default value is used as a MINIMAL height.