### PR TITLE
fix: setTooltip() - process bars differently, process 1st line point differently

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -218,13 +218,13 @@ class MiniGraphCard extends LitElement {
     });
 
     // array of "smoothing" values for each graph
-    this._graphSmoothing = this.config.entities.map((entityConfig, index) => this._isBarGraph[index]
+    this._graphSmoothing = this.config.entities.map((entityConfig, index) => (this._isBarGraph[index]
       ? false
       : getFirstDefinedItem(
           entityConfig.smoothing,
           this.config.smoothing,
           this.getDefaultSmoothing(index),
-        )
+        ))
     );
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));

--- a/src/main.js
+++ b/src/main.js
@@ -226,7 +226,8 @@ class MiniGraphCard extends LitElement {
           this.config.smoothing,
           this.getDefaultSmoothing(index),
         );
-      });
+      }
+    );
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);

--- a/src/main.js
+++ b/src/main.js
@@ -909,7 +909,7 @@ class MiniGraphCard extends LitElement {
     return svg`
       <circle
         class='line--point'
-        ?inactive=${this.tooltip.index !== point[3]}
+        ?inactive=${this.tooltip.bucketIndex !== point[3]}
         style=${`--mcg-hover: ${color};`}
         stroke=${color}
         fill=${color}
@@ -936,7 +936,7 @@ class MiniGraphCard extends LitElement {
     const color = this.computeColor(state, index);
     const inactive = this.tooltip.entityIndex !== undefined
       && this.tooltip.entityIndex !== index
-      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.bucketIndex !== -1)
       && !this._isShowStaticInactive[index];
     const radius = getFirstDefinedItem(
       this.config.entities[index].line_width,
@@ -989,7 +989,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, index);
     const inactive = this.tooltip.entityIndex !== undefined
       && this.tooltip.entityIndex !== index
-      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.bucketIndex !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='line--rect'
@@ -1018,7 +1018,7 @@ class MiniGraphCard extends LitElement {
       : this.computeColor(state, index);
     const inactive = this.tooltip.entityIndex !== undefined
       && this.tooltip.entityIndex !== index
-      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.bucketIndex !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='fill--rect'
@@ -1053,7 +1053,7 @@ class MiniGraphCard extends LitElement {
     });
     const inactive = this.tooltip.entityIndex !== undefined
       && this.tooltip.entityIndex !== index
-      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.bucketIndex !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <g

--- a/src/main.js
+++ b/src/main.js
@@ -218,16 +218,14 @@ class MiniGraphCard extends LitElement {
     });
 
     // array of "smoothing" values for each graph
-    this._graphSmoothing = this.config.entities.map(
-      (entityConfig, index) => {
+    this._graphSmoothing = this.config.entities.map((entityConfig, index) => {
         if (this._isBarGraph[index]) return false;
         return getFirstDefinedItem(
           entityConfig.smoothing,
           this.config.smoothing,
           this.getDefaultSmoothing(index),
         );
-      }
-    );
+    });
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);

--- a/src/main.js
+++ b/src/main.js
@@ -1173,6 +1173,7 @@ class MiniGraphCard extends LitElement {
       const smoothingType = this._graphSmoothing[entityIndex];
       const isFirstPointAnInterval = isBar || smoothingType === true;
 
+      // note that for a "2-points" smoothed line graph - bucketIndex is always >0
       if (bucketIndex > 0 || isFirstPointAnInterval) {
         now.setMilliseconds(now.getMilliseconds() + oneMinute - interval);
         start = formatDateTime(

--- a/src/main.js
+++ b/src/main.js
@@ -1109,21 +1109,35 @@ class MiniGraphCard extends LitElement {
       </svg>`;
   }
 
