### PR TITLE
fix: Use line & bar graphs together: fix for total_bars_in_group

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -287,7 +287,7 @@ class MiniGraphCard extends LitElement {
           ),
           bar_spacing: this.config.bar_spacing,
           bar_spacing_group: this.config.bar_spacing_group,
-          total_bars_in_group: this.visibleEntities.length,
+          total_bars_in_group: this.visibleBarEntities.length,
           baseline: getFirstDefinedItem(
             entityConfig.baseline,
             this.config.baseline,


### PR DESCRIPTION
A tiny but crucial change which was not added in https://github.com/kalkih/mini-graph-card/pull/1399.
Fixed a value for a `total_bars_in_group` argument for a `Graph` object constructor.