### PR TITLE
fix: more tooltip fixes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -610,7 +610,7 @@ class MiniGraphCard extends LitElement {
       const state = this.getEntityState(index);
       // use tooltip data for main entry state element, if tooltip is active
       // "tooltip" - a selected point/bar
-      const { entity: tooltipEntityIndex, value: tooltipValue } = this.tooltip;
+      const { entityIndex: tooltipEntityIndex, value: tooltipValue } = this.tooltip;
       const isTooltip = isPrimary && tooltipEntityIndex !== undefined;
       // either a state/attr/static_value for a selected point/bar
       // - or a "native" state/attr/static_value


### PR DESCRIPTION
Left out fixes not included into https://github.com/kalkih/mini-graph-card/pull/1449:

1. Fix in `renderState()`.