### PR TITLE
feat: Move axis-specific options into a "y_axis" config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | update_interval | number |  | v0.4.0 | Specify a custom update interval of the history data (in seconds), instead of on every state change.
 | cache | boolean | `true` | v0.9.0 | Enable/disable local caching of history data.
 | show | list |  | v0.2.0 | List of UI elements to display/hide, for available items see [available show options](#available-show-options).
+| y_axis | [Y-axis config object](#y-axis-object) |  | v0.14.0 | Settings related to Y-axes.
 | animate | boolean | `false` | v0.2.0 | Add a reveal animation to the graph.
 | height | number | `150` | v0.0.1 | Set a custom height of the line graph.
 | bar_spacing | number | `4` | v0.9.0 | Set the spacing between bars in bar graph. Value `-1` is used to place bars on each other. See [examples](#bar-spacing-examples).
@@ -106,8 +107,6 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | color_thresholds | list |  | v0.2.3 | Set thresholds for dynamic graph colors, see [Line color object](#line-color-object).
 | color_thresholds_transition | string | `smooth` | v0.4.3 | Color threshold transition, `smooth` or `hard`.
 | decimals | integer |  | v0.0.9 | Specify the exact number of decimals to show for number values, see [Number format](#number-format).
-| decimals_primary_labels | integer |  | v0.14.0 | Specify the exact number of decimals to show for primary Y-axis labels, see [Number format](#number-format).
-| decimals_secondary_labels | integer |  | v0.14.0 | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
 | hour24 | boolean |  | v0.2.1 | Set to `true` to display times in 24-hour format. See more details [here](#custom-format-for-datetime-values).
 | datetime_format | string | | v.0.14.0 | Set a custom [format](#custom-format-for-datetime-values) for datetime values.
 | font_size | number | `100` | v0.0.3 | Adjust the font size of the state, as percentage of the original size.
@@ -115,19 +114,25 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | align_header | string |  | v0.2.0 | Set the alignment of the name in the header, `left`, `right` or `center`. See more details [here](#alignment-for-name--icon-elements).
 | align_icon | string | `right` | v0.2.0 | Set the alignment of the icon, `left`, `right` or `state`. See more details [here](#alignment-for-name--icon-elements).
 | align_state | string | `left` | v0.2.0 | Set the alignment of the current state, `left`, `right` or `center`.
+| smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
+| state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
+| logarithmic | boolean | `false` | v0.10.0 | Use a logarithmic scale for the graph (see [Logarithmic options](#logarithmic-options)).
+| fill_baseline | number |  | v0.14.0 | Set a custom baseline for the graph (see [Baseline](#baseline)).
+
+These options are legacy and moved into [Y-axis config object](#y-axis-object):
+
+| Name | Type | Default | Since | Description |
+|------|:----:|:-------:|:-----:|-------------|
+| decimals_primary_labels | integer |  | v0.14.0-dev.1  | Specify the exact number of decimals to show for primary Y-axis labels, see [Number format](#number-format).
+| decimals_secondary_labels | integer |  | v0.14.0-dev.1  | Specify the exact number of decimals to show for secondary Y-axis labels, see [Number format](#number-format).
 | lower_bound | number *or* string |  | v0.2.3 | Set a fixed lower bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | upper_bound | number *or* string |  | v0.2.3 | Set a fixed upper bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | min_bound_range | number |  | v0.x.x | Applied after everything, makes sure there's a minimum range that the Y-axis will have. Useful for not making small changes look large because of scale.
 | lower_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed lower bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | upper_bound_secondary | number *or* string |  | v0.5.0 | Set a fixed upper bound for the graph secondary Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
 | min_bound_range_secondary | number |  | v0.x.x | Applied after everything, makes sure there's a minimum range that the secondary Y-axis will have. Useful for not making small changes look large because of scale.
-| smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
-| state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
-| value_factor | number or object |   | v0.9.4<br>v0.14.0 | Scale a value, see [Value factor](#value-factor).
-| value_factor_secondary | number or object |   | v0.14.0 | Scale a value, see [Value factor](#value-factor).
-| logarithmic | boolean | `false` | v0.10.0 | Use a logarithmic scale for the graph (see [Logarithmic options](#logarithmic-options)).
-| fill_baseline | number |  | v0.14.0 | Set a custom baseline for the graph (see [Baseline](#baseline)).
-
+| value_factor | number or object |   | v0.9.4<br>v0.14.0-dev.1 | Scale a value, see [Value factor](#value-factor).
+| value_factor_secondary | number or object |   | v0.14.0-dev.1  | Scale a value, see [Value factor](#value-factor).
 
 
 #### Entities object
@@ -197,6 +202,34 @@ All properties are optional.
 | icon_adaptive_color | `false` | `true` / `false` | Make the icon color adapt with the primary entity/static value color.
 | loading_indicator | `true` | `true` / `false` | Show loading indicator while attempting to retrieve a history.
 | graphs_order | `direct` | `direct` / `reversed` | Define an order of displaying graphs (see [Graphs order](#graphs-order)).
+
+#### Y-axis object
+
+The object has a tree-like structure with optional `primary` & `secondary` keys. Each key may contain optional properties listed below:
+
+| Name | Type | Default | Description |
+|------|:----:|:-------:|-------------|
+| decimals | integer |  | Specify the exact number of decimals to show for primary Y-axis labels, see [Number format](#number-format).
+| value_factor | number or object |   | Scale a value, see [Value factor](#value-factor).
+| lower_bound | number *or* string |   | Set a fixed lower bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
+| upper_bound | number *or* string |   | Set a fixed upper bound for the graph Y-axis. String value starting with ~ (e.g. `~50`) specifies soft bound.
+| min_bound_range | number |   | Applied after everything, makes sure there's a minimum range that the Y-axis will have. Useful for not making small changes look large because of scale.
+
+```yaml
+y_axis:
+  primary:
+    decimals: ...
+    value_factor: ...
+    lower_bound: ...
+    upper_bound: ...
+    min_bound_range: ...
+  secondary:
+    decimals: ...
+    value_factor: ...
+    lower_bound: ...
+    upper_bound: ...
+    min_bound_range: ...
+```
 
 
 #### Line color object
@@ -275,12 +308,12 @@ By default, tapping on an element opens a `more-info` dialog:
 
 #### Value factor
 
-Defines a coefficent (factor) applied to displayed values (including Y-axis labels).
-There are two available options - `value_factor` & `value_factor_secondary`:
+Defines a coefficient (factor) applied to displayed values (including Y-axis labels).
+There are two available options per each Y-axis - `y_axis.primary.value_factor` & `y_axis.secondary.value_factor`:
 1. If none option is defined, a default "1" factor is used (values are shown w/o any conversion).
-2. If only `value_factor` is defined - it is applied to all entities.
-3. If only `value_factor_secondary` is defined - it is applied to all entities with `y_axis: secondary`.
-4. If both `value_factor` & `value_factor_secondary` are defined - they are applied to entities without `y_axis: secondary` & with `y_axis: secondary` correspondingly.
+2. If only `y_axis.primary.value_factor` is defined - it is applied to all entities except entities with `y_axis: secondary`; for other entities a default "1" factor is used.
+3. If only `y_axis.secondary.value_factor` is defined - it is applied to all entities with `y_axis: secondary`; for other entities a default "1" factor is used.
+4. If both `y_axis.primary.value_factor` & `y_axis.secondary.value_factor` are defined - they are applied to entities without `y_axis: secondary` & with `y_axis: secondary` correspondingly.
 
 Each option can be defined either as a `number` or an `object` (see below).
 
@@ -344,20 +377,20 @@ See examples [below](#displaying-static-lines).
 Options `decimals` defined "card-wide" and/or for some entity/[static value](#static-lines) are used to set an exact number of decimals according to the following rules:
 1. For state & attribute values, static values:
 - if none `decimals` option is defined - a default presentation (see a note below) is used;
-- if "card-wide" `decimals` is defined - this value is used;
-- if `decimals` for some entity is defined - this value is used for this entity.
+- if `decimals` for some entity is defined - this value is used for this entity;
+- if "card-wide" `decimals` is defined - this value is used.
 2. For extrema & average values (supported for the 1st entity only):
 - if none `decimals` option is defined - a default presentation is used;
-- if "card-wide" `decimals` is defined - this value is used;
-- if `decimals` is defined for the 1st entity - this value is used.
+- if `decimals` is defined for the 1st entity - this value is used;
+- if "card-wide" `decimals` is defined - this value is used.
 3. For primary Y-axis labels:
-- if "card-wide" `decimals` & `decimals_primary_labels` options are not defined - a default presentation is used;
-- if "card-wide" `decimals` option is defined - this value is used;
-- if "card-wide" `decimals_primary_labels` option is defined - this value is used.
+- if "card-wide" `decimals` & `y_axis.primary.decimals` options are not defined - a default presentation is used;
+- if `y_axis.primary.decimals` option is defined - this value is used;
+- if "card-wide" `decimals` option is defined - this value is used.
 4. For secondary Y-axis labels:
-- if "card-wide" `decimals` & `decimals_secondary_labels` options are not defined - a default presentation is used;
-- if "card-wide" `decimals` option is defined - this value is used;
-- if "card-wide" `decimals_secondary_labels` option is defined - this value is used.
+- if "card-wide" `decimals` & `y_axis.secondary.decimals` options are not defined - a default presentation is used;
+- if `y_axis.secondary.decimals` option is defined - this value is used;
+- if "card-wide" `decimals` option is defined - this value is used.
   
 A "default presentation" refers to a default look in HA:
 1. For a state value (also for extrema & average): if accuracy settings are defined for an entity - these settings are used, otherwise some default HA settings (depend on many factors incl. a `device_class`; for template sensors - a user-defined accuracy set in jinja templates is used).
@@ -701,7 +734,9 @@ entities:
     line_width: 1
     line_style: 4,7
     color: red
-lower_bound: ~0
+y_axis:
+  primary:
+    lower_bound: ~0
 show:
   labels: true
 ```
@@ -744,7 +779,9 @@ entities:
     line_style: 4,7
     color: red
     show_static_inactive: true
-lower_bound: ~0
+y_axis:
+  primary:
+    lower_bound: ~0
 points_per_hour: 60
 hours_to_show: 3
 height: 200

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -243,9 +243,24 @@ export default (config) => {
       conf.entities[i] = { entity };
     } else {
       // check numeric per-entity options for validity
-      entity.line_width = checkNumericOption(entity, 'line_width', conf.line_width, { minBound: 0, allowString: true });
-      entity.decimals = checkIntegerOption(entity, 'decimals', conf.decimals, { minBound: 0, allowString: true });
-      entity.fill_baseline = checkNumericOption(entity, 'fill_baseline', undefined, { allowString: true });
+      entity.line_width = checkNumericOption(
+        entity,
+        'line_width',
+        conf.line_width,
+        { minBound: 0, allowString: true, logOptionName: `entities[${i}].line_width` },
+      );
+      entity.decimals = checkIntegerOption(
+        entity,
+        'decimals',
+        conf.decimals,
+        { minBound: 0, allowString: true, logOptionName: `entities[${i}].decimals` },
+      );
+      entity.fill_baseline = checkNumericOption(
+        entity,
+        'fill_baseline',
+        undefined,
+        { allowString: true, logOptionName: `entities[${i}].fill_baseline` },
+      );
 
       if (entity.color_thresholds) {
         // check color_thresholds

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -21,6 +21,7 @@ import {
   checkLineStyle,
 } from './checkOption';
 import { getFactor } from './others';
+import { migrateYaxisConfig } from './migrate';
 
 /**
  * Starting from the given index, increment the index until an array element with a
@@ -137,6 +138,9 @@ export default (config) => {
       `"line_color_above/line_color_below" was removed, please use "color_thresholds".\n See ${URL_DOCS}`,
     );
 
+  // migrate legacy options, currently belonging to y_axis object
+  const migratedConfig = migrateYaxisConfig(config);
+
   const conf = {
     animate: false,
     font_size: DEFAULT_FONT_SIZE,
@@ -158,48 +162,79 @@ export default (config) => {
     tap_action: {
       action: 'more-info',
     },
-    ...JSON.parse(JSON.stringify(config)),
-    show: { ...DEFAULT_SHOW, ...config.show },
+    ...JSON.parse(JSON.stringify(migratedConfig)),
+    show: { ...DEFAULT_SHOW, ...migratedConfig.show },
   };
 
   // check numeric options for validity
-  conf.font_size = checkNumericOption(conf, 'font_size', 100, 0.1, undefined, true);
-  conf.font_size_header = checkNumericOption(conf, 'font_size_header', DEFAULT_FONT_SIZE_HEADER, 0.1, undefined, true);
+  conf.font_size = checkNumericOption(conf, 'font_size', 100, { minBound: 0.1, allowString: true });
+  conf.font_size_header = checkNumericOption(conf, 'font_size_header', DEFAULT_FONT_SIZE_HEADER, { minBound: 0.1, allowString: true });
 
-  conf.bar_spacing = checkNumericOption(conf, 'bar_spacing', DEFAULT_BAR_SPACING, -1, undefined, true);
-  conf.bar_spacing_group = checkNumericOption(conf, 'bar_spacing_group', undefined, 0, undefined, true);
+  conf.bar_spacing = checkNumericOption(conf, 'bar_spacing', DEFAULT_BAR_SPACING, { minBound: -1, allowString: true });
+  conf.bar_spacing_group = checkNumericOption(conf, 'bar_spacing_group', undefined, { minBound: 0, allowString: true });
 
-  conf.height = checkNumericOption(conf, 'height', DEFAULT_GRAPH_HEIGHT, 0, undefined, true);
+  conf.height = checkNumericOption(conf, 'height', DEFAULT_GRAPH_HEIGHT, { minBound: 0, allowString: true });
 
-  conf.line_width = checkNumericOption(conf, 'line_width', DEFAULT_MARGIN, 0, undefined, true);
+  conf.line_width = checkNumericOption(conf, 'line_width', DEFAULT_MARGIN, { minBound: 0, allowString: true });
 
-  conf.hours_to_show = checkNumericOption(conf, 'hours_to_show', DEFAULT_HOURS_TO_SHOW, 0.01, undefined, true);
-  conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, 0.001, undefined, true);
-  conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, 0, undefined, true);
+  conf.hours_to_show = checkNumericOption(conf, 'hours_to_show', DEFAULT_HOURS_TO_SHOW, { minBound: 0.01, allowString: true });
+  conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, { minBound: 0.001, allowString: true });
+  conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, { minBound: 0, allowString: true });
 
-  ({ lowerBound: conf.lower_bound, upperBound: conf.upper_bound } = checkBounds(conf));
+    // axis options
+  if (conf.y_axis && conf.y_axis.primary) {
+    const primaryBounds = checkBounds(conf.y_axis.primary, 'primary');
+    conf.y_axis.primary.lower_bound = primaryBounds.lowerBound;
+    conf.y_axis.primary.upper_bound = primaryBounds.upperBound;
 
-  conf.min_bound_range = checkNumericOption(conf, 'min_bound_range', undefined, 0, undefined, true);
-  conf.min_bound_range_secondary = checkNumericOption(conf, 'min_bound_range_secondary', undefined, 0, undefined, true);
+    conf.y_axis.primary.min_bound_range = checkNumericOption(
+      conf.y_axis.primary, 
+      'min_bound_range', 
+      undefined, 
+      { minBound: 0, allowString: true, logOptionName: 'primary.min_bound_range' },
+    );
 
-  conf.decimals_primary_labels = checkIntegerOption(conf, 'decimals_primary_labels', undefined, 0, undefined, true);
-  conf.decimals_secondary_labels = checkIntegerOption(conf, 'decimals_secondary_labels', undefined, 0, undefined, true);
-  conf.decimals = checkIntegerOption(conf, 'decimals', undefined, 0, undefined, true);
+    conf.y_axis.primary.decimals = checkIntegerOption(
+      conf.y_axis.primary, 
+      'decimals', 
+      undefined, 
+      { minBound: 0, allowString: true, logOptionName: 'primary.decimals' },
+    );
+  }
+  if (conf.y_axis && conf.y_axis.secondary) {
+    const secondaryBounds = checkBounds(conf.y_axis.secondary, 'secondary');
+    conf.y_axis.secondary.lower_bound = secondaryBounds.lowerBound;
+    conf.y_axis.secondary.upper_bound = secondaryBounds.upperBound;
+
+     conf.y_axis.secondary.min_bound_range = checkNumericOption(
+      conf.y_axis.secondary, 
+      'min_bound_range', 
+      undefined, 
+      { minBound: 0, allowString: true, logOptionName: 'secondary.min_bound_range' },
+    );
+
+    conf.y_axis.secondary.decimals = checkIntegerOption(
+      conf.y_axis.secondary, 
+      'decimals', 
+      undefined, 
+      { minBound: 0, allowString: true, logOptionName: 'secondary.decimals' },
+    );
+  }
+
+  conf.decimals = checkIntegerOption(conf, 'decimals', undefined, { minBound: 0, allowString: true });
 
   conf.static_value_label_offset = checkNumericOption(
     conf,
     'static_value_label_offset',
     DEFAULT_STATIC_VALUE_LABEL_OFFSET,
-    0,
-    100,
-    true,
+    { minBound: 0, maxBound: 100, allowString: true },
   );
   if (conf.static_value_label_offset === undefined
     || conf.static_value_label_offset === null) {
     conf.static_value_label_offset = DEFAULT_STATIC_VALUE_LABEL_OFFSET;
   }
 
-  conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, undefined, undefined, true);
+  conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, { allowString: true });
 
   // process per-entity configs
   /* eslint-disable no-param-reassign */
@@ -208,9 +243,9 @@ export default (config) => {
       conf.entities[i] = { entity };
     } else {
       // check numeric per-entity options for validity
-      entity.line_width = checkNumericOption(entity, 'line_width', conf.line_width, 0, undefined, true);
-      entity.decimals = checkIntegerOption(entity, 'decimals', conf.decimals, 0, undefined, true);
-      entity.fill_baseline = checkNumericOption(entity, 'fill_baseline', undefined, undefined, undefined, true);
+      entity.line_width = checkNumericOption(entity, 'line_width', conf.line_width, { minBound: 0, allowString: true });
+      entity.decimals = checkIntegerOption(entity, 'decimals', conf.decimals, { minBound: 0, allowString: true });
+      entity.fill_baseline = checkNumericOption(entity, 'fill_baseline', undefined, { allowString: true });
 
       if (entity.color_thresholds) {
         // check color_thresholds

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -181,23 +181,23 @@ export default (config) => {
   conf.points_per_hour = checkNumericOption(conf, 'points_per_hour', DEFAULT_POINTS_PER_HOUR, { minBound: 0.001, allowString: true });
   conf.update_interval = checkNumericOption(conf, 'update_interval', undefined, { minBound: 0, allowString: true });
 
-    // axis options
+  // axis options
   if (conf.y_axis && conf.y_axis.primary) {
     const primaryBounds = checkBounds(conf.y_axis.primary, 'primary');
     conf.y_axis.primary.lower_bound = primaryBounds.lowerBound;
     conf.y_axis.primary.upper_bound = primaryBounds.upperBound;
 
     conf.y_axis.primary.min_bound_range = checkNumericOption(
-      conf.y_axis.primary, 
-      'min_bound_range', 
-      undefined, 
+      conf.y_axis.primary,
+      'min_bound_range',
+      undefined,
       { minBound: 0, allowString: true, logOptionName: 'primary.min_bound_range' },
     );
 
     conf.y_axis.primary.decimals = checkIntegerOption(
-      conf.y_axis.primary, 
-      'decimals', 
-      undefined, 
+      conf.y_axis.primary,
+      'decimals',
+      undefined,
       { minBound: 0, allowString: true, logOptionName: 'primary.decimals' },
     );
   }
@@ -206,17 +206,17 @@ export default (config) => {
     conf.y_axis.secondary.lower_bound = secondaryBounds.lowerBound;
     conf.y_axis.secondary.upper_bound = secondaryBounds.upperBound;
 
-     conf.y_axis.secondary.min_bound_range = checkNumericOption(
-      conf.y_axis.secondary, 
-      'min_bound_range', 
-      undefined, 
+    conf.y_axis.secondary.min_bound_range = checkNumericOption(
+      conf.y_axis.secondary,
+      'min_bound_range',
+      undefined,
       { minBound: 0, allowString: true, logOptionName: 'secondary.min_bound_range' },
     );
 
     conf.y_axis.secondary.decimals = checkIntegerOption(
-      conf.y_axis.secondary, 
-      'decimals', 
-      undefined, 
+      conf.y_axis.secondary,
+      'decimals',
+      undefined,
       { minBound: 0, allowString: true, logOptionName: 'secondary.decimals' },
     );
   }

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -93,7 +93,7 @@ const checkIntegerOption = (
   const value = checkNumericOption(config, option, defaultValue, params);
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value) + 0; // prevent "-0" value
-    const displayOption = params. || option;
+    const displayOption = params.logOptionName || option;
     log(`Invalid integer option ${displayOption}: [${value}]; rounding value to ${roundedValue}`);
     return roundedValue;
   }

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -65,7 +65,7 @@ const checkNumericOption = (
       errorDescr = `out of bounds, maximum allowed: ${maxBound}`;
     }
   }
-  log(`Invalid option ${displayOption}: [${invalidValue}] (${errorDescr}); adjusting value to ${clearedValue}`);
+  log(`Invalid option "${displayOption}": [${invalidValue}] (${errorDescr}); adjusting value to ${clearedValue}`);
   return clearedValue;
 };
 
@@ -94,7 +94,7 @@ const checkIntegerOption = (
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value) + 0; // prevent "-0" value
     const displayOption = params.logOptionName || option;
-    log(`Invalid integer option ${displayOption}: [${value}]; rounding value to ${roundedValue}`);
+    log(`Invalid integer option "${displayOption}": [${value}]; rounding value to ${roundedValue}`);
     return roundedValue;
   }
   return value;
@@ -132,7 +132,7 @@ const checkBoundOption = (config, option, logOptionName) => {
 
   // invalid type or value of the option
   const invalidValue = typeof value === 'object' ? JSON.stringify(value) : value;
-  log(`Invalid option ${logOptionName}: [${invalidValue}] (not a numeric value); adjusting value to undefined`);
+  log(`Invalid option "${logOptionName}": [${invalidValue}] (not a numeric value); adjusting value to undefined`);
   return undefined;
 };
 
@@ -161,7 +161,7 @@ const checkBounds = (config, yAxis) => {
   if (lowerBound !== undefined && upperBound !== undefined) {
     const cleanLowerBount = getBound(lowerBound).value;
     if (upperBound <= cleanLowerBount) {
-      log(`Invalid lower & upper bounds: [${lowerBound}, ${upperBound}]; unsetting value of upper_bound to undefined`);
+      log(`Invalid lower & upper bounds: [${lowerBound}, ${upperBound}]; unsetting value of "upper_bound" to undefined`);
       upperBound = undefined;
     }
   }
@@ -185,7 +185,7 @@ const checkColorThresholds = (config, configName) => {
 
   if (!Array.isArray(thresholds)) {
     // color_thresholds not a list
-    log(`Invalid option ${configName}.color_thresholds: expected a list; unsetting to []`);
+    log(`Invalid option "${configName}.color_thresholds": expected a list; unsetting to []`);
     config.color_thresholds = [];
     return;
   }
@@ -200,13 +200,13 @@ const checkColorThresholds = (config, configName) => {
         let { color, value } = threshold;
 
         if (color === undefined || typeof color !== 'string') {
-          log(`Invalid option ${configName}.color_thresholds[${idx}]: "color" is missing or not a string; adjusting to "var(--primary-text-color)"`);
+          log(`Invalid option "${configName}.color_thresholds[${idx}]": "color" is missing or not a string; adjusting to "var(--primary-text-color)"`);
           color = 'var(--primary-text-color)';
         }
 
         if (value !== undefined && value !== null) {
           if (!isNumeric(value, true)) {
-            log(`Invalid option ${configName}.color_thresholds[${idx}]: "value" is not a numeric value; unsetting to undefined`);
+            log(`Invalid option "${configName}.color_thresholds[${idx}]": "value" is not a numeric value; unsetting to undefined`);
             value = undefined;
           } else {
             // log a warning in case of a string presentation of a number
@@ -214,7 +214,7 @@ const checkColorThresholds = (config, configName) => {
             value = Number(value);
           }
         } else if (value === null) {
-          log(`Invalid option ${configName}.color_thresholds[${idx}]: "value" is null, unsetting to undefined`);
+          log(`Invalid option "${configName}.color_thresholds[${idx}]": "value" is null, unsetting to undefined`);
           value = undefined;
         }
 
@@ -222,7 +222,7 @@ const checkColorThresholds = (config, configName) => {
       }
 
       // other invalid content
-      log(`Invalid option ${configName}.color_thresholds[${idx}]: expected an object or color string; replacing with a default entry`);
+      log(`Invalid option "${configName}.color_thresholds[${idx}]": expected an object or a color string; replacing with a default entry`);
       return { color: 'var(--primary-text-color)' };
     });
 };
@@ -238,7 +238,7 @@ const checkLineStyle = (config) => {
       const hasLineStyle = (entity.line_style !== undefined && entity.line_style !== null)
         || (config.line_style !== undefined && config.line_style !== null);
       if (hasLineStyle) {
-        log(`Option 'line_style' will be ignored for entity[${index}] because animation is enabled for it`);
+        log(`Option "entities[${index}].line_style" will be ignored because animation is enabled for it`);
       }
     }
   });

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -15,7 +15,8 @@ import {
  * @param {object} [params={}] Optional parameters
  * @param {number} [params.minBound] Optional minimum allowed value
  * @param {number} [params.maxBound] Optional maximum allowed value
- * @param {boolean} [params.allowString=false] Optional flag to allow string representations of numbers
+ * @param {boolean} [params.allowString=false] Optional flag
+ * to allow string representations of numbers
  * @param {string} [params.logOptionName] Optional custom option name for detailed log output
  * @returns {number} Cleared value
  */
@@ -37,7 +38,7 @@ const checkNumericOption = (
     allowString = false,
     logOptionName = undefined,
   } = params;
-  const displayOption = params.logOptionName || option;
+  const displayOption = logOptionName || option;
 
   if (isNumeric(value, allowString)) {
     // log a warning in case of a string presentation of a number
@@ -78,8 +79,9 @@ const checkNumericOption = (
  * @param {object} [params={}] Optional parameters
  * @param {number} [params.minBound] Optional minimum allowed value
  * @param {number} [params.maxBound] Optional maximum allowed value
- * @param {boolean} [params.allowString=false] Optional flag to allow string representations of numbers
- * @param {string} [params.logOptionName] Optional custom option name for detailed log output
+ * @param {boolean} [params.allowString=false] Optional flag
+ * to allow string representations of numbers
+ * @param {string} [params.] Optional custom option name for detailed log output
  * @returns {number} Cleared value
  */
 const checkIntegerOption = (
@@ -91,7 +93,7 @@ const checkIntegerOption = (
   const value = checkNumericOption(config, option, defaultValue, params);
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value) + 0; // prevent "-0" value
-    const displayOption = params.logOptionName || option;
+    const displayOption = params. || option;
     log(`Invalid integer option ${displayOption}: [${value}]; rounding value to ${roundedValue}`);
     return roundedValue;
   }

--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -12,19 +12,18 @@ import {
  * @param {object} config Config object
  * @param {string} option Name of option to be checked
  * @param {number} defaultValue Default fallback value
- * @param {number} minBound Optional minimum allowed value
- * @param {number} maxBound Optional maximum allowed value
- * @param {boolean} [allowString=false] Optional flag
- * to allow string representations of numbers (like "123")
+ * @param {object} [params={}] Optional parameters
+ * @param {number} [params.minBound] Optional minimum allowed value
+ * @param {number} [params.maxBound] Optional maximum allowed value
+ * @param {boolean} [params.allowString=false] Optional flag to allow string representations of numbers
+ * @param {string} [params.logOptionName] Optional custom option name for detailed log output
  * @returns {number} Cleared value
  */
 const checkNumericOption = (
   config,
   option,
   defaultValue,
-  minBound = undefined,
-  maxBound = undefined,
-  allowString = false,
+  params = {},
 ) => {
   const value = config[option];
 
@@ -32,9 +31,17 @@ const checkNumericOption = (
     return undefined;
   }
 
+  const {
+    minBound = undefined,
+    maxBound = undefined,
+    allowString = false,
+    logOptionName = undefined,
+  } = params;
+  const displayOption = params.logOptionName || option;
+
   if (isNumeric(value, allowString)) {
     // log a warning in case of a string presentation of a number
-    logStringWarning(value, option);
+    logStringWarning(value, displayOption);
 
     const valueNumeric = Number(value);
     const isMinValid = minBound === undefined || valueNumeric >= minBound;
@@ -57,7 +64,7 @@ const checkNumericOption = (
       errorDescr = `out of bounds, maximum allowed: ${maxBound}`;
     }
   }
-  log(`Invalid option ${option}: [${invalidValue}] (${errorDescr}); adjusting value to ${clearedValue}`);
+  log(`Invalid option ${displayOption}: [${invalidValue}] (${errorDescr}); adjusting value to ${clearedValue}`);
   return clearedValue;
 };
 
@@ -68,24 +75,24 @@ const checkNumericOption = (
  * @param {object} config Config object
  * @param {string} option Name of option to be checked
  * @param {number} defaultValue Default fallback value
- * @param {number} minBound Optional minimum allowed value
- * @param {number} maxBound Optional maximum allowed value
- * @param {boolean} [allowString=false] Optional flag
- * to allow string representations of numbers (like "123")
+ * @param {object} [params={}] Optional parameters
+ * @param {number} [params.minBound] Optional minimum allowed value
+ * @param {number} [params.maxBound] Optional maximum allowed value
+ * @param {boolean} [params.allowString=false] Optional flag to allow string representations of numbers
+ * @param {string} [params.logOptionName] Optional custom option name for detailed log output
  * @returns {number} Cleared value
  */
 const checkIntegerOption = (
   config,
   option,
   defaultValue,
-  minBound = undefined,
-  maxBound = undefined,
-  allowString = false,
+  params = {},
 ) => {
-  const value = checkNumericOption(config, option, defaultValue, minBound, maxBound, allowString);
+  const value = checkNumericOption(config, option, defaultValue, params);
   if (value !== undefined && !Number.isInteger(value)) {
     const roundedValue = Math.round(value) + 0; // prevent "-0" value
-    log(`Invalid integer option ${option}: [${value}]; rounding value to ${roundedValue}`);
+    const displayOption = params.logOptionName || option;
+    log(`Invalid integer option ${displayOption}: [${value}]; rounding value to ${roundedValue}`);
     return roundedValue;
   }
   return value;
@@ -95,9 +102,10 @@ const checkIntegerOption = (
  * Check if a bound option is valid (accounting for an optional "~" prefix).
  * @param {object} config Config object
  * @param {string} option Name of the option to be checked
- * @returns {number|string|undefined} Cleared value in its original format, or undefined
+ * @param {string} logOptionName Option name for detailed log output
+* @returns {number|string|undefined} Cleared value in its original format, or undefined
  */
-const checkBoundOption = (config, option) => {
+const checkBoundOption = (config, option, logOptionName) => {
   const value = config[option];
 
   if (value === undefined || value === null) {
@@ -110,11 +118,11 @@ const checkBoundOption = (config, option) => {
       if (!parsed.soft && typeof value === 'string') {
         // check for a "string number" since this will not be cleared below
         // log a warning in case of a string presentation of a number
-        logStringWarning(value, option);
+        logStringWarning(value, logOptionName);
       }
 
       const cfg = { [option]: parsed.value };
-      if (checkNumericOption(cfg, option, undefined) !== undefined) {
+      if (checkNumericOption(cfg, option, undefined, { logOptionName }) !== undefined) {
         return parsed.soft ? value : parsed.value;
       }
     }
@@ -122,27 +130,30 @@ const checkBoundOption = (config, option) => {
 
   // invalid type or value of the option
   const invalidValue = typeof value === 'object' ? JSON.stringify(value) : value;
-  log(`Invalid option ${option}: [${invalidValue}] (not a numeric value); adjusting value to undefined`);
+  log(`Invalid option ${logOptionName}: [${invalidValue}] (not a numeric value); adjusting value to undefined`);
   return undefined;
 };
 
 /**
  * Check both upper/lower bounds for valid values.
  * @param {object} config Config object
+ * @param {string} yAxis Y axis type (primary/secondary)
  * @returns {{
  *   lowerBound: string|number|undefined,
  *   upperBound: string|number|undefined
  * }} Cleared bounds
  */
-const checkBounds = (config) => {
-  const lowerBound = checkBoundOption(config, 'lower_bound');
+const checkBounds = (config, yAxis) => {
+  const lowerBound = checkBoundOption(
+    config,
+    'lower_bound',
+    `${yAxis}.lower_bound`,
+  );
   let upperBound = checkNumericOption(
     config,
     'upper_bound',
     undefined,
-    undefined,
-    undefined,
-    true, // allowString
+    { allowString: true, logOptionName: `${yAxis}.upper_bound` },
   );
 
   if (lowerBound !== undefined && upperBound !== undefined) {

--- a/src/main.js
+++ b/src/main.js
@@ -414,9 +414,9 @@ class MiniGraphCard extends LitElement {
       return html`
         <div
           class="icon"
-          loc="${iconLoc}"
+          loc=${iconLoc}
         >
-          <img src="${this.config.icon_image}" height="25"/>
+          <img src=${this.config.icon_image} height="25"/>
         </div>
       `;
     }
@@ -435,8 +435,8 @@ class MiniGraphCard extends LitElement {
     return html`
       <div
         class="icon"
-        loc="${iconLoc}"
-        style="${iconColor !== undefined ? `color: ${iconColor};` : ''}"
+        loc=${iconLoc}
+        style=${iconColor !== undefined ? `color: ${iconColor};` : ''}
       >
         <ha-icon .icon=${this.computeIcon(this.entity[0])}></ha-icon>
       </div>
@@ -462,11 +462,11 @@ class MiniGraphCard extends LitElement {
     return html`
       <div
         class="name"
-        loc="${nameLoc}"
+        loc=${nameLoc}
       >
         <span
           class="ellipsis"
-          style="${color}"
+          style=${color}
         >${name}</span>
       </div>
     `;
@@ -483,7 +483,7 @@ class MiniGraphCard extends LitElement {
     return html`
       <div
         class="states flex"
-        loc="${this.config.align_state}"
+        loc=${this.config.align_state}
       >
         ${this.renderState(0)}
         <div class="states--secondary">
@@ -716,7 +716,7 @@ class MiniGraphCard extends LitElement {
   renderIndicator(state, index) {
     return svg`
       <svg width="10" height="10">
-        <rect width="10" height="10" fill="${this.computeColor(state, index)}" />
+        <rect width="10" height="10" fill=${this.computeColor(state, index)} />
       </svg>
     `;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1455,16 +1455,16 @@ class MiniGraphCard extends LitElement {
     // attempting to get "decimals" settings
     if (index === undefined) {
       // for a primary Y-axis
-      const primaryDecimals = this.config.y_axis 
-        && this.config.y_axis.primary 
+      const primaryDecimals = this.config.y_axis
+        && this.config.y_axis.primary
         && this.config.y_axis.primary.decimals;
       dec = primaryDecimals !== undefined
         ? primaryDecimals
         : this.config.decimals;
     } else if (index === -1) {
       // for a secondary Y-axis
-      const secondaryDecimals = this.config.y_axis 
-        && this.config.y_axis.secondary 
+      const secondaryDecimals = this.config.y_axis
+        && this.config.y_axis.secondary
         && this.config.y_axis.secondary.decimals;
       dec = secondaryDecimals !== undefined
         ? secondaryDecimals

--- a/src/main.js
+++ b/src/main.js
@@ -1455,13 +1455,19 @@ class MiniGraphCard extends LitElement {
     // attempting to get "decimals" settings
     if (index === undefined) {
       // for a primary Y-axis
-      dec = this.config.decimals_primary_labels !== undefined
-        ? this.config.decimals_primary_labels
+      const primaryDecimals = this.config.y_axis 
+        && this.config.y_axis.primary 
+        && this.config.y_axis.primary.decimals;
+      dec = primaryDecimals !== undefined
+        ? primaryDecimals
         : this.config.decimals;
     } else if (index === -1) {
       // for a secondary Y-axis
-      dec = this.config.decimals_secondary_labels !== undefined
-        ? this.config.decimals_secondary_labels
+      const secondaryDecimals = this.config.y_axis 
+        && this.config.y_axis.secondary 
+        && this.config.y_axis.secondary.decimals;
+      dec = secondaryDecimals !== undefined
+        ? secondaryDecimals
         : this.config.decimals;
     } else {
       // for a state or attribute value
@@ -1762,20 +1768,32 @@ class MiniGraphCard extends LitElement {
   }
 
   updateBounds({ config } = this) {
+    const primaryAxis = config.y_axis && config.y_axis.primary;
+    const {
+      lower_bound: primaryLowerBound,
+      upper_bound: primaryUpperBound,
+      min_bound_range: primaryMinBoundRange,
+    } = primaryAxis || {};
     this.bound = this.getBoundaries(
       this.primaryYaxisSeries,
-      config.lower_bound,
-      config.upper_bound,
+      primaryLowerBound,
+      primaryUpperBound,
       this.bound,
-      config.min_bound_range,
+      primaryMinBoundRange,
     );
 
+    const secondaryAxis = config.y_axis && config.y_axis.secondary;
+    const {
+      lower_bound: secondaryLowerBound,
+      upper_bound: secondaryUpperBound,
+      min_bound_range: secondaryMinBoundRange,
+    } = secondaryAxis || {};
     this.boundSecondary = this.getBoundaries(
       this.secondaryYaxisSeries,
-      config.lower_bound_secondary,
-      config.upper_bound_secondary,
+      secondaryLowerBound,
+      secondaryUpperBound,
       this.boundSecondary,
-      config.min_bound_range_secondary,
+      secondaryMinBoundRange,
     );
   }
 

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -8,7 +8,7 @@ import { log } from './utils';
  * @returns {object} Updated config object with y_axis
  */
 const migrateYaxisConfig = (config) => {
-  const conf = { ...config };
+  const conf = JSON.parse(JSON.stringify(config));
 
   // [ 'legacy_old_key', 'axis', 'new_key' ]
   const migrations = [
@@ -49,13 +49,17 @@ const migrateYaxisConfig = (config) => {
         }
         // copy a value
         conf.y_axis[axis][newKey] = oldValue;
-        log(`option "${oldKey}" is deprecated and has been automatically migrated. `
-          + `Please update your YAML configuration to: y_axis.${axis}.${newKey}: ${JSON.stringify(oldValue)}`);
+
+        log(`option "${oldKey}" is deprecated and has been automatically migrated. ` +
+          `Please update your YAML configuration to: "y_axis.${axis}.${newKey}": ${JSON.stringify(oldValue)}`
+        );
       } else {
         // new option is also present
         // legacy option is ignored in favor of the new option
-        log(`option "${oldKey}" is ignored `
-          + `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`);
+        log(
+          `Option "${oldKey}" is ignored ` +
+          `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`
+        );
       }
 
       // remove old option

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -51,7 +51,7 @@ const migrateYaxisConfig = (config) => {
         conf.y_axis[axis][newKey] = oldValue;
 
         log(`option "${oldKey}" is deprecated and has been automatically migrated. `
-          + `Please update your YAML configuration to: "y_axis.${axis}.${newKey}": ${JSON.stringify(oldValue)}`);
+          + `Please update your YAML configuration to "y_axis.${axis}.${newKey}"`);
       } else {
         // new option is also present
         // legacy option is ignored in favor of the new option

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -50,16 +50,13 @@ const migrateYaxisConfig = (config) => {
         // copy a value
         conf.y_axis[axis][newKey] = oldValue;
 
-        log(`option "${oldKey}" is deprecated and has been automatically migrated. ` +
-          `Please update your YAML configuration to: "y_axis.${axis}.${newKey}": ${JSON.stringify(oldValue)}`
-        );
+        log(`option "${oldKey}" is deprecated and has been automatically migrated. `
+          + `Please update your YAML configuration to: "y_axis.${axis}.${newKey}": ${JSON.stringify(oldValue)}`);
       } else {
         // new option is also present
         // legacy option is ignored in favor of the new option
-        log(
-          `Option "${oldKey}" is ignored ` +
-          `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`
-        );
+        log(`option "${oldKey}" is ignored `
+          + `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`);
       }
 
       // remove old option

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,0 +1,76 @@
+// Functions to migrate a legacy config to the latest config
+
+import { log } from './utils';
+
+/**
+ * Migrate legacy options to the new y_axis structure.
+ * @param {object} config Config object
+ * @returns {object} Updated config object with y_axis
+ */
+const migrateYaxisConfig = (config) => {
+  const conf = { ...config };
+
+  // [ 'legacy_old_key', 'axis', 'new_key' ]
+  const migrations = [
+    // primary
+    ['lower_bound', 'primary', 'lower_bound'],
+    ['upper_bound', 'primary', 'upper_bound'],
+    ['min_bound_range', 'primary', 'min_bound_range'],
+    ['decimals_primary_labels', 'primary', 'decimals'],
+    ['value_factor', 'primary', 'value_factor'],
+    // secondary
+    ['lower_bound_secondary', 'secondary', 'lower_bound'],
+    ['upper_bound_secondary', 'secondary', 'upper_bound'],
+    ['min_bound_range_secondary', 'secondary', 'min_bound_range'],
+    ['decimals_secondary_labels', 'secondary', 'decimals'],
+    ['value_factor_secondary', 'secondary', 'value_factor'],
+  ];
+
+  migrations.forEach(([oldKey, axis, newKey]) => {
+    const oldValue = conf[oldKey];
+
+    // check if the legacy option is present in config
+    if (oldValue !== undefined && oldValue !== null) {
+      // check if the option is already defined in the new y_axis object
+      const hasNewValue = conf.y_axis
+        && conf.y_axis[axis]
+        && conf.y_axis[axis][newKey] !== undefined
+        && conf.y_axis[axis][newKey] !== null;
+
+      if (!hasNewValue) {
+        // new option is missing
+
+        // create empty object if it was not created yet
+        if (!conf.y_axis) {
+          conf.y_axis = {};
+        }
+        if (!conf.y_axis[axis]) {
+          conf.y_axis[axis] = {};
+        }
+        // copy a value
+        conf.y_axis[axis][newKey] = oldValue;
+
+        log(`option "${oldKey}" is deprecated and has been automatically migrated. ` +
+          `Please update your YAML configuration to: y_axis.${axis}.${newKey}: ${JSON.stringify(oldValue)}`
+        );
+      } else {
+        // new option is also present
+        // legacy option is ignored in favor of the new option
+        log(
+          `Option "${oldKey}" is ignored ` +
+          `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`
+        );
+      }
+
+      // remove old option
+      delete conf[oldKey];
+    }
+  });
+
+  return conf;
+};
+
+
+export {
+  migrateYaxisConfig,
+};

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -49,17 +49,13 @@ const migrateYaxisConfig = (config) => {
         }
         // copy a value
         conf.y_axis[axis][newKey] = oldValue;
-
-        log(`option "${oldKey}" is deprecated and has been automatically migrated. ` +
-          `Please update your YAML configuration to: y_axis.${axis}.${newKey}: ${JSON.stringify(oldValue)}`
-        );
+        log(`option "${oldKey}" is deprecated and has been automatically migrated. `
+          + `Please update your YAML configuration to: y_axis.${axis}.${newKey}: ${JSON.stringify(oldValue)}`);
       } else {
         // new option is also present
         // legacy option is ignored in favor of the new option
-        log(
-          `Option "${oldKey}" is ignored ` +
-          `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`
-        );
+        log(`option "${oldKey}" is ignored `
+          + `because you have already configured "y_axis.${axis}.${newKey}". Please remove "${oldKey}" from your YAML`);
       }
 
       // remove old option

--- a/src/others.js
+++ b/src/others.js
@@ -87,11 +87,11 @@ const getFactor = (config, index = undefined) => {
   }
 
   const displayOption = yAxis
-   ? `${yAxis}.value_factor`
-   : `value_factor[${index}]`;
+    ? `${yAxis}.value_factor`
+    : `value_factor[${index}]`;
 
   const getExponent = factor => 10 ** factor;
-  const logInvalidValueFactor = (factor_obj) => log(`invalid ${displayOption}: [${JSON.stringify(factor_obj)}]`);
+  const logInvalidValueFactor = factor_obj => log(`invalid ${displayOption}: [${JSON.stringify(factor_obj)}]`);
 
   if (typeof value_factor === 'object') {
     const { type, factor } = value_factor;

--- a/src/others.js
+++ b/src/others.js
@@ -38,7 +38,7 @@ const isNumeric = (value, allowString = false) => {
  */
 const logStringWarning = (value, option) => {
   if (typeof value === 'string') {
-    log(`Warning for option ${option}: [${value}] is configured as a string; please make it a number`);
+    log(`Warning for option "${option}": [${value}] is configured as a string; please make it a number`);
   }
 };
 
@@ -91,7 +91,7 @@ const getFactor = (config, index = undefined) => {
     : `entities[${index}].value_factor`;
 
   const getExponent = factor => 10 ** factor;
-  const logInvalidValueFactor = factor_obj => log(`invalid ${displayOption}: [${JSON.stringify(factor_obj)}]`);
+  const logInvalidValueFactor = factor_obj => log(`invalid "${displayOption}": [${JSON.stringify(factor_obj)}]`);
 
   if (typeof value_factor === 'object') {
     const { type, factor } = value_factor;

--- a/src/others.js
+++ b/src/others.js
@@ -43,9 +43,10 @@ const logStringWarning = (value, option) => {
 };
 
 /**
-  * Return a multiplying factor (exponental or scale) based on a "value_factor" option
+  * Return a multiplying factor (exponential or scale) based on a "value_factor" option
   * @param {object} config Card config
-  * @param {number} index Index of an entity in config.entities
+  * @param {number} [index] Index of an entity in config.entities
+  * (`undefined` stands for a primary Y-axis, `-1` - for a secondary Y-axis)
   * @returns {number} Multiplying factor
   */
 const getFactor = (config, index = undefined) => {
@@ -60,20 +61,24 @@ const getFactor = (config, index = undefined) => {
     && Array.isArray(config.entities)
     && config.entities[index];
 
+  let yAxis;
   if (validIndex && config.entities[index].value_factor !== undefined) {
     // provided a per-entity value_factor
     ({ value_factor } = config.entities[index]);
   } else if (validIndex && config.entities[index].y_axis === 'secondary') {
-    // use value_factor_secondary for entities with 'y_axis: secondary'
-    // if value_factor_secondary = undefined, then later it will fallback to 1
-    value_factor = config.value_factor_secondary;
+    // use value_factor for secondary Y-axis labels for entities with 'y_axis: secondary'
+    // if value_factor = undefined, then later it will fallback to 1
+    value_factor = config.y_axis && config.y_axis.secondary && config.y_axis.secondary.value_factor;
+    yAxis = 'secondary';
   } else if (index === -1) {
-    // use value_factor_secondary for secondary Y-axis labels
-    // if value_factor_secondary = undefined, then later it will fallback to 1
-    value_factor = config.value_factor_secondary;
+    // use value_factor for secondary Y-axis labels
+    // if value_factor = undefined, then later it will fallback to 1
+    value_factor = config.y_axis && config.y_axis.secondary && config.y_axis.secondary.value_factor;
+    yAxis = 'secondary';
   } else {
-    // use a global value_factor
-    ({ value_factor } = config);
+    // use value_factor for primary Y-axis labels
+    value_factor = config.y_axis && config.y_axis.primary && config.y_axis.primary.value_factor;
+    yAxis = 'primary';
   }
 
   if (value_factor === undefined || value_factor === null) {
@@ -81,20 +86,24 @@ const getFactor = (config, index = undefined) => {
     return 1;
   }
 
+  const displayOption = yAxis
+   ? `${yAxis}.value_factor`
+   : `value_factor[${index}]`;
+
   const getExponent = factor => 10 ** factor;
-  const logValueFactor = factor_obj => log(`invalid value_factor: [${JSON.stringify(factor_obj)}]`);
+  const logInvalidValueFactor = (factor_obj) => log(`invalid ${displayOption}: [${JSON.stringify(factor_obj)}]`);
 
   if (typeof value_factor === 'object') {
     const { type, factor } = value_factor;
     if (type === undefined || factor === undefined
       || typeof type !== 'string' || !isNumeric(factor, true)) {
       // invalid options, fallback to a default factor
-      logValueFactor(value_factor);
+      logInvalidValueFactor(value_factor);
       return 1;
     }
     if (type === 'exponent' || type === 'scale') {
       // log a warning in case of a string presentation of a number
-      logStringWarning(factor, 'factor');
+      logStringWarning(factor, displayOption);
       switch (type) {
         case 'exponent':
           return getExponent(Number(factor));
@@ -103,18 +112,18 @@ const getFactor = (config, index = undefined) => {
       }
     }
     // invalid 'type' option
-    logValueFactor(value_factor);
+    logInvalidValueFactor(value_factor);
     return 1;
   }
 
   if (isNumeric(value_factor, true)) {
     // log a warning in case of a string presentation of a number
-    logStringWarning(value_factor, 'value_factor');
+    logStringWarning(value_factor, displayOption);
     // use a legacy "exponent" way
     return getExponent(Number(value_factor));
   }
 
-  logValueFactor(value_factor);
+  logInvalidValueFactor(value_factor);
   // fallback to a default factor
   return 1;
 };

--- a/src/others.js
+++ b/src/others.js
@@ -88,7 +88,7 @@ const getFactor = (config, index = undefined) => {
 
   const displayOption = yAxis
     ? `${yAxis}.value_factor`
-    : `value_factor[${index}]`;
+    : `entities[${index}].value_factor`;
 
   const getExponent = factor => 10 ** factor;
   const logInvalidValueFactor = factor_obj => log(`invalid ${displayOption}: [${JSON.stringify(factor_obj)}]`);

--- a/tests/checkNumericOption.test.ts.dis
+++ b/tests/checkNumericOption.test.ts.dis
@@ -206,9 +206,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            undefined,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -221,9 +223,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            undefined,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -236,9 +240,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            undefined,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -251,9 +257,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            HUGE_NEGATIVE,
-            undefined,
-            variant.allowString,
+            {
+              minBound: HUGE_NEGATIVE,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -266,9 +274,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            HUGE_POSITIVE,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: HUGE_POSITIVE,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -281,9 +291,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            HUGE_NEGATIVE,
-            HUGE_POSITIVE,
-            variant.allowString,
+            {
+              minBound: HUGE_NEGATIVE,
+              maxBound: HUGE_POSITIVE,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -298,9 +310,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueNumber,
-            undefined,
-            variant.allowString,
+            {
+              minBound: valueNumber,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -313,9 +327,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            valueNumber,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: valueNumber,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -328,9 +344,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueNumber,
-            valueNumber,
-            variant.allowString,
+            {
+              minBound: valueNumber,
+              maxBound: valueNumber,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -343,9 +361,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueSmaller,
-            undefined,
-            variant.allowString,
+            {
+              minBound: valueSmaller,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -358,9 +378,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            valueBigger,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: valueBigger,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -373,9 +395,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueSmaller,
-            valueNumber,
-            variant.allowString,
+            {
+              minBound: valueSmaller,
+              maxBound: valueNumber,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -388,9 +412,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueNumber,
-            valueBigger,
-            variant.allowString,
+            {
+              minBound: valueNumber,
+              maxBound: valueBigger,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -403,9 +429,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueSmaller,
-            valueBigger,
-            variant.allowString,
+            {
+              minBound: valueSmaller,
+              maxBound: valueBigger,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -424,9 +452,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueBigger,
-            undefined,
-            variant.allowString,
+            {
+              minBound: valueBigger,
+              maxBound: undefined,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -439,9 +469,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueBigger,
-            valueMuchBigger,
-            variant.allowString,
+            {
+              minBound: valueBigger,
+              maxBound: valueMuchBigger,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -454,9 +486,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            undefined,
-            valueSmaller,
-            variant.allowString,
+            {
+              minBound: undefined,
+              maxBound: valueSmaller,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,
@@ -469,9 +503,11 @@ describe("checkNumericOption, checkIntegerOption", () => {
             config,
             option,
             variant.defaultValue,
-            valueMuchSmaller,
-            valueSmaller,
-            variant.allowString,
+            {
+              minBound: valueMuchSmaller,
+              maxBound: valueSmaller,
+              allowString: variant.allowString,
+            },
           );
           assert.strictEqual(
             result,

--- a/tests/getFactor.test.ts.dis
+++ b/tests/getFactor.test.ts.dis
@@ -7,6 +7,7 @@
 
 import { assert, describe, it } from 'vitest';
 import { getFactor } from '../others';
+import { migrateYaxisConfig } from '../migrate';
 
 interface ValueFactorType {
   type?: string | any,
@@ -14,6 +15,7 @@ interface ValueFactorType {
 };
 
 interface EntityConfig {
+  // value_factor?: number | ValueFactorType | any;  // ?
   y_axis?: "primary" | "secondary";
 };
 
@@ -21,7 +23,17 @@ interface ConfigType {
   value_factor?: number | ValueFactorType | any;
   value_factor_secondary?: number | ValueFactorType | any;
   entities?: EntityConfig[];
+  y_axis?: {
+    primary?: {
+      value_factor?: number | ValueFactorType | any;
+    },
+    secondary?: {
+      value_factor?: number | ValueFactorType | any;
+    },
+  },
 };
+
+const DELTA = 0.0001;
 
 const VALUES: number[] = [
   -2,
@@ -36,39 +48,572 @@ const VALUES: number[] = [
 describe("getFactor", () => {
   VALUES.forEach((value) => {
 
+    // Legacy syntax
     //////////////////////////////////////////////////////////////////////////
     // Testing value_factor non-object
 
-    it(`getFactor [value: ${value}]: value_factor: explicitly set to 0`, () => {
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: explicitly set to 0`, () => {
       const config: ConfigType = {
         value_factor: 0,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value;
+      assert.closeTo(
+        result,
+        expectedValue,
+        DELTA,
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: exponent 2`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor: exponent,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        DELTA,
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: invalid`, () => {
+      const config: ConfigType = {
+        value_factor: 'abc',
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: undefined`, () => {
+      const config: ConfigType = {
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor_secondary
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - still ignored since "index" in "getFactor()" is undefined`, () => {
+      const config: ConfigType = {
+        value_factor_secondary: 0,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: exponent 2 - still ignored since "index" in "getFactor()" is undefined`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor_secondary: exponent,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: exponent 2, index -1`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor_secondary: exponent,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, -1);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: exponent 2, index 0 (y_axis: undefined)`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor_secondary: exponent,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 0);
+      const expectedValue = value;  // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: exponent 2, index 1 (y_axis: secondary)`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor_secondary: exponent,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 1);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: invalid`, () => {
+      const config: ConfigType = {
+        value_factor_secondary: 'abc',
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: undefined`, () => {
+      const config: ConfigType = {
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "factor = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor_secondary with value_factor
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - ignored since "index" in "getFactor()" is undefined, value_factor 'exponent 3' is used instead`, () => {
+      const exponent = 3;
+      const config: ConfigType = {
+        value_factor: exponent,
+        value_factor_secondary: 0,
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - ignored since "index" in "getFactor()" is set to 0, and the 0th entity is not assigned to a 'secondary' y_axis; value_factor 'exponent 3' is used instead`, () => {
+      const exponent = 3;
+      const config: ConfigType = {
+        value_factor: exponent,
+        value_factor_secondary: 0,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 0);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
+      const exponent = 3;
+      const config: ConfigType = {
+        value_factor: exponent,
+        value_factor_secondary: 0,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 1);
+      const expectedValue = value;
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: set to 4, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
+      const exponent = 3;
+      const exponent_secondary = 4;
+      const config: ConfigType = {
+        value_factor: exponent,
+        value_factor_secondary: exponent_secondary,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 1);
+      const expectedValue = value * (10 ** exponent_secondary);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary undefined, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
+      const exponent = 3;
+      const config: ConfigType = {
+        value_factor: exponent,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 1);
+      const expectedValue = value;
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor_secondary: set to a wrong 'abc', "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
+      const exponent = 3;
+      const exponent_secondary = 'abc';
+      const config: ConfigType = {
+        value_factor: exponent,
+        value_factor_secondary: exponent_secondary,
+        entities: [
+          {},
+          {y_axis: 'secondary'},
+        ],
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig, 1);
+      const expectedValue = value;
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor object
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, exponent 2`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        value_factor: {
+          type: 'exponent',
+          factor: exponent,
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, scale 2`, () => {
+      const scale = 2;
+      const config: ConfigType = {
+        value_factor: {
+          type: 'scale',
+          factor: scale,
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * scale;
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor object, invalid data
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, type invalid`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'abc',
+          factor: 2,
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, type undefined`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          factor: 2,
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, exponent invalid`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'exponent',
+          factor: 'abc',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, exponent = string`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'exponent',
+          factor: '-2',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * (10 ** Number(config.value_factor.factor));
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, exponent undefined`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'exponent',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, scale = string`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'scale',
+          factor: '123',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value * Number(config.value_factor.factor);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, scale invalid`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'scale',
+          factor: 'abc',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`(legacy syntax) getFactor [value: ${value}]: value_factor: value_factor = object, scale undefined`, () => {
+      const config: ConfigType = {
+        value_factor: {
+          type: 'scale',
+        },
+      };
+      const migratedConfig = migrateYaxisConfig(config);
+      const result = value * getFactor(migratedConfig);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // testing y_axis syntax
+
+    //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor non-object
+    // Testing primary.value_factor
+
+    it(`getFactor [value: ${value}]: value_factor: explicitly set to 0`, () => {
+      const config: ConfigType = {
+        y_axis: {
+          primary: {value_factor: 0},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value;
       assert.closeTo(
         result,
         expectedValue,
-        6, // number of digits adter a point
+        DELTA,
       );
     });
 
     it(`getFactor [value: ${value}]: value_factor: exponent 2`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor: exponent,
+        y_axis: {
+          primary: {value_factor: exponent},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value * (10 ** exponent);
       assert.closeTo(
         result,
         expectedValue,
-        6, // number of digits adter a point
+        DELTA,
+      );
+    });
+
+    it(`getFactor [value: ${value}]: value_factor: exponent 2, index = 0`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        y_axis: {
+          primary: {value_factor: exponent},
+        },
+      };
+      const result = value * getFactor(config, 0);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        DELTA,
+      );
+    });
+
+    it(`getFactor [value: ${value}]: value_factor: exponent 2, index = 1`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        y_axis: {
+          primary: {value_factor: exponent},
+        },
+        entities: [
+          {y_axis: 'secondary'},
+          {},
+        ],
+      };
+      const result = value * getFactor(config, 1);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        DELTA,
+      );
+    });
+
+    it(`getFactor [value: ${value}]: value_factor: exponent 2, index = 2 (wrong index)`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        y_axis: {
+          primary: {value_factor: exponent},
+        },
+        entities: [
+          {y_axis: 'secondary'},
+          {},
+        ],
+      };
+      const result = value * getFactor(config, 2);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        DELTA,
       );
     });
 
     it(`getFactor [value: ${value}]: value_factor: invalid`, () => {
       const config: ConfigType = {
-        value_factor: 'abc',
+        y_axis: {
+          primary: {value_factor: 'abc'},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -81,6 +626,9 @@ describe("getFactor", () => {
 
     it(`getFactor [value: ${value}]: value_factor: undefined`, () => {
       const config: ConfigType = {
+        y_axis: {
+          primary: {},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -92,11 +640,13 @@ describe("getFactor", () => {
     });
 
     //////////////////////////////////////////////////////////////////////////
-    // Testing value_factor_secondary
+    // Testing secondary.value_factor
 
     it(`getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - still ignored since "index" in "getFactor()" is undefined`, () => {
       const config: ConfigType = {
-        value_factor_secondary: 0,
+        y_axis: {
+          secondary: {value_factor: 0},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -110,7 +660,9 @@ describe("getFactor", () => {
     it(`getFactor [value: ${value}]: value_factor_secondary: exponent 2 - still ignored since "index" in "getFactor()" is undefined`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor_secondary: exponent,
+        y_axis: {
+          secondary: {value_factor: exponent},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -124,7 +676,9 @@ describe("getFactor", () => {
     it(`getFactor [value: ${value}]: value_factor_secondary: exponent 2, index -1`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor_secondary: exponent,
+        y_axis: {
+          secondary: {value_factor: exponent},
+        },
       };
       const result = value * getFactor(config, -1);
       const expectedValue = value * (10 ** exponent);
@@ -138,7 +692,9 @@ describe("getFactor", () => {
     it(`getFactor [value: ${value}]: value_factor_secondary: exponent 2, index 0 (y_axis: undefined)`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor_secondary: exponent,
+        y_axis: {
+          secondary: {value_factor: exponent},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -156,7 +712,9 @@ describe("getFactor", () => {
     it(`getFactor [value: ${value}]: value_factor_secondary: exponent 2, index 1 (y_axis: secondary)`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor_secondary: exponent,
+        y_axis: {
+          secondary: {value_factor: exponent},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -173,7 +731,9 @@ describe("getFactor", () => {
 
     it(`getFactor [value: ${value}]: value_factor_secondary: invalid`, () => {
       const config: ConfigType = {
-        value_factor_secondary: 'abc',
+        y_axis: {
+          secondary: {value_factor: 'abc'},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -186,6 +746,9 @@ describe("getFactor", () => {
 
     it(`getFactor [value: ${value}]: value_factor_secondary: undefined`, () => {
       const config: ConfigType = {
+        y_axis: {
+          secondary: {},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value; // fallback to "factor = 1"
@@ -197,13 +760,15 @@ describe("getFactor", () => {
     });
 
     //////////////////////////////////////////////////////////////////////////
-    // Testing value_factor_secondary with value_factor
+    // Testing value_factor for secondary with value_factor
 
-    it(`getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - ignored since "index" in "getFactor()" is undefined, value_factor 'exponent 3' is used instead`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor: explicitly set to 0 - ignored since "index" in "getFactor()" is undefined, value_factor 'exponent 3' is used instead`, () => {
       const exponent = 3;
       const config: ConfigType = {
-        value_factor: exponent,
-        value_factor_secondary: 0,
+        y_axis: {
+          primary: {value_factor: exponent},
+          secondary: {value_factor: 0},
+        },
       };
       const result = value * getFactor(config);
       const expectedValue = value * (10 ** exponent);
@@ -214,11 +779,13 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0 - ignored since "index" in "getFactor()" is set to 0, and the 0th entity is not assigned to a 'secondary' y_axis; value_factor 'exponent 3' is used instead`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor: explicitly set to 0 - ignored since "index" in "getFactor()" is set to 0, and the 0th entity is not assigned to a 'secondary' y_axis; value_factor 'exponent 3' is used instead`, () => {
       const exponent = 3;
       const config: ConfigType = {
-        value_factor: exponent,
-        value_factor_secondary: 0,
+        y_axis: {
+          primary: {value_factor: exponent},
+          secondary: {value_factor: 0},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -233,11 +800,13 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor_secondary: explicitly set to 0, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor: explicitly set to 0, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
       const exponent = 3;
       const config: ConfigType = {
-        value_factor: exponent,
-        value_factor_secondary: 0,
+        y_axis: {
+          primary: {value_factor: exponent},
+          secondary: {value_factor: 0},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -252,12 +821,14 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor_secondary: set to 4, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor: set to 4, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis`, () => {
       const exponent = 3;
       const exponent_secondary = 4;
       const config: ConfigType = {
-        value_factor: exponent,
-        value_factor_secondary: exponent_secondary,
+        y_axis: {
+          primary: {value_factor: exponent},
+          secondary: {value_factor: exponent_secondary},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -272,10 +843,12 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor_secondary undefined, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor undefined, "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
       const exponent = 3;
       const config: ConfigType = {
-        value_factor: exponent,
+        y_axis: {
+          primary: {value_factor: exponent},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -290,12 +863,14 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor_secondary: set to a wrong 'abc', "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
+    it(`getFactor [value: ${value}]: secondary.value_factor: set to a wrong 'abc', "index" in "getFactor()" is set to 1, and the 1st entity is assigned to a 'secondary' y_axis; finally, a default value_factor = 1 is used`, () => {
       const exponent = 3;
       const exponent_secondary = 'abc';
       const config: ConfigType = {
-        value_factor: exponent,
-        value_factor_secondary: exponent_secondary,
+        y_axis: {
+          primary: {value_factor: exponent},
+          secondary: {value_factor: exponent_secondary},
+        },
         entities: [
           {},
           {y_axis: 'secondary'},
@@ -313,12 +888,16 @@ describe("getFactor", () => {
     //////////////////////////////////////////////////////////////////////////
     // Testing value_factor object
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, exponent 2`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, exponent 2`, () => {
       const exponent = 2;
       const config: ConfigType = {
-        value_factor: {
-          type: 'exponent',
-          factor: exponent,
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'exponent',
+              factor: exponent,
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -330,12 +909,16 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, scale 2`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, scale 2`, () => {
       const scale = 2;
       const config: ConfigType = {
-        value_factor: {
-          type: 'scale',
-          factor: scale,
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'scale',
+              factor: scale,
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -347,14 +930,142 @@ describe("getFactor", () => {
       );
     });
 
+    it(`getFactor [value: ${value}]: secondary.value_factor: value_factor = object, exponent 2`, () => {
+      const exponent = 2;
+      const config: ConfigType = {
+        y_axis: {
+          secondary: {
+            value_factor: {
+              type: 'exponent',
+              factor: exponent,
+            },
+          },
+        },
+      };
+      const result = value * getFactor(config, -1);
+      const expectedValue = value * (10 ** exponent);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`getFactor [value: ${value}]: secondary.value_factor: value_factor = object, scale 2`, () => {
+      const scale = 2;
+      const config: ConfigType = {
+        y_axis: {
+          secondary: {
+            value_factor: {
+              type: 'scale',
+              factor: scale,
+            },
+          },
+        },
+      };
+      const result = value * getFactor(config, -1);
+      const expectedValue = value * scale;
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    // //////////////////////////////////////////////////////////////////////////
+    // Testing value_factor per-entity // ?
+
+    // // it(`getFactor [value: ${value}]: value_factor: exponent 2, index 0`, () => {
+    // //   const exponent = 2;
+    // //   const config: ConfigType = {
+    // //     entities: [],
+    // //     value_factor: exponent,
+    // //   };
+    // //   const index = 0;
+    // //   const result = value * getFactor(config, index);
+    // //   const expectedValue = value * (10 ** exponent);
+    // //   assert.closeTo(
+    // //     result,
+    // //     expectedValue,
+    // //     6, // number of digits after a point
+    // //   );
+    // // });
+
+    // // it(`getFactor [value: ${value}]: value_factor: exponent 2, index -1`, () => {
+    // //   const exponent = 2;
+    // //   const config: ConfigType = {
+    // //     entities: [],
+    // //     value_factor: exponent,
+    // //   };
+    // //   const index = -1;
+    // //   const result = value * getFactor(config, index);
+    // //   const expectedValue = value * (10 ** exponent);
+    // //   assert.closeTo(
+    // //     result,
+    // //     expectedValue,
+    // //     6, // number of digits after a point
+    // //   );
+    // // });
+
+    // // it(`getFactor [value: ${value}]: value_factor: exponent 2, index undefined`, () => {
+    // //   const exponent = 2;
+    // //   const config: ConfigType = {
+    // //     entities: [],
+    // //     value_factor: exponent,
+    // //   };
+    // //   const index = undefined;
+    // //   const result = value * getFactor(config, index);
+    // //   const expectedValue = value * (10 ** exponent);
+    // //   assert.closeTo(
+    // //     result,
+    // //     expectedValue,
+    // //     6, // number of digits after a point
+    // //   );
+    // // });
+
+    // // it(`getFactor [value: ${value}]: value_factor: index 0: exponent 1`, () => {
+    // //   const exponent = 1;
+    // //     const config: ConfigType = {
+    // //     entities: [{value_factor: exponent}],
+    // //   };
+    // //   const index = 0;
+    // //   const result = value * getFactor(config, index);
+    // //   const expectedValue = value * (10 ** exponent);
+    // //   assert.closeTo(
+    // //     result,
+    // //     expectedValue,
+    // //     6, // number of digits after a point
+    // //   );
+    // // });
+
+    // // it(`getFactor [value: ${value}]: value_factor: index 0: exponent 1`, () => {
+    // //   const exponent = 1;
+    // //     const config: ConfigType = {
+    // //     entities: [{value_factor: exponent}],
+    // //     value_factor: 2,
+    // //   };
+    // //   const index = 0;
+    // //   const result = value * getFactor(config, index);
+    // //   const expectedValue = value * (10 ** exponent);
+    // //   assert.closeTo(
+    // //     result,
+    // //     expectedValue,
+    // //     6, // number of digits after a point
+    // //   );
+    // // });
+
     //////////////////////////////////////////////////////////////////////////
     // Testing value_factor object, invalid data
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, type invalid`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, type invalid`, () => {
       const config: ConfigType = {
-        value_factor: {
-          type: 'abc',
-          factor: 2,
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'abc',
+              factor: 2,
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -366,10 +1077,14 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, type undefined`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, type undefined`, () => {
       const config: ConfigType = {
-        value_factor: {
-          factor: 2,
+        y_axis: {
+          primary: {
+            value_factor: {
+              factor: 2,
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -381,11 +1096,15 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, exponent invalid`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, exponent invalid`, () => {
       const config: ConfigType = {
-        value_factor: {
-          type: 'exponent',
-          factor: 'abc',
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'exponent',
+              factor: 'abc',
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -397,15 +1116,19 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, exponent = string`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, exponent = string`, () => {
       const config: ConfigType = {
-        value_factor: {
-          type: 'exponent',
-          factor: '-2',
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'exponent',
+              factor: '-2',
+            },
+          },
         },
       };
       const result = value * getFactor(config);
-      const expectedValue = value * (10 ** Number(config.value_factor.factor));
+      const expectedValue = value * (10 ** Number(config.y_axis!.primary!.value_factor.factor));
       assert.closeTo(
         result,
         expectedValue,
@@ -413,42 +1136,14 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, exponent undefined`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, exponent undefined`, () => {
       const config: ConfigType = {
-        value_factor: {
-          type: 'exponent',
-        },
-      };
-      const result = value * getFactor(config);
-      const expectedValue = value; // fallback to "exponent = 1"
-      assert.closeTo(
-        result,
-        expectedValue,
-        6, // number of digits after a point
-      );
-    });
-
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, scale = string`, () => {
-      const config: ConfigType = {
-        value_factor: {
-          type: 'scale',
-          factor: '123',
-        },
-      };
-      const result = value * getFactor(config);
-      const expectedValue = value * Number(config.value_factor.factor);
-      assert.closeTo(
-        result,
-        expectedValue,
-        6, // number of digits after a point
-      );
-    });
-
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, scale invalid`, () => {
-      const config: ConfigType = {
-        value_factor: {
-          type: 'scale',
-          factor: 'abc',
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'exponent',
+            },
+          },
         },
       };
       const result = value * getFactor(config);
@@ -460,10 +1155,54 @@ describe("getFactor", () => {
       );
     });
 
-    it(`getFactor [value: ${value}]: value_factor: value_factor = object, scale undefined`, () => {
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, scale = string`, () => {
       const config: ConfigType = {
-        value_factor: {
-          type: 'scale',
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'scale',
+              factor: '123',
+            },
+          },
+        },
+      };
+      const result = value * getFactor(config);
+      const expectedValue = value * Number(config.y_axis!.primary!.value_factor.factor);
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, scale invalid`, () => {
+      const config: ConfigType = {
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'scale',
+              factor: 'abc',
+            },
+          },
+        },
+      };
+      const result = value * getFactor(config);
+      const expectedValue = value; // fallback to "exponent = 1"
+      assert.closeTo(
+        result,
+        expectedValue,
+        6, // number of digits after a point
+      );
+    });
+
+    it(`getFactor [value: ${value}]: primary.value_factor: value_factor = object, scale undefined`, () => {
+      const config: ConfigType = {
+        y_axis: {
+          primary: {
+            value_factor: {
+              type: 'scale',
+            },
+          },
         },
       };
       const result = value * getFactor(config);


### PR DESCRIPTION
Currently there are options which are related to a particular Y axis:
- `lower_bound`, `upper_bound`, `min_bound_range`
- `lower_bound_secondary`, `upper_bound_secondary`, `min_bound_range_secondary`
- `decimals_primary_labels`, `decimals_secondary_labels` (added in https://github.com/kalkih/mini-graph-card/pull/1233)
- `value_factor`, `value_factor_secondary` (added in https://github.com/kalkih/mini-graph-card/pull/1359)

Number of these options may increase in future.
That is why a new `y_axis` structure is proposed for a config:
```
y_axis:
  primary:
    lower_bound: ...
    upper_bound: ...
    min_bound_range: ...
    decimals: ...
    value_factor: ...
  secondary:
    lower_bound: ...
    upper_bound: ...
    min_bound_range: ...
    decimals: ...
    value_factor: ...
```
Old options are considered as legacy; they need to be migrated to a new `y_axis` structure.
But old configs will keep working: during an initialization of a card, legacy options are automatically copied to a new `y_axis` structure; this process is performed in a memory and does not affect a card's yaml code. A corresponding message is logged in a browser's console, so then a user may be aware & then should manually edit a config.

Additional unrelated change:
Internal functions `checkNumericOption()`, `checkIntegerOption()` now accept an optional dictionary argument instead of plenty of optional arguments.

Changes in Docs:
1. The proposed `y_axis` structure is described.
2. (unrelated) For a number format - tiny fixes to avoid a confusion with using `decimals` options.
3. (unrelated) For a value factor - tiny fixes to avoid a confusion with using options.