-  setTooltip(entity, index, value, label = null) {
+  /** Set a tooltip - an object used to display
+  * either a current value or a value for a selected point/bar
+  * @param {number} entityIndex Index of an entry in config.entities
+  * @param {number} bucketIndex Index of a point/bar
+  * @param {any} value Value
+  * @param {string|null} label Optional label
+  * @returns {void}
+  */
+  setTooltip(entityIndex, bucketIndex, value, label = null) {
     const {
       group_by,
       points_per_hour,
       hours_to_show,
     } = this.config;
 
-    // time units in milliseconds in this function
+    // time units in milliseconds in an interval
     const interval = getMilli(1 / points_per_hour);
-    const n_points = Math.ceil(hours_to_show * points_per_hour);
+    // number of intervals in the defined timespan
+    const nIntervals = Math.ceil(hours_to_show * points_per_hour);
+    // number of buckets in the defined timespan
+    const nBuckets = this._isBarGraph[entityIndex]
+      ? nIntervals
+      : nIntervals + 1; // including the 1st point on a left boundary
 
-    // index is 0 (oldest) to n_points-1 (most recent ~= now)
-    // count of intervals from now to end of bin
-    // count is 0 (now) to n_points-1 (oldest)
-    const count = (n_points - 1) - index;
+    // bucketIndex is 0 (oldest) to nBuckets-1 (most recent ~= now)
+    // count - number of intervals from "now" to end of the timespan
+    // count is 0 (the last point) to nBuckets-1 (oldest)
+    // "now" - time of a processed point
+    const count = (nBuckets - 1) - bucketIndex;
 
     // offset end by a minute, if grouped by, e.g., date or hour
     const oneMinute = group_by !== 'interval' ? 60000 : 0;
@@ -1152,9 +1166,9 @@ class MiniGraphCard extends LitElement {
     this.tooltip = {
       value,
       count,
-      entity,
+      entityIndex,
       time: [start, end],
-      index,
+      bucketIndex,
       label,
     };
   }

--- a/src/main.js
+++ b/src/main.js
@@ -642,12 +642,12 @@ class MiniGraphCard extends LitElement {
     }
     return html`
       <div class="state__time">
-        ${this.tooltip.label ? html`
-          <span class="tooltip--label">${this.tooltip.label}</span>
-        ` : html`
-          <span>${this.tooltip.time[0]}</span> -
-          <span>${this.tooltip.time[1]}</span>
-        `}
+        ${this.tooltip.label
+          ? html`<span class="tooltip--label">${this.tooltip.label}</span>`
+          : this.tooltip.time[0]
+            ? html`<span>${this.tooltip.time[0]}</span> - <span>${this.tooltip.time[1]}</span>`
+            : html`<span>${this.tooltip.time[1]}</span>`
+        }
       </div>
     `;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -650,6 +650,7 @@ class MiniGraphCard extends LitElement {
     if (this.tooltip.value === undefined) {
       return html``;
     }
+     /* eslint-disable indent */
     return html`
       <div class="state__time">
         ${this.tooltip.label
@@ -659,6 +660,7 @@ class MiniGraphCard extends LitElement {
             : html`<span>${this.tooltip.time[1]}</span>`}
       </div>
     `;
+     /* eslint-enable indent */
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -218,13 +218,14 @@ class MiniGraphCard extends LitElement {
     });
 
     // array of "smoothing" values for each graph
-    this._graphSmoothing = this.config.entities.map((entityConfig, index) => (this._isBarGraph[index]
-      ? false
-      : getFirstDefinedItem(
-          entityConfig.smoothing,
-          this.config.smoothing,
-          this.getDefaultSmoothing(index),
-        ))
+    this._graphSmoothing = this.config.entities.map(
+      (entityConfig, index) => (this._isBarGraph[index]
+        ? false
+        : getFirstDefinedItem(
+            entityConfig.smoothing,
+            this.config.smoothing,
+            this.getDefaultSmoothing(index),
+          )),
     );
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));

--- a/src/main.js
+++ b/src/main.js
@@ -347,7 +347,7 @@ class MiniGraphCard extends LitElement {
       this.color = this.computeColor(
         this.tooltip.value !== undefined
           ? this.tooltip.value : this.getEntityState(0),
-        this.tooltip.entity || 0,
+        this.tooltip.entityIndex || 0,
       );
       return true;
     }
@@ -502,8 +502,8 @@ class MiniGraphCard extends LitElement {
       return html``;
     }
 
-    const name = this.tooltip.entity !== undefined
-      ? this.computeName(this.tooltip.entity)
+    const name = this.tooltip.entityIndex !== undefined
+      ? this.computeName(this.tooltip.entityIndex)
       : this.config.name || this.computeName(0);
     const color = this.config.show.name_adaptive_color
       ? `opacity: 1; color: ${this.color};`
@@ -793,7 +793,7 @@ class MiniGraphCard extends LitElement {
 
           return html`<span
             id="static-label-${index}"
-            ?inactive=${this.tooltip.entity !== undefined && this.tooltip.entity !== index
+            ?inactive=${this.tooltip.entityIndex !== undefined && this.tooltip.entityIndex !== index
               && !this._isShowStaticInactive[index]}
             style="
               color: ${color};
@@ -934,9 +934,9 @@ class MiniGraphCard extends LitElement {
         ? this.config.entities[index].static_value
         : undefined;
     const color = this.computeColor(state, index);
-    const inactive = this.tooltip.entity !== undefined
-      && this.tooltip.entity !== index
-      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
+    const inactive = this.tooltip.entityIndex !== undefined
+      && this.tooltip.entityIndex !== index
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     const radius = getFirstDefinedItem(
       this.config.entities[index].line_width,
@@ -945,7 +945,7 @@ class MiniGraphCard extends LitElement {
     const isAnimated = isEntryAnimated(this.config, index);
     return svg`
       <g class='line--points'
-        ?tooltip=${this.tooltip.entity === index}
+        ?tooltip=${this.tooltip.entityIndex === index}
         ?inactive=${inactive}
         ?init=${this.length[index]}
         anim=${isAnimated && this.config.show.points !== 'hover'}
@@ -987,9 +987,9 @@ class MiniGraphCard extends LitElement {
     const fill = this.gradient[index]
       ? `url(#grad-${this.id}-${index})`
       : this.computeColor(state, index);
-    const inactive = this.tooltip.entity !== undefined
-      && this.tooltip.entity !== index
-      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
+    const inactive = this.tooltip.entityIndex !== undefined
+      && this.tooltip.entityIndex !== index
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='line--rect'
@@ -1016,9 +1016,9 @@ class MiniGraphCard extends LitElement {
     const svgFill = this.gradient[index]
       ? `url(#grad-${this.id}-${index})`
       : this.computeColor(state, index);
-    const inactive = this.tooltip.entity !== undefined
-      && this.tooltip.entity !== index
-      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
+    const inactive = this.tooltip.entityIndex !== undefined
+      && this.tooltip.entityIndex !== index
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <rect class='fill--rect'
@@ -1051,9 +1051,9 @@ class MiniGraphCard extends LitElement {
           @mouseout=${() => (this.tooltip = {})}>
         </rect>`;
     });
-    const inactive = this.tooltip.entity !== undefined
-      && this.tooltip.entity !== index
-      && !(this._isBarGraph[this.tooltip.entity] && this.tooltip.index !== -1)
+    const inactive = this.tooltip.entityIndex !== undefined
+      && this.tooltip.entityIndex !== index
+      && !(this._isBarGraph[this.tooltip.entityIndex] && this.tooltip.index !== -1)
       && !this._isShowStaticInactive[index];
     return svg`
       <g

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,9 @@ class MiniGraphCard extends LitElement {
     // array of flags: true if a graph for the entry must be vertically inverted, false - otherwise
     this._isInverted = [];
 
+    // array of "smoothing" values for each graph
+    this._graphSmoothing = [];
+
     // update datetime settings periodically
     this._updateHour24 = true;
     this._updateDateTimeFormat = true;
@@ -214,6 +217,16 @@ class MiniGraphCard extends LitElement {
       ) || false;
     });
 
+    // array of "smoothing" values for each graph
+    this._graphSmoothing = this.config.entities.map((entityConfig, index) => this._isBarGraph[index]
+      ? false
+      : getFirstDefinedItem(
+          entityConfig.smoothing,
+          this.config.smoothing,
+          this.getDefaultSmoothing(index),
+        )
+    );
+
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
 
@@ -249,11 +262,7 @@ class MiniGraphCard extends LitElement {
           points_per_hour: this.config.points_per_hour,
           aggregateFuncName: entityConfig.aggregate_func || this.config.aggregate_func,
           groupBy: this.config.group_by,
-          smoothing: getFirstDefinedItem(
-            entityConfig.smoothing,
-            this.config.smoothing,
-            this.getDefaultSmoothing(index),
-          ),
+          smoothing: this._graphSmoothing[index],
           logarithmic: getFirstDefinedItem(
             entityConfig.logarithmic,
             this.config.logarithmic,

--- a/src/main.js
+++ b/src/main.js
@@ -219,14 +219,14 @@ class MiniGraphCard extends LitElement {
 
     // array of "smoothing" values for each graph
     this._graphSmoothing = this.config.entities.map(
-      (entityConfig, index) => (this._isBarGraph[index]
-        ? false
-        : getFirstDefinedItem(
-            entityConfig.smoothing,
-            this.config.smoothing,
-            this.getDefaultSmoothing(index),
-          )),
-    );
+      (entityConfig, index) => {
+        if (this._isBarGraph[index]) return false;
+        return getFirstDefinedItem(
+          entityConfig.smoothing,
+          this.config.smoothing,
+          this.getDefaultSmoothing(index),
+        );
+      });
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));
     const entitiesChanged = !compareArray(this.config.entities || [], config.entities);
@@ -650,7 +650,7 @@ class MiniGraphCard extends LitElement {
     if (this.tooltip.value === undefined) {
       return html``;
     }
-     /* eslint-disable indent */
+    /* eslint-disable indent */
     return html`
       <div class="state__time">
         ${this.tooltip.label

--- a/src/main.js
+++ b/src/main.js
@@ -305,7 +305,7 @@ class MiniGraphCard extends LitElement {
   * on every render
   * @param {boolean|undefined} forced True to forcibly update a format
   */
-  updateFormatFromLocale(forced) {
+  updateFormatFromLocale(forced = undefined) {
     if (this._updateDateTimeFormat || forced) {
       this._datetimeFormatDateOptions = getDateFormat(
         this.config,

--- a/src/main.js
+++ b/src/main.js
@@ -1108,7 +1108,7 @@ class MiniGraphCard extends LitElement {
   }
 
   /** Set a tooltip - an object used to display
-  * either a current value or a value for a selected point/bar
+   * either a current value or a value for a selected point/bar
   * @param {number} entityIndex Index of an entry in config.entities
   * @param {number} bucketIndex Index of a point/bar
   * @param {any} value Value
@@ -1116,50 +1116,65 @@ class MiniGraphCard extends LitElement {
   * @returns {void}
   */
   setTooltip(entityIndex, bucketIndex, value, label = null) {
-    const {
-      group_by,
-      points_per_hour,
-      hours_to_show,
-    } = this.config;
+    let start;
+    let end;
+    let count;
 
-    // time units in milliseconds in an interval
-    const interval = getMilli(1 / points_per_hour);
-    // number of intervals in the defined timespan
-    const nIntervals = Math.ceil(hours_to_show * points_per_hour);
-    // number of buckets in the defined timespan
-    const nBuckets = this._isBarGraph[entityIndex]
-      ? nIntervals
-      : nIntervals + 1; // including the 1st point on a left boundary
+    // ignore when bucketIndex = -1
+    if (bucketIndex >= 0) {
+      const {
+        group_by,
+        points_per_hour,
+        hours_to_show,
+      } = this.config;
 
-    // bucketIndex is 0 (oldest) to nBuckets-1 (most recent ~= now)
-    // count - number of intervals from "now" to end of the timespan
-    // count is 0 (the last point) to nBuckets-1 (oldest)
-    // "now" - time of a processed point
-    const count = (nBuckets - 1) - bucketIndex;
+      const isBar = this._isBarGraph[entityIndex];
 
-    // offset end by a minute, if grouped by, e.g., date or hour
-    const oneMinute = group_by !== 'interval' ? 60000 : 0;
+      // time units in milliseconds in an interval
+      const interval = getMilli(1 / points_per_hour);
+      // number of intervals in the defined timespan
+      const nIntervals = Math.ceil(hours_to_show * points_per_hour);
+      // number of buckets in the defined timespan
+      const nBuckets = isBar
+        ? nIntervals
+        : nIntervals + 1; // including the 1st point on a left boundary
 
-    const now = this.getEndDate();
+      // bucketIndex is 0 (oldest) to nBuckets-1 (most recent ~= now)
+      // count - number of intervals from "now" to end of the timespan
+      // count is 0 (the last point) to nBuckets-1 (oldest)
+      // "now" - time of a processed point
+      count = (nBuckets - 1) - bucketIndex;
 
-    now.setMilliseconds(now.getMilliseconds() - oneMinute - interval * count);
-    const end = formatDateTime(
-      now,
-      this.config,
-      this.datetimeFormatFromCfgParsed,
-      this._datetimeFormatDateOptions,
-      this._datetimeFormatTimeOptions,
-      this._hass,
-    );
-    now.setMilliseconds(now.getMilliseconds() + oneMinute - interval);
-    const start = formatDateTime(
-      now,
-      this.config,
-      this.datetimeFormatFromCfgParsed,
-      this._datetimeFormatDateOptions,
-      this._datetimeFormatTimeOptions,
-      this._hass,
-    );
+      // offset end by a minute, if grouped by, e.g., date or hour
+      const oneMinute = group_by !== 'interval' ? 60000 : 0;
+
+      const now = this.getEndDate();
+
+      now.setMilliseconds(now.getMilliseconds() - oneMinute - interval * count);
+      end = formatDateTime(
+        now,
+        this.config,
+        this.datetimeFormatFromCfgParsed,
+        this._datetimeFormatDateOptions,
+        this._datetimeFormatTimeOptions,
+        this._hass,
+      );
+
+      const smoothingType = this._graphSmoothing[entityIndex];
+      const isFirstPointAnInterval = isBar || smoothingType === true;
+
+      if (bucketIndex > 0 || isFirstPointAnInterval) {
+        now.setMilliseconds(now.getMilliseconds() + oneMinute - interval);
+        start = formatDateTime(
+          now,
+          this.config,
+          this.datetimeFormatFromCfgParsed,
+          this._datetimeFormatDateOptions,
+          this._datetimeFormatTimeOptions,
+          this._hass,
+        );
+      }
+    }
 
     this.tooltip = {
       value,

--- a/src/main.js
+++ b/src/main.js
@@ -219,12 +219,12 @@ class MiniGraphCard extends LitElement {
 
     // array of "smoothing" values for each graph
     this._graphSmoothing = this.config.entities.map((entityConfig, index) => {
-        if (this._isBarGraph[index]) return false;
-        return getFirstDefinedItem(
-          entityConfig.smoothing,
-          this.config.smoothing,
-          this.getDefaultSmoothing(index),
-        );
+      if (this._isBarGraph[index]) return false;
+      return getFirstDefinedItem(
+        entityConfig.smoothing,
+        this.config.smoothing,
+        this.getDefaultSmoothing(index),
+      );
     });
 
     this._md5Config = SparkMD5.hash(JSON.stringify(this.config));

--- a/src/main.js
+++ b/src/main.js
@@ -655,8 +655,7 @@ class MiniGraphCard extends LitElement {
           ? html`<span class="tooltip--label">${this.tooltip.label}</span>`
           : this.tooltip.time[0]
             ? html`<span>${this.tooltip.time[0]}</span> - <span>${this.tooltip.time[1]}</span>`
-            : html`<span>${this.tooltip.time[1]}</span>`
-        }
+            : html`<span>${this.tooltip.time[1]}</span>`}
       </div>
     `;
   }


### PR DESCRIPTION
Changes in `setTooltip()`:
1.Process bars differently:
For a bars graph, a number of buckets is smaller (= number of intervals).

2.Process 1st line point differently
If this point belongs to a not-smoothed linear graph (and thus is located on the left boundary, see https://github.com/kalkih/mini-graph-card/pull/1439) - only an "end" time is shown.

Also - changed a confusing naming:
1. Property `tooltip.entity` - an index for the `config.entities` array - changed to `tooltip.entityIndex`.
2. Property `tooltip.index` - an index for points/bars arrays - changed to `tooltip.bucketIndex`.

Addition unrelated fix:
fix a description of `updateFormatFromLocale()`