### PR TITLE
feat: Add a conditional stroke for a bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,12 @@ The following theme variables can be set in your HA theme to customize the appea
 | mcg-label-static-opacity | 0.75 | Opacity of the static values' labels.
 | mcg-label-axis-border-radius | 1em | Border radius of the Y-axis labels.
 | mcg-label-static-border-radius | 1em | Border radius of the static values' labels.
+| mcg-bar-seam-opacity | 0.3 | Bar stroke opacity (see a note below).
+| mcg-bar-seam-width | 0.5px | Bar stroke width (see a note below).
 
+Note: Bar stroke is added to a bar for a better presentation if `bar_spacing: 0`.
+The opacity is applied for a color defined as `stroke-color: var(--card-background-color, white)`.
+Customizing these 2 variables may be desirable for some client devices.
 
 
 ### Example usage

--- a/src/main.js
+++ b/src/main.js
@@ -1096,12 +1096,27 @@ class MiniGraphCard extends LitElement {
     const isAnimated = isEntryAnimated(this.config, index);
     const { width: barWidth, items } = this.bar[index]; // bars
     const { baselineY } = this.Graph[index];
-    const barStyle = isAnimated ? `transform-origin: 50% ${baselineY}px;` : '';
+
+    // use a semi-transparent border in case of "bar_spacing: 0"
+    const isZeroSpacing = this.config.bar_spacing === 0;
+    const strokeColor = isZeroSpacing
+      ? 'var(--card-background-color, white)'
+      : 'none';
+    const strokeWidth = isZeroSpacing
+      ? 'var(--mcg-bar-seam-width, 0.5px)'
+      : '0px';
+    const barStyle = (isAnimated ? `transform-origin: 50% ${baselineY}px; ` : '')
+      + 'paint-order: fill stroke; '
+      + `stroke: ${strokeColor}; `
+      + `stroke-width: ${strokeWidth}; `
+      + 'stroke-opacity: var(--mcg-bar-seam-opacity, 0.3);';
+
     const renderedItems = items.map((bar, i) => {
       const color = this.computeColor(bar.value, index);
       return svg`
         <rect class='bar' x=${bar.x} y=${bar.y}
           height=${bar.height} width=${barWidth} fill=${color}
+          vector-effect="non-scaling-stroke"
           style=${barStyle}
           @mouseover=${() => this.setTooltip(index, i, bar.value)}
           @mouseout=${() => (this.tooltip = {})}>

--- a/src/main.js
+++ b/src/main.js
@@ -1105,11 +1105,11 @@ class MiniGraphCard extends LitElement {
     const strokeWidth = isZeroSpacing
       ? 'var(--mcg-bar-seam-width, 0.5px)'
       : '0px';
-    const barStyle = (isAnimated ? `transform-origin: 50% ${baselineY}px; ` : '')
-      + 'paint-order: fill stroke; '
-      + `stroke: ${strokeColor}; `
-      + `stroke-width: ${strokeWidth}; `
-      + 'stroke-opacity: var(--mcg-bar-seam-opacity, 0.3);';
+    let barStyle = isAnimated ? `transform-origin: 50% ${baselineY}px; ` : '';
+    barStyle += 'paint-order: fill stroke; ';
+    barStyle += `stroke: ${strokeColor}; `;
+    barStyle += `stroke-width: ${strokeWidth}; `;
+    barStyle += 'stroke-opacity: var(--mcg-bar-seam-opacity, 0.3);';
 
     const renderedItems = items.map((bar, i) => {
       const color = this.computeColor(bar.value, index);


### PR DESCRIPTION
When `bar_spacing: 0`:
some bars MAY BE displayed as separated by a thin line - this is nice,
but some bars - MAY BE NOT.
Probably this happens due to processing a graphics in a browser.

This PR adds a thin stroke for a bar if `bar_spacing: 0`.
Also, 2 new theme variables are added:
1. `mcg-bar-seam-opacity` (if not defined - a default opacity `0.3` is used) - set an opacity of a stroke (a `'var(--card-background-color, white)'` color is used for a stroke);
2. `mcg-bar-seam-width` (if not defined - a default width `0.5px` is used) - set a stroke width.

Before/After:

<img width="1038" height="958" alt="image" src="https://github.com/user-attachments/assets/dc6737d4-e757-4871-b4df-6a8fcf8927b0" />

Tests with different CSS variables (applied by card-mod 3.x).
"Default" - a default processing with the new code, then there are 2 tests with custom CSS vars.

<img width="1505" height="933" alt="image" src="https://github.com/user-attachments/assets/85af15cb-a4b2-4292-9975-76ba27a0a7a6" />

Note: it is important to use `0px` instead of `0`.