### PR TITLE
fix: renderIcon() - minor fixes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -455,7 +455,7 @@ class MiniGraphCard extends LitElement {
 
   /**
   * Renders an icon
-  * @param {string} iconLoc Location of an icon in a header (left/right)
+  * @param {string} iconLoc Location of an icon (left/right/state)
   * @returns {TemplateResult} Lit template result
   */
   renderIcon(iconLoc) {
@@ -538,7 +538,7 @@ class MiniGraphCard extends LitElement {
         <div class="states--secondary">
           ${this.config.entities.slice(1).map((entityConfig, i) => this.renderState(i + 1))}
         </div>
-        ${this.config.align_icon === 'state' ? this.renderIcon() : html``}
+        ${this.config.align_icon === 'state' ? this.renderIcon('state') : html``}
       </div>
     `;
   }

--- a/src/style.js
+++ b/src/style.js
@@ -126,9 +126,6 @@ const style = css`
     grid-column: 3;
     justify-self: end;
   }
-  .icon[loc="state"] {
-    align-self: center;
-  }
   .states {
     align-items: flex-start;
     font-weight: 300;


### PR DESCRIPTION
Minor fixes for `renderIcon()`:
1. Remove an unneeded style for icon when 'align_icon: state'.
2. Fix a call of 'renderIcon()' in `renderStates()`.

This fixes are not critical, do not change a current behaviour & mainly for consistency.