### PR TITLE
fix: Reduce coords for bars right in update()

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -8,6 +8,7 @@ import { log } from './utils';
 
 export default class Graph {
   constructor({
+    graphType = 'line',
     width,
     height,
     margin,
@@ -35,6 +36,7 @@ export default class Graph {
       diff: this._diff,
     };
 
+    this._graphType = graphType;
     this._history = undefined;
     this.coords = [];
     this._width = width - margin[X] * 2;
@@ -137,6 +139,11 @@ export default class Graph {
 
     // calculate coordinates
     this.coords = this._calcPoints(histGroups);
+
+    // reduce for bars
+    if (this._graphType === 'bar') {
+      this.coords = this.coords.slice(1);
+    }
 
     // define new value boundaries
     this.min = Math.min(...this.coords.map(item => Number(item[V])));
@@ -365,7 +372,6 @@ export default class Graph {
     const total = this._total_bars_in_group;
 
     let coords = this.calcY(this.coords); // set Y coord
-    coords = coords.slice(1); // remove left border
 
     // number of measures
     const total_groups = coords.length;

--- a/src/graph.js
+++ b/src/graph.js
@@ -371,7 +371,7 @@ export default class Graph {
     const spacing_group = this._bar_spacing_group;
     const total = this._total_bars_in_group;
 
-    let coords = this.calcY(this.coords); // set Y coord
+    const coords = this.calcY(this.coords); // set Y coord
 
     // number of measures
     const total_groups = coords.length;

--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ class MiniGraphCard extends LitElement {
 
     // check if an entry's graph is "bars"
     // (will be revised in future when combined "lines & bars" config is supported)
-    this._isBarGraph = this.config.entities.map((_entity) => (this.config.show.graph === 'bar'));
+    this._isBarGraph = this.config.entities.map((_) => this.config.show.graph === 'bar');
 
     // check if an entry's graph must be vertically inverted
     this._isInverted = this.config.entities.map((entity) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1588,7 +1588,7 @@ class MiniGraphCard extends LitElement {
   /**
   * Returns settings defining an order of a state/attribute value presentation;
   * fallback to default settings in case of a static_value
-  * @returns {Object}
+  * @returns {object}
   * directOrder - true: "value literal unit", false: "unit literal value";
   *
   * delimiter - an optional literal separator between value & unit

--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,11 @@ class MiniGraphCard extends LitElement {
     // for a currently unavailable entity
     this._preservedUom = [];
     this._preservedOrder = [];
+
+    // data prepared by buildConfig()
+    this._axisBoundsParsed = undefined; // parsed Y-axis bounds
+    this._entityFactors = undefined; // predefined factors
+    this._axisFactors = undefined; // predefined factors
   }
 
   static get styles() {

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,9 @@ class MiniGraphCard extends LitElement {
     // false - otherwise
     this._isShowStaticInactive = [];
 
+    // array of flags: true if an entity graph is "bars", false - otherwise
+    this._isBarGraph = [];
+
     // array of flags: true if a graph for the entry must be vertically inverted, false - otherwise
     this._isInverted = [];
 
@@ -189,6 +192,10 @@ class MiniGraphCard extends LitElement {
       (entity, index) => this._isStaticValue[index] && entity.show_static_inactive === true,
     );
 
+    // check if an entry's graph is "bars"
+    // (will be revised in future when combined "lines & bars" config is supported)
+    this._isBarGraph = this.config.entities.map((_entity) => (this.config.show.graph === 'bar'));
+
     // check if an entry's graph must be vertically inverted
     this._isInverted = this.config.entities.map((entity) => {
       const axisType = entity && entity.y_axis === 'secondary'
@@ -228,6 +235,7 @@ class MiniGraphCard extends LitElement {
           : [min_line_width, max_line_width];
       this.Graph = this.config.entities.map(
         (entity, index) => new Graph({
+          graphType: this._isBarGraph[index] ? 'bar' : 'line',
           width: 500,
           height: this.config.height,
           margin,
@@ -1724,10 +1732,12 @@ class MiniGraphCard extends LitElement {
           return;
         const bound = config.entities[i].y_axis === 'secondary' ? this.boundSecondary : this.bound;
         [this.Graph[i].min, this.Graph[i].max] = [bound[0], bound[1]];
-        if (config.show.graph === 'bar') {
+        if (this._isBarGraph[i]) {
+          // bar graph
           this.bar[i] = this.Graph[i].getBars(graphPos);
           graphPos += 1;
         } else {
+          // line graph
           const line = this.Graph[i].getPath();
           if (config.entities[i].show_line !== false) this.line[i] = line;
           if (config.show.fill

--- a/src/main.js
+++ b/src/main.js
@@ -194,9 +194,8 @@ class MiniGraphCard extends LitElement {
 
     // check if an entry's graph is "bars"
     // (will be revised in future when combined "lines & bars" config is supported)
-    this._isBarGraph = this.config.entities.map((__) => {
-      return this.config.show.graph === 'bar';
-    });
+    // eslint-disable-next-line no-unused-vars
+    this._isBarGraph = this.config.entities.map(entity => this.config.show.graph === 'bar');
 
     // check if an entry's graph must be vertically inverted
     this._isInverted = this.config.entities.map((entity) => {

--- a/src/main.js
+++ b/src/main.js
@@ -573,7 +573,7 @@ class MiniGraphCard extends LitElement {
     const entityConfig = this.config.entities[index];
     if (this.config.show.state === 'last' && this.config.show.graph === 'bar') {
       // last "bar" value
-      return this.bar[index][this.bar[index].length - 1].value;
+      return this.bar[index].items[this.bar[index].items.length - 1].value;
     } else if (this.config.show.state === 'last' && this.points[index] && this.points[index].length) {
       // last "point" value
       // only if "points" exist (show_points: true)

--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,9 @@ class MiniGraphCard extends LitElement {
 
     // check if an entry's graph is "bars"
     // (will be revised in future when combined "lines & bars" config is supported)
-    this._isBarGraph = this.config.entities.map((, i) => this.config.show.graph === 'bar');
+    this._isBarGraph = this.config.entities.map((__) => {
+      return this.config.show.graph === 'bar';
+    });
 
     // check if an entry's graph must be vertically inverted
     this._isInverted = this.config.entities.map((entity) => {

--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ class MiniGraphCard extends LitElement {
 
     // check if an entry's graph is "bars"
     // (will be revised in future when combined "lines & bars" config is supported)
-    this._isBarGraph = this.config.entities.map((_) => this.config.show.graph === 'bar');
+    this._isBarGraph = this.config.entities.map((, i) => this.config.show.graph === 'bar');
 
     // check if an entry's graph must be vertically inverted
     this._isInverted = this.config.entities.map((entity) => {


### PR DESCRIPTION
Currently a `Graph::coords` array contains a 1st element which relates either to a "0" value (for sum/delta/diff aggregate funcs) or to an initial raw state (for other aggregate funcs) - see https://github.com/kalkih/mini-graph-card/pull/1439.
The "max/min" bounds are calculated in `Graph::update()` based on that `coords` data.
This works fine for a "line" graph.
But for "bars" graph there is a chance that a calculated "max" value is significantly bigger than the 1st bar - because `Graph::getBars()` do not  use the 1st `coords` element.

In this PR:
1. A graph type is passed into a Graph object.
2. In `Graph::update()` - the calculated `coords` is forcibly reduced if a graph type = "bar".

As a result - max/min values are properly calculated for bars.

Additional unrelated fixes:
1. Added initialization for data prepared by buildConfig() - not really critical but better to have it
2. Fixed `getEntityState()` after changes in https://github.com/kalkih/mini-graph-card/pull/1443.