### PR TITLE
fix: upper_bound check

### DIFF
--- a/src/checkOption.js
+++ b/src/checkOption.js
@@ -151,17 +151,17 @@ const checkBounds = (config, yAxis) => {
     'lower_bound',
     `${yAxis}.lower_bound`,
   );
-  let upperBound = checkNumericOption(
+  let upperBound = checkBoundOption(
     config,
     'upper_bound',
-    undefined,
-    { allowString: true, logOptionName: `${yAxis}.upper_bound` },
+    `${yAxis}.upper_bound`,
   );
 
   if (lowerBound !== undefined && upperBound !== undefined) {
-    const cleanLowerBount = getBound(lowerBound).value;
-    if (upperBound <= cleanLowerBount) {
-      log(`Invalid lower & upper bounds: [${lowerBound}, ${upperBound}]; unsetting value of "upper_bound" to undefined`);
+    const cleanLowerBound = getBound(lowerBound).value;
+    const cleanUpperBound = getBound(upperBound).value;
+    if (cleanUpperBound <= cleanLowerBound) {
+      log(`Invalid ${yAxis} lower & upper bounds: [${lowerBound}, ${upperBound}]; unsetting value of "${yAxis}.upper_bound" to undefined`);
       upperBound = undefined;
     }
   }

--- a/tests/checkBounds.test.ts.dis
+++ b/tests/checkBounds.test.ts.dis
@@ -40,14 +40,14 @@ const VARIANTS: any[] = [
     expected: { lowerBound: '~123', upperBound: undefined },
   },
   {
-    description: 'invalid soft value for upper',
+    description: 'valid soft value for upper',
     config: { upper_bound: '~456' },
-    expected: { lowerBound: undefined, upperBound: undefined },
+    expected: { lowerBound: undefined, upperBound: '~456' },
   },
   {
-    description: 'valid soft value for lower, invalid soft value for upper',
+    description: 'valid soft value for lower, valid soft value for upper',
     config: { lower_bound: '~123', upper_bound: '~456' },
-    expected: { lowerBound: '~123', upperBound: undefined },
+    expected: { lowerBound: '~123', upperBound: '~456' },
   },
   {
     description: 'valid soft value for lower, valid value for upper',
@@ -60,8 +60,18 @@ const VARIANTS: any[] = [
     expected: { lowerBound: 123, upperBound: undefined },
   },
   {
+    description: 'lower = soft upper',
+    config: { lower_bound: 123, upper_bound: '~123' },
+    expected: { lowerBound: 123, upperBound: undefined },
+  },
+  {
     description: 'soft lower = upper',
     config: { lower_bound: '~123', upper_bound: 123 },
+    expected: { lowerBound: '~123', upperBound: undefined },
+  },
+  {
+    description: 'soft lower = soft upper',
+    config: { lower_bound: '~123', upper_bound: '~123' },
     expected: { lowerBound: '~123', upperBound: undefined },
   },
   {
@@ -90,6 +100,11 @@ const VARIANTS: any[] = [
     expected: { lowerBound: '~457', upperBound: undefined },
   },
   {
+    description: 'soft lower > soft upper',
+    config: { lower_bound: '~457', upper_bound: '~456' },
+    expected: { lowerBound: '~457', upperBound: undefined },
+  },
+  {
     description: 'soft lower > upper(string)',
     config: { lower_bound: '~457', upper_bound: '456' },
     expected: { lowerBound: '~457', upperBound: undefined },
@@ -99,7 +114,8 @@ const VARIANTS: any[] = [
 describe("checkBounds", () => {
   VARIANTS.forEach((variant) => {
     it(`checkBounds: check [${JSON.stringify(variant)}], ${variant.description}`, () => {
-      const result = checkBounds(variant.config);
+      const yAxis = 'primary';
+      const result = checkBounds(variant.config, yAxis);
       const expectedValue = variant.expected;
       assert.deepEqual(
         result,


### PR DESCRIPTION
Fixed checks for `upper_bound` to account a possible "`~`" prefix.