### PR TITLE
feat: Inverted graph

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -21,6 +21,7 @@ export default class Graph {
     bar_spacing_group = DEFAULT_BAR_SPACING, // spacing between groups of bars
     total_bars_in_group = 1, // number of bars (i.e. number of entities with a shown bar graph)
     baseline,
+    invert = false,
   }) {
     const aggregateFuncMap = {
       avg: this._average,
@@ -53,6 +54,7 @@ export default class Graph {
     this._groupBy = groupBy;
     this._endTime = 0;
     this._baseline = baseline;
+    this._invert = invert;
   }
 
   get max() { return this._max; }
@@ -68,7 +70,9 @@ export default class Graph {
    * @returns {number} Y-coord of a baseline
    */
   get baselineY() {
-    let baselineY = this._height + this._margin[Y] * 4;
+    let baselineY = this._invert
+      ? 0
+      : this._height + this._margin[Y] * 4;
     if (this._baseline !== undefined) {
       const [baselineCoord] = this.calcY([[0, 0, this._baseline]]);
       [, baselineY] = baselineCoord;
@@ -212,7 +216,12 @@ export default class Graph {
     }
     const coords2 = coords.map((coord) => {
       const val = this._logarithmic ? Math.log10(Math.max(1, coord[V])) : coord[V];
-      const coordY = this._height - ((val - min) / yRatio) + this._margin[Y] * 2;
+      let coordY;
+      if (this._invert) {
+        coordY = ((val - min) / yRatio) + this._margin[Y] * 2;
+      } else {
+        coordY = this._height - ((val - min) / yRatio) + this._margin[Y] * 2;
+      }
       return [coord[X], coordY, coord[V]];
     });
 
@@ -275,7 +284,7 @@ export default class Graph {
       ? Math.log10(Math.max(1, this._max)) - Math.log10(Math.max(1, this._min))
       : this._max - this._min;
 
-    return thresholds.map((stop, index, arr) => {
+    const gradientStops = thresholds.map((stop, index, arr) => {
       let color;
       if (stop.value > this._max && arr[index + 1]) {
         const factor = (this._max - arr[index + 1].value) / (stop.value - arr[index + 1].value);
@@ -305,6 +314,10 @@ export default class Graph {
         offset,
       };
     });
+
+    return this._invert
+      ? gradientStops.reverse()
+      : gradientStops;
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,9 @@ class MiniGraphCard extends LitElement {
     // false - otherwise
     this._isShowStaticInactive = [];
 
+    // array of flags: true if a graph for the entry must be vertically inverted, false - otherwise
+    this._isInverted = [];
+
     // update datetime settings periodically
     this._updateHour24 = true;
     this._updateDateTimeFormat = true;
@@ -186,6 +189,18 @@ class MiniGraphCard extends LitElement {
       (entity, index) => this._isStaticValue[index] && entity.show_static_inactive === true,
     );
 
+    // check if an entry's graph must be vertically inverted
+    this._isInverted = this.config.entities.map((entity) => {
+      const axisType = entity && entity.y_axis === 'secondary'
+        ? 'secondary'
+        : 'primary';
+      return (
+        this.config.y_axis
+        && this.config.y_axis[axisType]
+        && this.config.y_axis[axisType].invert
+      ) || false;
+    });
+
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
 
@@ -237,6 +252,7 @@ class MiniGraphCard extends LitElement {
             entity.baseline,
             this.config.baseline,
           ),
+          invert: this._isInverted[index],
         }),
       );
     }
@@ -790,11 +806,14 @@ class MiniGraphCard extends LitElement {
     const isAnimated = isEntryAnimated(this.config, index);
     const fade = this.config.show.fill === 'fade';
     const init = this.length[index] || this.config.entities[index].show_line === false;
+    const isInverted = this._isInverted && this._isInverted[index];
+    const opacityTop = isInverted ? '0.15' : '1';
+    const opacityBottom = isInverted ? '1' : '0.15';
     const { baselineRatio } = this.Graph[index];
     const gradientStops = baselineRatio === undefined
       ? svg`
-          <stop stop-color='white' offset='0%' stop-opacity='1'/>
-          <stop stop-color='white' offset='100%' stop-opacity='0.15'/>
+          <stop stop-color='white' offset='0%' stop-opacity="${opacityTop}"/>
+          <stop stop-color='white' offset='100%' stop-opacity="${opacityBottom}"/>
         `
       : svg`
           <stop stop-color='white' offset='0%' stop-opacity='1'/>
@@ -1132,8 +1151,11 @@ class MiniGraphCard extends LitElement {
       return html``;
     }
     // index is not passed into computeState() for a primary axis
+    const invert = this.config.y_axis
+      && this.config.y_axis.primary
+      && this.config.y_axis.primary.invert;
     return html`
-      <div class="graph__labels --primary flex">
+      <div class="graph__labels --primary flex" ?invert=${invert}>
         <span class="label--max">${this.computeState(this.bound[1])}</span>
         <span class="label--min">${this.computeState(this.bound[0])}</span>
       </div>
@@ -1150,8 +1172,11 @@ class MiniGraphCard extends LitElement {
       return html``;
     }
     // index "-1" is passed into computeState() for a secondary axis
+    const invert = this.config.y_axis
+      && this.config.y_axis.secondary
+      && this.config.y_axis.secondary.invert;
     return html`
-      <div class="graph__labels --secondary flex">
+      <div class="graph__labels --secondary flex" ?invert=${invert}>
         <span class="label--max">${this.computeState(this.boundSecondary[1], -1)}</span>
         <span class="label--min">${this.computeState(this.boundSecondary[0], -1)}</span>
       </div>

--- a/src/style.js
+++ b/src/style.js
@@ -353,6 +353,9 @@ const style = css`
     grid-row: 1;
     position: relative;
   }
+  .graph__labels[invert] {
+    flex-direction: column-reverse;
+  }
   .graph__labels.--secondary {
     align-items: flex-end;
     grid-column: 1;


### PR DESCRIPTION
Adding a new `invert` option (true/false).
Is defined per axis:
```
y_axis:
  primary:
    invert: true
```
or
```
y_axis:
  secondary:
    invert: true
```
or
```
y_axis:
  primary:
    invert: true
  secondary:
    invert: true
```
Not defined by default (same as `false`).
Defining an axis inverted makes all associated graphs also inverted.

Inverting a graph means - Y-scale is inverted: bigger values are shown lower, smaller values - upper.
Can be used for cases when smaller values are considered as "better values".

Example:
water level in a well: value 0 means "well is full", bigger values mean "water went down":

<img width="477" height="272" alt="image" src="https://github.com/user-attachments/assets/3aeba615-c207-400f-929d-e5fee5a4e60a" />

```
type: custom:mini-graph-card
entities:
  - entity: sensor.water_level
    baseline: 100
height: 200
y_axis:
  primary:
    invert: true
show:
  name: false
  icon: false
  state: true
  labels: true
```
Similar case - a "ping" graph (a smaller ping is a "good value").