### PR TITLE
fix: Hide inactive bars: improve  "inactive" attribute

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -936,6 +936,7 @@ class MiniGraphCard extends LitElement {
     const color = this.computeColor(state, index);
     const inactive = this.tooltip.entity !== undefined
       && this.tooltip.entity !== index
+      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     const radius = getFirstDefinedItem(
       this.config.entities[index].line_width,
@@ -988,6 +989,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, index);
     const inactive = this.tooltip.entity !== undefined
       && this.tooltip.entity !== index
+      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='line--rect'
@@ -1016,6 +1018,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, index);
     const inactive = this.tooltip.entity !== undefined
       && this.tooltip.entity !== index
+      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='fill--rect'
@@ -1050,6 +1053,7 @@ class MiniGraphCard extends LitElement {
     });
     const inactive = this.tooltip.entity !== undefined
       && this.tooltip.entity !== index
+      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <g


### PR DESCRIPTION
In https://github.com/kalkih/mini-graph-card/pull/1396 a functionality to hide inactive "bars" graphs was added, as per the following rules:
1. When a legend label is selected - only a "bars" graph for the selected entity is shown.
2. When a bar is selected - only a "bars" graph for the selected bar is shown.

The idea was to make "bars" graphs to behave like "lines" graphs.

Unfortunately, this turned out to be not a nice UX functionality:
Rule 1 works good.
Rule 2 - not good because bars belonging to different graphs by default are shown "one by one" with a defined "bar_spacing" (by default "4"), and hovering over bars could make bars flicker.

This PR removes Rule 2 from the logic:

<img width="480" height="316" alt="Untitled Project" src="https://github.com/user-attachments/assets/5867a6c8-abee-421a-bd23-6a559514eedf" />
