### PR TITLE
feat: Add a custom baseline for "bars" graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,20 +807,25 @@ show:
 
 Baseline is set to 0:
 
-<img width="497" height="217" alt="изображение" src="https://github.com/user-attachments/assets/c755d398-bbe8-435a-8571-ee4947483b56" />
+<img width="480" height="402" alt="image" src="https://github.com/user-attachments/assets/3b38e7dd-d5e6-4b9c-b75c-b6b53c07f04c" />
 
 ```yaml
 type: custom:mini-graph-card
 entities:
   - entity: sensor.xxx
 baseline: 0
+height: 400
 show:
   labels: true
+  name: false
+  icon: false
+  state: false
+  fill: fade
 ```
 
 Individual baselines for entities (along with displaying static lines):
 
-<img width="498" height="264" alt="изображение" src="https://github.com/user-attachments/assets/43a39c0b-4ca2-40ad-8443-2e8821aa987b" />
+<img width="483" height="249" alt="image" src="https://github.com/user-attachments/assets/d1bd9cc8-78a4-4428-8642-182ab15aa2dd" />
 
 ```yaml
 type: custom:mini-graph-card
@@ -830,19 +835,21 @@ entities:
     color: orange
     name: Room 1
   - static_value: 660
-    show_fill: false
     line_width: 1
     color: orange
+    show_fill: false
     show_legend: false
+    show_static_inactive: true
   - entity: sensor.xiaomi_cg_2_co2
-    baseline: 740
+    baseline: 690
     color: green
     name: Room 2
-  - static_value: 740
-    show_fill: false
+  - static_value: 690
     line_width: 1
     color: green
+    show_fill: false
     show_legend: false
+    show_static_inactive: true
 height: 200
 show:
   static_value_labels: left

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ This can be useful to show a deviation of a value near some basis (like for enti
 
 For a bar graph: with the `baseline` option set, a bar graph has bars growing upward or downward from the defined baseline. Typically, this can be used with `baseline: 0` to show deviations from zero (positive & negative), although any non-zero value can be defined.
 
-Additionally, the `baseline` option can be set individually for entities.
+Additionally, the `baseline` option can be set individually for entities; may not be meaningful for bar graphs.
 
 See examples [below](#custom-baseline).
 

--- a/README.md
+++ b/README.md
@@ -430,11 +430,13 @@ Warning: the `line_style` option is not accounted if `animation: true` option is
 
 ### Baseline
 
-The `baseline` option is only meaningful for linear graphs with a fill.
+The `baseline` option is only meaningful for linear graphs with a fill and bar graphs.
 
-By default, a fill is applied to an area between a curve and a bottom edge.
+For a linear graph: by default, a fill is applied to an area between a curve and a bottom edge.
 With the `baseline` option set, areas between a curve & a baseline are filled.
-This can be useful to show a deviation of a value near some basis (like for entities which can be both positive & negitive).
+This can be useful to show a deviation of a value near some basis (like for entities which can be both positive & negative).
+
+For a bar graph: with the `baseline` option set, a bar graph has bars growing upward or downward from the defined baseline. Typically, this can be used with `baseline: 0` to show deviations from zero (positive & negative), although any non-zero value can be defined.
 
 Additionally, the `baseline` option can be set individually for entities.
 
@@ -847,6 +849,24 @@ show:
   name: false
   icon: false
   state: false
+```
+
+Bar graph with a baseline set to 0:
+
+<img width="474" height="265" alt="image" src="https://github.com/user-attachments/assets/1bd4029b-d086-4748-add0-f7408551f147" />
+
+
+```yaml
+type: custom:mini-graph-card
+entities:
+  - entity: sensor.xxx
+baseline: 0
+height: 200
+show:
+  graph: bar
+  name: false
+  icon: false
+  labels: true
 ```
 
 #### Grouping by date

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ We recommend looking at the [Example usage section](#example-usage) to understan
 | smoothing | boolean | `true` | v0.8.0 | Whether to make graph line smooth.
 | state_map | [state map object](#state-map-object) |  | v0.8.0 | List of entity states to convert (order matters as position becomes a value on the graph).
 | logarithmic | boolean | `false` | v0.10.0 | Use a logarithmic scale for the graph (see [Logarithmic options](#logarithmic-options)).
-| fill_baseline | number |  | v0.14.0 | Set a custom baseline for the graph (see [Baseline](#baseline)).
+| baseline | number |  | v0.14.0 | Set a custom baseline for the graph (see [Baseline](#baseline)).
 
 These options are legacy and moved into [Y-axis config object](#y-axis-object):
 
@@ -168,7 +168,7 @@ properties of the Entity object detailed in the following table (as per `sensor.
 | fixed_value | boolean |         | Set to true to graph the entity's current state as a fixed value instead of graphing its state history.
 | smoothing | boolean |         | Override for a flag indicating whether to make graph line smooth.
 | logarithmic | boolean |         | Override logarithmic scaling for this entity only (see [Logarithmic options](#logarithmic-options)).
-| fill_baseline | number |   | Set a custom baseline for the graph or override a global `fill_baseline` option (see [Baseline](#baseline)).
+| baseline | number |   | Set a custom baseline for the graph or override a global `baseline` option (see [Baseline](#baseline)).
 
 Note: the "points" term is only applicable to a "line" graph, not to a "bar" graph.
 
@@ -430,13 +430,13 @@ Warning: the `line_style` option is not accounted if `animation: true` option is
 
 ### Baseline
 
-The `fill_baseline` option is only meaningful for linear graphs with a fill.
+The `baseline` option is only meaningful for linear graphs with a fill.
 
 By default, a fill is applied to an area between a curve and a bottom edge.
-With the `fill_baseline` option set, areas between a curve & a baseline are filled.
-This can be useful to show a deviation of a value near some basis (like for entities which can be both positive & nagitive).
+With the `baseline` option set, areas between a curve & a baseline are filled.
+This can be useful to show a deviation of a value near some basis (like for entities which can be both positive & negitive).
 
-Additionally, the `fill_baseline` option can be set individually for entities.
+Additionally, the `baseline` option can be set individually for entities.
 
 See examples [below](#custom-baseline).
 
@@ -811,7 +811,7 @@ Baseline is set to 0:
 type: custom:mini-graph-card
 entities:
   - entity: sensor.xxx
-fill_baseline: 0
+baseline: 0
 show:
   labels: true
 ```
@@ -824,7 +824,7 @@ Individual baselines for entities (along with displaying static lines):
 type: custom:mini-graph-card
 entities:
   - entity: sensor.xiaomi_cg_1_co2
-    fill_baseline: 660
+    baseline: 660
     color: orange
     name: Room 1
   - static_value: 660
@@ -833,7 +833,7 @@ entities:
     color: orange
     show_legend: false
   - entity: sensor.xiaomi_cg_2_co2
-    fill_baseline: 740
+    baseline: 740
     color: green
     name: Room 2
   - static_value: 740

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -238,7 +238,7 @@ export default (config) => {
     conf.static_value_label_offset = DEFAULT_STATIC_VALUE_LABEL_OFFSET;
   }
 
-  conf.fill_baseline = checkNumericOption(conf, 'fill_baseline', undefined, { allowString: true });
+  conf.baseline = checkNumericOption(conf, 'baseline', undefined, { allowString: true });
 
   // process per-entity configs
   /* eslint-disable no-param-reassign */
@@ -259,11 +259,11 @@ export default (config) => {
         conf.decimals,
         { minBound: 0, allowString: true, logOptionName: `entities[${i}].decimals` },
       );
-      entity.fill_baseline = checkNumericOption(
+      entity.baseline = checkNumericOption(
         entity,
-        'fill_baseline',
+        'baseline',
         undefined,
-        { allowString: true, logOptionName: `entities[${i}].fill_baseline` },
+        { allowString: true, logOptionName: `entities[${i}].baseline` },
       );
 
       if (entity.color_thresholds) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -333,8 +333,10 @@ export default class Graph {
       }
     }
 
-    // calculate a baseline; by default it is a bottom edge
-    let baselineY = this._height + this._margin[Y] * 4;
+    // calculate a baseline; by default it is either a bottom edge or a top edge (if inverted)
+    let baselineY = this._invert
+      ? 0
+      : this._height + this._margin[Y] * 4;
     // re-calculate in case of a "baseline" option is defined
     if (this._baseline !== undefined) {
       const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
@@ -343,18 +345,16 @@ export default class Graph {
 
     return coords.map((coord, i) => {
       let y;
-      let height;
-
+      // let growDown;
       const realY = coord[Y];
       if (realY <= baselineY) {
-        // grow down
         y = realY;
-        height = baselineY - realY;
+        // growDown = false;
       } else {
-        // grow up
         y = baselineY;
-        height = realY - baselineY;
+        // growDown = true;
       }
+      const height = Math.abs(baselineY - realY);
 
       const x = this._margin[X]
         + (group_width + spacing_group) * i
@@ -366,6 +366,7 @@ export default class Graph {
         height,
         width: bar_width,
         value: coord[V],
+        // growDown,
         baselineY,
       });
     });

--- a/src/graph.js
+++ b/src/graph.js
@@ -20,7 +20,7 @@ export default class Graph {
     bar_spacing = DEFAULT_BAR_SPACING, // spacing between bars
     bar_spacing_group = DEFAULT_BAR_SPACING, // spacing between groups of bars
     total_bars_in_group = 1, // number of bars (i.e. number of entities with a shown bar graph)
-    fill_baseline,
+    baseline,
   }) {
     const aggregateFuncMap = {
       avg: this._average,
@@ -52,7 +52,7 @@ export default class Graph {
     this._total_bars_in_group = total_bars_in_group;
     this._groupBy = groupBy;
     this._endTime = 0;
-    this._fill_baseline = fill_baseline;
+    this._baseline = baseline;
   }
 
   get max() { return this._max; }
@@ -289,8 +289,8 @@ export default class Graph {
    */
   getFill(path) {
     let height = this._height + this._margin[Y] * 4;
-    if (this._fill_baseline !== undefined) {
-      const [baselineCoord] = this.calcY([[0, 0, this._fill_baseline]]);
+    if (this._baseline !== undefined) {
+      const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
       [, height] = baselineCoord;
     }
     let fill = path;

--- a/src/graph.js
+++ b/src/graph.js
@@ -345,14 +345,13 @@ export default class Graph {
 
     return coords.map((coord, i) => {
       let y;
-      // let growDown;
       const realY = coord[Y];
       if (realY <= baselineY) {
+        // grow up
         y = realY;
-        // growDown = false;
       } else {
+        // grow down
         y = baselineY;
-        // growDown = true;
       }
       const height = Math.abs(baselineY - realY);
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -365,7 +365,6 @@ export default class Graph {
         height,
         width: bar_width,
         value: coord[V],
-        // growDown,
         baselineY,
       });
     });

--- a/src/graph.js
+++ b/src/graph.js
@@ -63,6 +63,32 @@ export default class Graph {
 
   set min(min) { this._min = min; }
 
+  /**
+   * Get the current Y-coord for a baseline
+   * @returns {number} Y-coord of a baseline
+   */
+  get baselineY() {
+    let baselineY = this._height + this._margin[Y] * 4;
+    if (this._baseline !== undefined) {
+      const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
+      [, baselineY] = baselineCoord;
+    }
+
+    return baselineY;
+  }
+
+  /**
+   * Get a relative ratio of the baseline position (0..1)
+   * @returns {number|undefined} Baseline position ratio from the top,
+   * or undefined if no baseline is customized
+   */
+  get baselineRatio() {
+    if (this._baseline === undefined) {
+      return undefined;
+    }
+    return this.baselineY / (this._height + this._margin[Y] * 4);
+  }
+
   get history() { return this._history; }
 
   set history(data) { this._history = data; }
@@ -288,11 +314,7 @@ export default class Graph {
    * @returns {string} SVG path for a fill
    */
   getFill(path) {
-    let height = this._height + this._margin[Y] * 4;
-    if (this._baseline !== undefined) {
-      const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
-      [, height] = baselineCoord;
-    }
+    const height = this.baselineY;
     let fill = path;
     // note that currently this._margin[X] = 0 when fill is defined
     fill += ` L ${this._width + this._margin[X]}, ${height}`;
@@ -333,24 +355,14 @@ export default class Graph {
       }
     }
 
-    // calculate a baseline; by default it is either a bottom edge or a top edge (if inverted)
-    let baselineY = this._invert
-      ? 0
-      : this._height + this._margin[Y] * 4;
-    // re-calculate in case of a "baseline" option is defined
-    if (this._baseline !== undefined) {
-      const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
-      [, baselineY] = baselineCoord;
-    }
+    const { baselineY } = this;
 
-    return coords.map((coord, i) => {
+    const items = coords.map((coord, i) => {
       let y;
       const realY = coord[Y];
       if (realY <= baselineY) {
-        // grow up
         y = realY;
       } else {
-        // grow down
         y = baselineY;
       }
       const height = Math.abs(baselineY - realY);
@@ -359,15 +371,18 @@ export default class Graph {
         + (group_width + spacing_group) * i
         + (spacing === -1 ? 0 : (bar_width + spacing) * position);
 
-      return ({
+      return {
         x,
         y,
         height,
-        width: bar_width,
         value: coord[V],
-        baselineY,
-      });
+      };
     });
+
+    return {
+      width: bar_width,
+      items,
+    };
   }
 
   _midPoint(Ax, Ay, Bx, By) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -73,7 +73,6 @@ export default class Graph {
       const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
       [, baselineY] = baselineCoord;
     }
-
     return baselineY;
   }
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -333,15 +333,42 @@ export default class Graph {
       }
     }
 
-    return coords.map((coord, i) => ({
-      x: this._margin[X]
+    // calculate a baseline; by default it is a bottom edge
+    let baselineY = this._height + this._margin[Y] * 4;
+    // re-calculate in case of a "baseline" option is defined
+    if (this._baseline !== undefined) {
+      const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
+      [, baselineY] = baselineCoord;
+    }
+
+    return coords.map((coord, i) => {
+      let y;
+      let height;
+
+      const realY = coord[Y];
+      if (realY <= baselineY) {
+        // grow down
+        y = realY;
+        height = baselineY - realY;
+      } else {
+        // grow up
+        y = baselineY;
+        height = realY - baselineY;
+      }
+
+      const x = this._margin[X]
         + (group_width + spacing_group) * i
-        + (spacing === -1 ? 0 : (bar_width + spacing) * position),
-      y: coord[Y],
-      height: this._height - coord[Y] + this._margin[Y] * 4,
-      width: bar_width,
-      value: coord[V],
-    }));
+        + (spacing === -1 ? 0 : (bar_width + spacing) * position);
+
+      return ({
+        x,
+        y,
+        height,
+        width: bar_width,
+        value: coord[V],
+        baselineY,
+      });
+    });
   }
 
   _midPoint(Ax, Ay, Bx, By) {

--- a/src/main.js
+++ b/src/main.js
@@ -993,7 +993,7 @@ class MiniGraphCard extends LitElement {
     if (!bars) return;
     const isAnimated = isEntryAnimated(this.config, index);
     const items = bars.map((bar, i) => {
-      const barsStyle = isAnimated
+      const barStyle = isAnimated
         ? `transform-origin: 50% ${bar.baselineY}px;`
         : '';
       const color = this.computeColor(bar.value, index);

--- a/src/main.js
+++ b/src/main.js
@@ -992,16 +992,15 @@ class MiniGraphCard extends LitElement {
   renderSvgBars(bars, index) {
     if (!bars) return;
     const isAnimated = isEntryAnimated(this.config, index);
-    const graphHeight = this.config.height;
     const items = bars.map((bar, i) => {
       const barsStyle = isAnimated
-        ? `transform-origin: ${bar.x}px ${graphHeight}px;`
+        ? `transform-origin: 50% ${bar.baselineY}px;`
         : '';
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
           height=${bar.height} width=${bar.width} fill=${color}
-          style=${barsStyle}
+          style=${barStyle}
           @mouseover=${() => this.setTooltip(index, i, bar.value)}
           @mouseout=${() => (this.tooltip = {})}>
         </rect>`;

--- a/src/main.js
+++ b/src/main.js
@@ -233,9 +233,9 @@ class MiniGraphCard extends LitElement {
           bar_spacing: this.config.bar_spacing,
           bar_spacing_group: this.config.bar_spacing_group,
           total_bars_in_group: this.visibleEntities.length,
-          fill_baseline: getFirstDefinedItem(
-            entity.fill_baseline,
-            this.config.fill_baseline,
+          baseline: getFirstDefinedItem(
+            entity.baseline,
+            this.config.baseline,
           ),
         }),
       );

--- a/src/main.js
+++ b/src/main.js
@@ -790,7 +790,7 @@ class MiniGraphCard extends LitElement {
     const isAnimated = isEntryAnimated(this.config, index);
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
-    const baselineRatio = this.Graph[index].baselineRatio;
+    const { baselineRatio } = this.Graph[index];
     const gradientStops = baselineRatio === undefined
       ? svg`
           <stop stop-color='white' offset='0%' stop-opacity='1'/>
@@ -1003,7 +1003,7 @@ class MiniGraphCard extends LitElement {
     if (!bars || !bars.items) return;
     const isAnimated = isEntryAnimated(this.config, index);
     const { width: barWidth, items } = this.bar[index]; // bars
-    const baselineY = this.Graph[index].baselineY;
+    const { baselineY } = this.Graph[index];
     const barStyle = isAnimated ? `transform-origin: 50% ${baselineY}px;` : '';
     const renderedItems = items.map((bar, i) => {
       const color = this.computeColor(bar.value, index);
@@ -1015,6 +1015,9 @@ class MiniGraphCard extends LitElement {
           @mouseout=${() => (this.tooltip = {})}>
         </rect>`;
     });
+    const inactive = this.tooltip.entity !== undefined
+      && this.tooltip.entity !== index
+      && !this._isShowStaticInactive[index];
     return svg`
       <g
         class='bars'

--- a/src/main.js
+++ b/src/main.js
@@ -790,11 +790,21 @@ class MiniGraphCard extends LitElement {
     const isAnimated = isEntryAnimated(this.config, index);
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
+    const baselineRatio = this.Graph[index].baselineRatio;
+    const gradientStops = baselineRatio === undefined
+      ? svg`
+          <stop stop-color='white' offset='0%' stop-opacity='1'/>
+          <stop stop-color='white' offset='100%' stop-opacity='0.15'/>
+        `
+      : svg`
+          <stop stop-color='white' offset='0%' stop-opacity='1'/>
+          <stop stop-color='white' offset="${baselineRatio * 100}%" stop-opacity='0.15'/>
+          <stop stop-color='white' offset='100%' stop-opacity='1'/>
+        `;
     return svg`
       <defs>
         <linearGradient id=${`fill-grad-${this.id}-${index}`} x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop stop-color='white' offset='0%' stop-opacity='1'/>
-          <stop stop-color='white' offset='100%' stop-opacity='.15'/>
+          ${gradientStops}
         </linearGradient>
         <mask id=${`fill-grad-mask-${this.id}-${index}`}>
           <rect width="100%" height="100%" fill=${`url(#fill-grad-${this.id}-${index})`} />
@@ -990,30 +1000,27 @@ class MiniGraphCard extends LitElement {
   * @param {number} index Index of an entry in config.entities
   */
   renderSvgBars(bars, index) {
-    if (!bars) return;
+    if (!bars || !bars.items) return;
     const isAnimated = isEntryAnimated(this.config, index);
-    const items = bars.map((bar, i) => {
-      const barStyle = isAnimated
-        ? `transform-origin: 50% ${bar.baselineY}px;`
-        : '';
+    const { width: barWidth, items } = this.bar[index]; // bars
+    const baselineY = this.Graph[index].baselineY;
+    const barStyle = isAnimated ? `transform-origin: 50% ${baselineY}px;` : '';
+    const renderedItems = items.map((bar, i) => {
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
-          height=${bar.height} width=${bar.width} fill=${color}
+          height=${bar.height} width=${barWidth} fill=${color}
           style=${barStyle}
           @mouseover=${() => this.setTooltip(index, i, bar.value)}
           @mouseout=${() => (this.tooltip = {})}>
         </rect>`;
     });
-    const inactive = this.tooltip.entity !== undefined
-      && this.tooltip.entity !== index
-      && !this._isShowStaticInactive[index];
     return svg`
       <g
         class='bars'
         ?anim=${isAnimated}
         ?inactive=${inactive}
-      >${items}</g>`;
+      >${renderedItems}</g>`;
   }
 
   /** Returns a rendered SVG part (fill, line, bars, points)


### PR DESCRIPTION
Part of credits comes to @fran68 - see below.

This PR is a further development after https://github.com/kalkih/mini-graph-card/pull/1205 & https://github.com/kalkih/mini-graph-card/pull/1408 - now a custom baseline is added for BARS.

Changes:
-- `fill_baseline` option is renamed to `baseline`
-- process a baseline for bars.

Animation "grow-up" is performed "from a baseline" to "up" & "down" directions:

<img width="480" height="276" alt="11" src="https://github.com/user-attachments/assets/a41b804d-a546-4683-884e-29a205eaefa5" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.xxx
    baseline: 0
height: 200
animate: true
show:
  graph: bar
  name: false
  icon: false
  labels: true
```

Regarding https://github.com/kalkih/mini-graph-card/pull/1409 by @fran68:
Comparing
https://github.com/kalkih/mini-graph-card/pull/1408 & this https://github.com/kalkih/mini-graph-card/pull/1443
vs
https://github.com/kalkih/mini-graph-card/pull/1409,
it seems that both variants have mathematically same algorithms for `calcY()`, `getFill()`, `getBars()` (in part of a baseline).
The only meaningful difference is a "caching values" method in https://github.com/kalkih/mini-graph-card/pull/1409 to avoid additional calculations.
BUT - conditions like `if (this._max !== max)` used in https://github.com/kalkih/mini-graph-card/pull/1409 should account an "epsilon" value.
IMHO this task "use cached values in Graph" is a bit wider than "add a baseline" feature and worth a separate PR.

Next thing which seems to be accounted in https://github.com/kalkih/mini-graph-card/pull/1409 (and not accounted yet in merged https://github.com/kalkih/mini-graph-card/pull/1205 & https://github.com/kalkih/mini-graph-card/pull/1408) - opacity for a fill in linear graphs.
This is accounted in this current PR:

<img width="478" height="688" alt="image" src="https://github.com/user-attachments/assets/2330e7b5-7573-4104-8ef3-9f8208f52b37" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.xiaomi_cg_1_co2
    baseline: 680
height: 600
hours_to_show: 4
points_per_hour: 60
show:
  fill: fade
  labels: true
```