### PR TITLE
fix: Baseline edge cases

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -68,11 +68,32 @@ export default class Graph {
    * @returns {number} Y-coord of a baseline
    */
   get baselineY() {
-    let baselineY = this._height + this._margin[Y] * 4;
+    const absoluteTop = 0;
+    const absoluteBottom = this._height + this._margin[Y] * 4;
+    let baselineY = this._invert
+      ? absoluteTop
+      : absoluteBottom;
+
     if (this._baseline !== undefined) {
+      // calculate Y coord
       const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
       [, baselineY] = baselineCoord;
+
+      // if the baseline is inside a top "margins area"
+      // - then shift the baseline to the top edge (0)
+      const gridTop = this._margin[Y] * 2;
+      if (baselineY <= gridTop) {
+        baselineY = absoluteTop;
+      }
+
+      // if the baseline is inside a bottom "margins area"
+      // - then shift the baseline to the bottom edge
+      const gridBottom = this._height + this._margin[Y] * 2;
+      if (baselineY >= gridBottom) {
+        baselineY = absoluteBottom;
+      }
     }
+
     return baselineY;
   }
 


### PR DESCRIPTION
When no `baseline` option is set:
-- a linear graph has a fill starting from a bottom edge;
-- a bar graph starts from a bottom edge.

Assume we have a "processor load" graph, value changes between 0..100.
Adding a `lower_bound: 0` limit gives us a graph starting from 0.

When `baseline: 0` is set - then we expect to see SAME picture as described above.
But in fact we see this:
-- a linear graph has a fill starting from some distance from a bottom edge (equal to a double margin);
-- a bar graph also starts from the same distance.

Fixed in a `Graph::baselineY()` getter.